### PR TITLE
Enable SwiftLint rule: unused_closure_parameter

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -74,6 +74,9 @@ only_rules:
   # Lines should not have trailing whitespace.
   - trailing_whitespace
 
+  # Unused parameter in a closure should be replaced with _.
+  - unused_closure_parameter
+
   - vertical_whitespace
 
   - weak_delegate

--- a/Modules/Sources/AsyncImageKit/Views/CachedAsyncImage.swift
+++ b/Modules/Sources/AsyncImageKit/Views/CachedAsyncImage.swift
@@ -182,7 +182,7 @@ fileprivate let videoURL = URL(
 }
 
 #Preview("Image that never loads") {
-    CachedAsyncImage(url: nil) { image in
+    CachedAsyncImage(url: nil) { _ in
         Text("This shouldn't be visible")
     } placeholder: {
         ProgressView("Forever loading...")

--- a/Modules/Sources/JetpackStats/Cards/RealtimeTopListCard.swift
+++ b/Modules/Sources/JetpackStats/Cards/RealtimeTopListCard.swift
@@ -42,7 +42,7 @@ struct RealtimeTopListCard: View {
         }
         .padding(.vertical, Constants.step3)
         .redacted(reason: viewModel.isFirstLoad ? .placeholder : [])
-        .onChange(of: selectedItem) { oldValue, newValue in
+        .onChange(of: selectedItem) { _, newValue in
             viewModel.loadData(for: newValue)
         }
     }

--- a/Modules/Sources/JetpackStats/Screens/AuthorStatsView.swift
+++ b/Modules/Sources/JetpackStats/Screens/AuthorStatsView.swift
@@ -56,7 +56,7 @@ struct AuthorStatsView: View {
         }
         .background(Constants.Colors.background)
         .animation(.spring, value: viewModel.data.map(ObjectIdentifier.init))
-        .onChange(of: dateRange) { oldValue, newValue in
+        .onChange(of: dateRange) { _, newValue in
             viewModel.dateRange = newValue
         }
         .onAppear {

--- a/Modules/Sources/JetpackStats/Screens/StatsMainView.swift
+++ b/Modules/Sources/JetpackStats/Screens/StatsMainView.swift
@@ -36,7 +36,7 @@ public struct StatsMainView: View {
                 .onAppear {
                     context.tracker?.send(.statsMainScreenShown)
                 }
-                .onChange(of: selectedTab) { oldValue, newValue in
+                .onChange(of: selectedTab) { _, newValue in
                     trackTabChange(from: selectedTab, to: newValue)
                 }
         } else {

--- a/Modules/Sources/JetpackStats/Screens/UTMMetricStatsView.swift
+++ b/Modules/Sources/JetpackStats/Screens/UTMMetricStatsView.swift
@@ -54,7 +54,7 @@ struct UTMMetricStatsView: View {
         }
         .background(Constants.Colors.background)
         .animation(.spring, value: viewModel.data.map(ObjectIdentifier.init))
-        .onChange(of: dateRange) { oldValue, newValue in
+        .onChange(of: dateRange) { _, newValue in
             viewModel.dateRange = newValue
         }
         .onAppear {

--- a/Modules/Sources/JetpackStats/Services/Data/TopListData.swift
+++ b/Modules/Sources/JetpackStats/Services/Data/TopListData.swift
@@ -148,7 +148,7 @@ extension TopListData {
             ("Medium", "medium.com", 600)
         ]
 
-        return referrers.enumerated().map { index, data in
+        return referrers.enumerated().map { _, data in
             let baseValue = data.2
             let metrics = createMetrics(baseValue: baseValue, metric: metric)
             return TopListItem.Referrer(
@@ -195,7 +195,7 @@ extension TopListData {
             ("Netherlands", "NL", "🇳🇱", 900)
         ]
 
-        return locations.enumerated().map { index, data in
+        return locations.enumerated().map { _, data in
             let baseValue = data.3
             let metrics = createMetrics(baseValue: baseValue, metric: metric)
             return TopListItem.Location(
@@ -266,7 +266,7 @@ extension TopListData {
             ("Sarah Davis", "Contributor", 8, 400)
         ]
 
-        return authors.enumerated().map { index, data in
+        return authors.enumerated().map { _, data in
             let baseValue = data.3
             let metrics = createMetrics(baseValue: baseValue, metric: metric)
             return TopListItem.Author(
@@ -291,7 +291,7 @@ extension TopListData {
             ("SwiftUI Lab", "https://swiftui-lab.com", 300)
         ]
 
-        return links.enumerated().map { index, data in
+        return links.enumerated().map { _, data in
             let baseValue = data.2
             let metrics = createMetrics(baseValue: baseValue, metric: metric)
             return TopListItem.ExternalLink(
@@ -315,7 +315,7 @@ extension TopListData {
             ("dataset.csv", "/downloads/data/dataset.csv", 400)
         ]
 
-        return files.enumerated().map { index, data in
+        return files.enumerated().map { _, data in
             let baseValue = data.2
             let metrics = createMetrics(baseValue: baseValue, metric: metric)
             return TopListItem.FileDownload(
@@ -338,7 +338,7 @@ extension TopListData {
             ("swift best practices", 500)
         ]
 
-        return terms.enumerated().map { index, data in
+        return terms.enumerated().map { _, data in
             let baseValue = data.1
             let metrics = createMetrics(baseValue: baseValue, metric: metric)
             return TopListItem.SearchTerm(
@@ -360,7 +360,7 @@ extension TopListData {
             ("Testing Strategies", "108", "https://example.com/videos/testing.mp4", 700)
         ]
 
-        return videos.enumerated().map { index, data in
+        return videos.enumerated().map { _, data in
             let baseValue = data.3
             let metrics = createMetrics(baseValue: baseValue, metric: metric)
             return TopListItem.Video(

--- a/Modules/Sources/JetpackStats/Views/Customization/TopListCardCustomizationView.swift
+++ b/Modules/Sources/JetpackStats/Views/Customization/TopListCardCustomizationView.swift
@@ -39,7 +39,7 @@ struct TopListCardCustomizationView: View {
                 }
             }
         }
-        .onChange(of: selectedItem) { oldValue, newValue in
+        .onChange(of: selectedItem) { _, newValue in
             if let newValue {
                 updateConfiguration(with: newValue)
             }

--- a/Modules/Sources/JetpackStats/Views/Heatmap/WeeklyTrendsView.swift
+++ b/Modules/Sources/JetpackStats/Views/Heatmap/WeeklyTrendsView.swift
@@ -68,7 +68,7 @@ struct WeeklyTrendsView: View {
     private var heatmap: some View {
         VStack(spacing: cellSpacing) {
             // Show last 4 weeks, 7 days per week
-            ForEach(Array(viewModel.weeks.prefix(4).enumerated()), id: \.offset) { weekIndex, week in
+            ForEach(Array(viewModel.weeks.prefix(4).enumerated()), id: \.offset) { _, week in
                 HStack(spacing: 8) {
                     // Week label
                     Text(viewModel.weekLabel(for: week))

--- a/Modules/Sources/JetpackStats/Views/TopList/TopListItemsView.swift
+++ b/Modules/Sources/JetpackStats/Views/TopList/TopListItemsView.swift
@@ -10,7 +10,7 @@ struct TopListItemsView: View {
 
     var body: some View {
         VStack(spacing: Constants.step1 / 2) {
-            ForEach(Array(data.items.prefix(itemLimit).enumerated()), id: \.element.id) { index, item in
+            ForEach(Array(data.items.prefix(itemLimit).enumerated()), id: \.element.id) { _, item in
                 makeView(for: item)
                     .transition(.move(edge: .leading)
                         .combined(with: .scale(scale: 0.75))

--- a/Modules/Sources/ShareExtensionCore/Data/SharedCoreDataStack.swift
+++ b/Modules/Sources/ShareExtensionCore/Data/SharedCoreDataStack.swift
@@ -35,7 +35,7 @@ public final class SharedCoreDataStack {
 
     fileprivate lazy var storeContainer: SharedPersistentContainer = {
         let container = SharedPersistentContainer(name: "SharedCoreDataStack", managedObjectModel: SharedCoreDataStack.model)
-        container.loadPersistentStores { (storeDescription, error) in
+        container.loadPersistentStores { (_, error) in
             if let error = error as NSError? {
                 DDLogError("Error loading persistent stores: \(error), \(error.userInfo)")
             }

--- a/Modules/Sources/Support/UI/Application Logs/ActivityLogDetailView.swift
+++ b/Modules/Sources/Support/UI/Application Logs/ActivityLogDetailView.swift
@@ -70,7 +70,7 @@ struct ActivityLogDetailView: View {
         }
         .task(self.loadLogContent)
         .refreshable(action: self.loadLogContent)
-        .onChange(of: state) { oldValue, newValue in
+        .onChange(of: state) { _, _ in
             if case .loaded(_, let isSharing) = state {
                 self.sharingIsDisabled = false
                 self.isDisplayingShareSheet = isSharing

--- a/Modules/Sources/Support/UI/Bot Conversations/CompositionView.swift
+++ b/Modules/Sources/Support/UI/Bot Conversations/CompositionView.swift
@@ -50,7 +50,7 @@ struct CompositionView: View {
         }
         .padding(.horizontal, 16)
         .padding(.vertical, 8)
-        .onChange(of: self.text, initial: true, { oldValue, newValue in
+        .onChange(of: self.text, initial: true, { _, newValue in
             withAnimation {
                 textIsEmpty = newValue
                     .trimmingCharacters(in: .whitespacesAndNewlines)
@@ -88,7 +88,7 @@ struct CompositionView: View {
     NavigationStack {
         VStack {
             Spacer()
-            CompositionView(isDisabled: false) { message in
+            CompositionView(isDisabled: false) { _ in
                 // Do nothing
             }
         }
@@ -103,7 +103,7 @@ struct CompositionView: View {
             }
             VStack {
                 Spacer()
-                CompositionView(isDisabled: false) { message in
+                CompositionView(isDisabled: false) { _ in
                     // You'd do something with the message if this weren't a preview
                 }
             }

--- a/Modules/Sources/Support/UI/OverlayProgressView.swift
+++ b/Modules/Sources/Support/UI/OverlayProgressView.swift
@@ -59,7 +59,7 @@ struct OverlayProgressView: View {
             .accessibilityAddTraits(.isStaticText)
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
             .padding(.top, 24)
-            .onChange(of: context.date, { oldValue, newValue in
+            .onChange(of: context.date, { _, _ in
                 if case .awaitingHiding(let until) = state {
                     if until.hasPast {
                         withAnimation {
@@ -68,7 +68,7 @@ struct OverlayProgressView: View {
                     }
                 }
             })
-            .onChange(of: self.shouldBeVisible) { oldValue, newValue in
+            .onChange(of: self.shouldBeVisible) { _, newValue in
                 withAnimation {
                     if newValue {
                         self.state = .mustBeVisible

--- a/Modules/Sources/Support/UI/Support Conversations/AttachmentListView.swift
+++ b/Modules/Sources/Support/UI/Support Conversations/AttachmentListView.swift
@@ -10,7 +10,7 @@ struct SingleImageView: View {
     @GestureState private var currentZoom = 1.0
 
     var magnification: some Gesture {
-        MagnifyGesture().updating($currentZoom, body: { newValue, state, transaction in
+        MagnifyGesture().updating($currentZoom, body: { newValue, state, _ in
             state = newValue.magnification
         })
     }

--- a/Modules/Sources/Support/UI/Support Conversations/SupportConversationListView.swift
+++ b/Modules/Sources/Support/UI/Support Conversations/SupportConversationListView.swift
@@ -159,7 +159,7 @@ struct EmailRowView: View {
                 header
 
                 HStack {
-                    TimelineView(.periodic(from: .now, by: 1.0)) { context in
+                    TimelineView(.periodic(from: .now, by: 1.0)) { _ in
                         Text(formatTimestamp(conversation.lastMessageSentAt))
                             .font(.caption)
                             .foregroundColor(.secondary)

--- a/Modules/Sources/UITestsFoundation/Globals.swift
+++ b/Modules/Sources/UITestsFoundation/Globals.swift
@@ -87,7 +87,7 @@ extension ScreenObject {
     }
 
     public func openMagicLink() {
-        XCTContext.runActivity(named: "Open magic link in Safari") { activity in
+        XCTContext.runActivity(named: "Open magic link in Safari") { _ in
             let safari = Apps.safari
             safari.launch()
 

--- a/Modules/Sources/UITestsFoundation/Screens/Editor/AztecEditorScreen.swift
+++ b/Modules/Sources/UITestsFoundation/Screens/Editor/AztecEditorScreen.swift
@@ -212,8 +212,8 @@ public class AztecEditorScreen: ScreenObject {
 
     // returns void since return screen depends on from which screen it loaded
     public func closeEditor() {
-        XCTContext.runActivity(named: "Close the Aztec editor") { (activity) in
-            XCTContext.runActivity(named: "Close the More menu if needed") { (activity) in
+        XCTContext.runActivity(named: "Close the Aztec editor") { (_) in
+            XCTContext.runActivity(named: "Close the More menu if needed") { (_) in
                 let actionSheet = app.sheets.element(boundBy: 0)
                 if actionSheet.exists {
                     if XCTestCase.isPad {
@@ -228,7 +228,7 @@ public class AztecEditorScreen: ScreenObject {
 
             editorCloseButton.tap()
 
-            XCTContext.runActivity(named: "Discard any local changes") { (activity) in
+            XCTContext.runActivity(named: "Discard any local changes") { (_) in
 
                 let postHasChangesSheet = app.sheets["post-has-changes-alert"]
                 let discardButton = XCTestCase.isPad ? postHasChangesSheet.buttons.lastMatch : postHasChangesSheet.buttons.element(boundBy: 1)

--- a/Modules/Sources/UITestsFoundation/Screens/Editor/BlockEditorScreen.swift
+++ b/Modules/Sources/UITestsFoundation/Screens/Editor/BlockEditorScreen.swift
@@ -248,8 +248,8 @@ public class BlockEditorScreen: ScreenObject {
 
     // returns void since return screen depends on from which screen it loaded
     public func closeEditor() {
-        XCTContext.runActivity(named: "Close the block editor") { (activity) in
-            XCTContext.runActivity(named: "Close the More menu if needed") { (activity) in
+        XCTContext.runActivity(named: "Close the block editor") { (_) in
+            XCTContext.runActivity(named: "Close the More menu if needed") { (_) in
                 let actionSheet = app.sheets.element(boundBy: 0)
                 if actionSheet.exists {
                     dismissBlockEditorPopovers()
@@ -260,7 +260,7 @@ public class BlockEditorScreen: ScreenObject {
             editorCloseButton.waitForIsHittable(timeout: 3)
             editorCloseButton.tap()
 
-            XCTContext.runActivity(named: "Discard any local changes") { (activity) in
+            XCTContext.runActivity(named: "Discard any local changes") { (_) in
                 guard unsavedChangesLabel.waitForIsHittable(timeout: 3) else { return }
 
                 Logger.log(message: "Discarding unsaved changes", event: .v)

--- a/Modules/Sources/WordPressKit/DashboardServiceRemote.swift
+++ b/Modules/Sources/WordPressKit/DashboardServiceRemote.swift
@@ -38,7 +38,7 @@ open class DashboardServiceRemote: ServiceRemoteWordPressComREST {
             "cards": cards.joined(separator: ",") as NSString
         ]
         let featureFlagParams: [String: AnyObject]? = try SessionDetails(deviceId: deviceId).dictionaryRepresentation()
-        return cardsParams.merging(featureFlagParams ?? [:]) { first, second in
+        return cardsParams.merging(featureFlagParams ?? [:]) { first, _ in
             return first
         }
     }

--- a/Modules/Sources/WordPressKit/PostServiceRemoteREST.swift
+++ b/Modules/Sources/WordPressKit/PostServiceRemoteREST.swift
@@ -40,7 +40,7 @@ extension PostServiceRemoteREST {
 
         wordPressComRESTAPI.get(requestUrl,
                                parameters: parameters,
-                               success: { (responseObject, httpResponse) in
+                               success: { (responseObject, _) in
             if let success {
                 let responseDict = responseObject as? [String: Any] ?? [:]
                 let jsonUsers = responseDict["likes"] as? [[String: Any]] ?? []

--- a/Modules/Sources/WordPressShared/Utility/Debouncer.swift
+++ b/Modules/Sources/WordPressShared/Utility/Debouncer.swift
@@ -52,7 +52,7 @@ public final class Debouncer {
     }
 
     private func scheduleCallback() {
-        timer = Timer.scheduledTimer(withTimeInterval: delay, repeats: false) { [callback] timer in
+        timer = Timer.scheduledTimer(withTimeInterval: delay, repeats: false) { [callback] _ in
             callback?()
         }
     }

--- a/Modules/Sources/WordPressShared/Utility/String+Helpers.swift
+++ b/Modules/Sources/WordPressShared/Utility/String+Helpers.swift
@@ -254,7 +254,7 @@ extension String {
         let range = NSMakeRange(0, count)
         var offset = 0
 
-        detector.enumerateMatches(in: self, options: [], range: range) { (result, flags, stop) in
+        detector.enumerateMatches(in: self, options: [], range: range) { (result, _, _) in
             guard let range = result?.range else {
                 return
             }

--- a/Modules/Sources/WordPressUI/Views/AdaptiveTabBarController.swift
+++ b/Modules/Sources/WordPressUI/Views/AdaptiveTabBarController.swift
@@ -103,7 +103,7 @@ public final class AdaptiveTabBarController<Item: AdaptiveTabBarItem> {
     }
 
     private func setupTraitObserver(for viewController: UIViewController) {
-        traitObserver = viewController.registerForTraitChanges([UITraitHorizontalSizeClass.self]) { [weak self] (viewController: UIViewController, previousTraitCollection: UITraitCollection) in
+        traitObserver = viewController.registerForTraitChanges([UITraitHorizontalSizeClass.self]) { [weak self] (_: UIViewController, _: UITraitCollection) in
             self?.refresh()
         }
     }

--- a/Tests/KeystoneTests/Tests/Features/Blog/BloggingRemindersSchedulerTests.swift
+++ b/Tests/KeystoneTests/Tests/Features/Blog/BloggingRemindersSchedulerTests.swift
@@ -65,9 +65,9 @@ class BloggingRemindersSchedulerTests: XCTestCase {
             return
         }
 
-        let notificationCenter = NotificationSchedulerMock { (request, completionHandler) in
+        let notificationCenter = NotificationSchedulerMock { (_, completionHandler) in
             completionHandler?(nil)
-        } removeNotificationMock: { identifier in
+        } removeNotificationMock: { _ in
         }
 
         let scheduler = BloggingRemindersScheduler(
@@ -109,10 +109,10 @@ class BloggingRemindersSchedulerTests: XCTestCase {
             return
         }
 
-        let notificationCenter = NotificationSchedulerMock { (request, completionHandler) in
+        let notificationCenter = NotificationSchedulerMock { (_, completionHandler) in
             scheduleExpectation.fulfill()
             completionHandler?(nil)
-        } removeNotificationMock: { identifier in
+        } removeNotificationMock: { _ in
             cancelExpectation.fulfill()
         }
 

--- a/Tests/KeystoneTests/Tests/Features/Dashboard/BlogDashboardServiceTests.swift
+++ b/Tests/KeystoneTests/Tests/Features/Dashboard/BlogDashboardServiceTests.swift
@@ -274,7 +274,7 @@ class BlogDashboardServiceTests: CoreDataTestCase {
 
         let blog = newTestBlog(id: wpComID, context: mainContext)
 
-        service.fetch(blog: blog) { snapshot in
+        service.fetch(blog: blog) { _ in
             XCTAssertEqual(self.persistenceMock.didCallPersistWithCards,
                            self.dictionary(from: "dashboard-200-with-drafts-and-scheduled.json"))
             XCTAssertEqual(self.persistenceMock.didCallPersistWithWpComID, self.wpComID)

--- a/Tests/KeystoneTests/Tests/Features/Notifications/MarkAsSpamActionTests.swift
+++ b/Tests/KeystoneTests/Tests/Features/Notifications/MarkAsSpamActionTests.swift
@@ -54,7 +54,7 @@ final class MarkAsSpamActionTests: CoreDataTestCase {
 
         var executionCompleted = false
 
-        let context = ActionContext(block: try utility.mockCommentContent(), content: "content") { (request, success) in
+        let context = ActionContext(block: try utility.mockCommentContent(), content: "content") { (_, _) in
             executionCompleted = true
         }
 

--- a/Tests/KeystoneTests/Tests/Features/Notifications/PushAuthenticationServiceTests.swift
+++ b/Tests/KeystoneTests/Tests/Features/Notifications/PushAuthenticationServiceTests.swift
@@ -33,13 +33,13 @@ class PushAuthenticationServiceTests: CoreDataTestCase {
 
     func testAuthorizeLoginDoesntCallServiceRemoteIfItsNull() {
         pushAuthenticationService.authenticationServiceRemote = nil
-        pushAuthenticationService.authorizeLogin(token, completion: { (completed: Bool) -> () in
+        pushAuthenticationService.authorizeLogin(token, completion: { (_: Bool) -> () in
         })
         XCTAssertFalse(mockPushAuthenticationServiceRemote!.authorizeLoginCalled, "Authorize login should not have been called")
     }
 
     func testAuthorizeLoginCallsServiceRemoteAuthorizeLoginWhenItsNotNull() {
-        pushAuthenticationService.authorizeLogin(token, completion: { (completed: Bool) -> () in
+        pushAuthenticationService.authorizeLogin(token, completion: { (_: Bool) -> () in
         })
         XCTAssertTrue(mockPushAuthenticationServiceRemote.authorizeLoginCalled, "Authorize login should have been called")
     }

--- a/Tests/KeystoneTests/Tests/Features/Notifications/TrashCommentActionTests.swift
+++ b/Tests/KeystoneTests/Tests/Features/Notifications/TrashCommentActionTests.swift
@@ -52,7 +52,7 @@ final class TrashCommentActionTests: CoreDataTestCase {
         action?.on = false
 
         var executionCompleted = false
-        let context = ActionContext(block: try utils.mockCommentContent(), content: "content") { (request, success) in
+        let context = ActionContext(block: try utils.mockCommentContent(), content: "content") { (_, _) in
             executionCompleted = true
         }
 

--- a/Tests/KeystoneTests/Tests/Features/SiteCreation/SiteDesignTests.swift
+++ b/Tests/KeystoneTests/Tests/Features/SiteCreation/SiteDesignTests.swift
@@ -12,7 +12,7 @@ class SiteDesignTests: XCTestCase {
 
         // given
         let siteDesignPreviewVC = SiteDesignPreviewViewController(
-            siteDesign: remoteDesign, selectedPreviewDevice: nil, createsSite: false, sectionType: .standard, onDismissWithDeviceSelected: nil, completion: {design in })
+            siteDesign: remoteDesign, selectedPreviewDevice: nil, createsSite: false, sectionType: .standard, onDismissWithDeviceSelected: nil, completion: {_ in })
         let expectedPrimaryTitle = "Choose"
 
         // when
@@ -28,7 +28,7 @@ class SiteDesignTests: XCTestCase {
 
         // given
         let siteDesignPreviewVC = SiteDesignPreviewViewController(
-            siteDesign: remoteDesign, selectedPreviewDevice: nil, createsSite: true, sectionType: .standard, onDismissWithDeviceSelected: nil, completion: {design in })
+            siteDesign: remoteDesign, selectedPreviewDevice: nil, createsSite: true, sectionType: .standard, onDismissWithDeviceSelected: nil, completion: {_ in })
         let expectedPrimaryTitle = "Create Site"
 
         // when

--- a/Tests/KeystoneTests/Tests/Misc/StatsPeriodAsyncOperationTests.swift
+++ b/Tests/KeystoneTests/Tests/Misc/StatsPeriodAsyncOperationTests.swift
@@ -14,7 +14,7 @@ class StatsPeriodAsyncOperationTests: XCTestCase {
 
     func testStatsPeriodOperation() {
         let expect = expectation(description: "Add Stats Period Operation")
-        let operation = StatsPeriodAsyncOperation(service: mockRemoteService, for: .day, date: date) { [unowned self] (item: MockStatsType?, error: Error?) in
+        let operation = StatsPeriodAsyncOperation(service: mockRemoteService, for: .day, date: date) { [unowned self] (item: MockStatsType?, _: Error?) in
             XCTAssertNotNil(item)
             XCTAssertTrue(item?.period == .day)
             XCTAssertTrue(item?.periodEndDate == self.date)

--- a/Tests/KeystoneTests/Tests/Networking/MediaHostTests.swift
+++ b/Tests/KeystoneTests/Tests/Networking/MediaHostTests.swift
@@ -116,7 +116,7 @@ struct MediaHostTests {
                 isAtomic: true,
                 siteID: nil,
                 username: nil,
-                authToken: nil) { error in
+                authToken: nil) { _ in
                     continuation.resume()
                 }
         }

--- a/Tests/KeystoneTests/Tests/Networking/MediaRequestAuthenticatorTests.swift
+++ b/Tests/KeystoneTests/Tests/Networking/MediaRequestAuthenticatorTests.swift
@@ -46,7 +46,7 @@ class MediaRequestAuthenticatorTests: CoreDataTestCase {
 
                 XCTAssertFalse(hasAuthorizationHeader)
                 XCTAssertEqual(request.url, url)
-        }) { error in
+        }) { _ in
             XCTFail("This should not be called")
         }
     }
@@ -63,7 +63,7 @@ class MediaRequestAuthenticatorTests: CoreDataTestCase {
 
                 XCTAssertFalse(hasAuthorizationHeader)
                 XCTAssertEqual(request.url, url)
-        }) { error in
+        }) { _ in
             XCTFail("This should not be called")
         }
     }
@@ -85,7 +85,7 @@ class MediaRequestAuthenticatorTests: CoreDataTestCase {
 
                 XCTAssertFalse(hasAuthorizationHeader)
                 XCTAssertEqual(request.url, url)
-        }) { error in
+        }) { _ in
             XCTFail("This should not be called")
         }
     }
@@ -106,7 +106,7 @@ class MediaRequestAuthenticatorTests: CoreDataTestCase {
 
                 XCTAssertTrue(hasAuthorizationHeader)
                 XCTAssertEqual(request.url, expectedURL)
-        }) { error in
+        }) { _ in
             XCTFail("This should not be called")
         }
     }
@@ -138,7 +138,7 @@ class MediaRequestAuthenticatorTests: CoreDataTestCase {
 
                 XCTAssertTrue(hasAuthorizationHeader)
                 XCTAssertEqual(request.url, expectedURL)
-        }) { error in
+        }) { _ in
             XCTFail("This should not be called")
         }
 

--- a/Tests/KeystoneTests/Tests/Networking/RequestAuthenticatorTests.swift
+++ b/Tests/KeystoneTests/Tests/Networking/RequestAuthenticatorTests.swift
@@ -50,7 +50,7 @@ class RequestAuthenticatorTests: XCTestCase {
                     "Set-Cookie": self.selfHostedAuthCookies])
         }
 
-        authenticator.request(url: url, cookieJar: cookieJar) { request in
+        authenticator.request(url: url, cookieJar: cookieJar) { _ in
             cookieJar.hasWordPressSelfHostedAuthCookie(for: url, username: self.siteUser) { hasCookie in
                 if hasCookie {
                     expectation.fulfill()
@@ -77,7 +77,7 @@ class RequestAuthenticatorTests: XCTestCase {
                     "Set-Cookie": self.wpComAuthCookies])
         }
 
-        authenticator.request(url: url, cookieJar: cookieJar) { request in
+        authenticator.request(url: url, cookieJar: cookieJar) { _ in
             cookieJar.hasWordPressComAuthCookie(username: self.dotComUser, atomicSite: false) { hasCookie in
                 if hasCookie {
                     expectation.fulfill()

--- a/Tests/KeystoneTests/Tests/Reader/ReaderSubscribeCommentsActionTests.swift
+++ b/Tests/KeystoneTests/Tests/Reader/ReaderSubscribeCommentsActionTests.swift
@@ -42,7 +42,7 @@ final class ReaderSubscribeCommentsActionTests: CoreDataTestCase {
             context: mainContext,
             followCommentsService: service,
             sourceViewController: UIViewController(),
-            completion: nil) { error in
+            completion: nil) { _ in
                 XCTAssertEqual(service.toggleSubscribedCallCount, 1)
                 XCTAssertEqual(service.toggleNotificationSettingsCallCount, 0)
                 testExpectation.fulfill()
@@ -66,7 +66,7 @@ final class ReaderSubscribeCommentsActionTests: CoreDataTestCase {
             context: mainContext,
             followCommentsService: service,
             sourceViewController: UIViewController(),
-            completion: nil) { error in
+            completion: nil) { _ in
                 XCTAssertEqual(service.toggleSubscribedCallCount, 1)
                 XCTAssertEqual(service.toggleNotificationSettingsCallCount, 1)
                 testExpectation.fulfill()

--- a/Tests/KeystoneTests/Tests/Services/BloggingPromptsServiceTests.swift
+++ b/Tests/KeystoneTests/Tests/Services/BloggingPromptsServiceTests.swift
@@ -84,7 +84,7 @@ final class BloggingPromptsServiceTests: CoreDataTestCase {
 
             expectation.fulfill()
 
-        } failure: { error in
+        } failure: { _ in
             XCTFail("This closure shouldn't be called.")
             expectation.fulfill()
         }
@@ -111,7 +111,7 @@ final class BloggingPromptsServiceTests: CoreDataTestCase {
 
             expectation.fulfill()
 
-        } failure: { error in
+        } failure: { _ in
             XCTFail("This closure shouldn't be called.")
             expectation.fulfill()
         }
@@ -185,7 +185,7 @@ final class BloggingPromptsServiceTests: CoreDataTestCase {
 
             expectation.fulfill()
 
-        } failure: { error in
+        } failure: { _ in
             XCTFail("This closure shouldn't be called.")
             expectation.fulfill()
         }
@@ -219,7 +219,7 @@ final class BloggingPromptsServiceTests: CoreDataTestCase {
 
             expectation.fulfill()
 
-        } failure: { error in
+        } failure: { _ in
             XCTFail("This closure shouldn't be called.")
             expectation.fulfill()
         }
@@ -254,7 +254,7 @@ final class BloggingPromptsServiceTests: CoreDataTestCase {
 
             expectation.fulfill()
 
-        } failure: { error in
+        } failure: { _ in
             XCTFail("This closure shouldn't be called.")
             expectation.fulfill()
         }
@@ -279,7 +279,7 @@ final class BloggingPromptsServiceTests: CoreDataTestCase {
         service.fetchPrompts(from: .distantPast) { prompts in
             XCTAssertEqual(prompts.count, 3)
             expectation.fulfill()
-        } failure: { error in
+        } failure: { _ in
             XCTFail("This closure shouldn't be called.")
             expectation.fulfill()
         }
@@ -325,7 +325,7 @@ final class BloggingPromptsServiceTests: CoreDataTestCase {
 
             expectation.fulfill()
 
-        } failure: { error in
+        } failure: { _ in
             XCTFail("This closure shouldn't be called.")
             expectation.fulfill()
         }

--- a/Tests/KeystoneTests/Tests/Services/CommentService+LikesTests.swift
+++ b/Tests/KeystoneTests/Tests/Services/CommentService+LikesTests.swift
@@ -75,7 +75,7 @@ final class CommentService_LikesTests: CoreDataTestCase {
         commentService.toggleLikeStatus(for: comment, siteID: 1) {
             XCTFail("The failure block should be called instaled")
             exp.fulfill()
-        } failure: { error in
+        } failure: { _ in
             exp.fulfill()
         }
         wait(for: [exp], timeout: 5)
@@ -149,7 +149,7 @@ final class CommentService_LikesTests: CoreDataTestCase {
         commentService.toggleLikeStatus(for: comment, siteID: 1) {
             XCTFail("The failure block should be called instaled")
             exp.fulfill()
-        } failure: { error in
+        } failure: { _ in
             exp.fulfill()
         }
         wait(for: [exp], timeout: 5)

--- a/Tests/KeystoneTests/Tests/Services/CommentService+RepliesTests.swift
+++ b/Tests/KeystoneTests/Tests/Services/CommentService+RepliesTests.swift
@@ -168,7 +168,7 @@ final class CommentService_RepliesTests: CoreDataTestCase {
         self.commentService.reply(to: post, content: "test comment") {
             XCTFail("The failure should be called instead")
             exp.fulfill()
-        } failure: { error in
+        } failure: { _ in
             exp.fulfill()
         }
         wait(for: [exp], timeout: 5)
@@ -242,7 +242,7 @@ final class CommentService_RepliesTests: CoreDataTestCase {
         self.commentService.replyToHierarchicalComment(withID: 3, post: post, content: "test comment") {
             XCTFail("The failure should be called instead")
             exp.fulfill()
-        } failure: { error in
+        } failure: { _ in
             exp.fulfill()
         }
         wait(for: [exp], timeout: 5)

--- a/Tests/KeystoneTests/Tests/Services/CommentServiceTests.swift
+++ b/Tests/KeystoneTests/Tests/Services/CommentServiceTests.swift
@@ -60,7 +60,7 @@ extension CommentServiceTests {
 
         // Act
         let exp = expectation(description: "Fetch comment likes should succeed")
-        self.service.getLikesFor(commentID: commentID, siteID: siteID, success: { users, totalLikes, likesPerPage in
+        self.service.getLikesFor(commentID: commentID, siteID: siteID, success: { users, _, likesPerPage in
             // Assert
             XCTAssertNotNil(users)
             XCTAssertEqual(users.count, 1)
@@ -82,7 +82,7 @@ extension CommentServiceTests {
 
         // Act
         let exp = expectation(description: "Fetch comment likes should fail")
-        self.service.getLikesFor(commentID: commentID, siteID: siteID, success: { users, totalLikes, likesPerPage in
+        self.service.getLikesFor(commentID: commentID, siteID: siteID, success: { _, _, _ in
             XCTFail("this closure should not be called")
         },
         failure: { _ in

--- a/Tests/KeystoneTests/Tests/Services/DomainsServiceTests.swift
+++ b/Tests/KeystoneTests/Tests/Services/DomainsServiceTests.swift
@@ -67,7 +67,7 @@ class DomainsServiceTests: CoreDataTestCase {
     fileprivate func fetchDomains() {
         let expect = expectation(description: "Domains fetch complete expectation")
         let service = DomainsService(coreDataStack: contextManager, remote: remote)
-        service.refreshDomains(siteID: testBlog.dotComID!.intValue) { result in
+        service.refreshDomains(siteID: testBlog.dotComID!.intValue) { _ in
             expect.fulfill()
         }
 

--- a/Tests/KeystoneTests/Tests/Services/EditorSettingsServiceTests.swift
+++ b/Tests/KeystoneTests/Tests/Services/EditorSettingsServiceTests.swift
@@ -67,7 +67,7 @@ class EditorSettingsServiceTest: CoreDataTestCase {
         let finalResponse = responseWith(mobileEditor: "gutenberg")
         remoteApi.successBlockPassedIn?(finalResponse, HTTPURLResponse())
 
-        waitForExpectations(timeout: 0.1) { (error) in
+        waitForExpectations(timeout: 0.1) { (_) in
             // The default value should be now on local and remote
             XCTAssertEqual(blog.mobileEditor, .gutenberg)
         }

--- a/Tests/KeystoneTests/Tests/Services/JetpackSocialServiceTests.swift
+++ b/Tests/KeystoneTests/Tests/Services/JetpackSocialServiceTests.swift
@@ -175,7 +175,7 @@ class JetpackSocialServiceTests: CoreDataTestCase {
         let syncSucceeded = await withCheckedContinuation { continuation in
             service.syncSharingLimit(dotComID: NSNumber(value: blogID)) {
                 continuation.resume(returning: true)
-            } failure: { error in
+            } failure: { _ in
                 continuation.resume(returning: false)
             }
         }
@@ -191,7 +191,7 @@ class JetpackSocialServiceTests: CoreDataTestCase {
         let syncSucceeded = await withCheckedContinuation { continuation in
             service.syncSharingLimit(dotComID: NSNumber(value: blogID)) {
                 continuation.resume(returning: true)
-            } failure: { error in
+            } failure: { _ in
                 continuation.resume(returning: false)
             }
         }
@@ -207,7 +207,7 @@ class JetpackSocialServiceTests: CoreDataTestCase {
         let syncSucceeded = await withCheckedContinuation { continuation in
             service.syncSharingLimit(dotComID: NSNumber(value: blogID)) {
                 continuation.resume(returning: true)
-            } failure: { error in
+            } failure: { _ in
                 continuation.resume(returning: false)
             }
         }

--- a/Tests/KeystoneTests/Tests/Services/NotificationSettingsServiceTests.swift
+++ b/Tests/KeystoneTests/Tests/Services/NotificationSettingsServiceTests.swift
@@ -163,7 +163,7 @@ class NotificationSettingsServiceTests: CoreDataTestCase {
                 settings = theSettings
                 expect.fulfill()
             },
-            failure: { (error: NSError?) in
+            failure: { (_: NSError?) in
                 expect.fulfill()
             })
 

--- a/Tests/KeystoneTests/Tests/Services/NotificationSyncMediatorTests.swift
+++ b/Tests/KeystoneTests/Tests/Services/NotificationSyncMediatorTests.swift
@@ -143,7 +143,7 @@ class NotificationSyncMediatorTests: CoreDataTestCase {
         let expect = expectation(description: "Mark as Read")
 
         // Mark as Read!
-        mediator.markAsRead(note) { success in
+        mediator.markAsRead(note) { _ in
             XCTAssertTrue(note.read)
             expect.fulfill()
         }
@@ -179,7 +179,7 @@ class NotificationSyncMediatorTests: CoreDataTestCase {
         let expect = expectation(description: "Mark as Read")
 
         // Mark as Read!
-        mediator.markAsRead([note1, note3]) { success in
+        mediator.markAsRead([note1, note3]) { _ in
             XCTAssertTrue(note1.read)
             XCTAssertTrue(note2.read)
             XCTAssertTrue(note3.read)
@@ -217,7 +217,7 @@ class NotificationSyncMediatorTests: CoreDataTestCase {
         let expect = expectation(description: "Mark as Read")
 
         // Mark as Read!
-        mediator.markAsRead([note1]) { success in
+        mediator.markAsRead([note1]) { _ in
             XCTAssertTrue(note1.read)
             XCTAssertFalse(note3.read)
             expect.fulfill()

--- a/Tests/KeystoneTests/Tests/Services/PeopleServiceTests.swift
+++ b/Tests/KeystoneTests/Tests/Services/PeopleServiceTests.swift
@@ -75,7 +75,7 @@ class PeopleServiceTests: CoreDataTestCase {
 
         let exp = expectation(description: "loadUsersPage fails")
         self.service.loadUsersPage(
-            success: { count, _ in
+            success: { _, _ in
                 XCTFail("The failure block should be called instead")
                 exp.fulfill()
             },
@@ -208,7 +208,7 @@ class PeopleServiceTests: CoreDataTestCase {
 
         let exp = expectation(description: "loadFollowersPage fails")
         self.service.loadFollowersPage(
-            success: { count, _ in
+            success: { _, _ in
                 XCTFail("The failure block should be called instead")
                 exp.fulfill()
             },

--- a/Tests/KeystoneTests/Tests/Services/PostCoordinatorTests.swift
+++ b/Tests/KeystoneTests/Tests/Services/PostCoordinatorTests.swift
@@ -43,7 +43,7 @@ class PostCoordinatorTests: CoreDataTestCase {
         revision1.content = "content-a"
 
         // GIVEN
-        stub(condition: isPath("/rest/v1.2/sites/80511/posts/new")) { request in
+        stub(condition: isPath("/rest/v1.2/sites/80511/posts/new")) { _ in
             try! HTTPStubsResponse(value: WordPressComPost.mock, statusCode: 201)
         }
 
@@ -181,7 +181,7 @@ class PostCoordinatorTests: CoreDataTestCase {
             return try! HTTPStubsResponse(value: mock, statusCode: 201)
         }
 
-        stub(condition: isPath("/rest/v1.1/sites/80511/media/new")) { request in
+        stub(condition: isPath("/rest/v1.1/sites/80511/media/new")) { _ in
             HTTPStubsResponse(data: mediaResponse.data(using: .utf8)!, statusCode: 202, headers: [:])
         }
 
@@ -213,7 +213,7 @@ class PostCoordinatorTests: CoreDataTestCase {
         // GIVEN a first request that fails with a `.notConnectedToInternet`
         // error and the second one that succedes
         var requestCount = 0
-        stub(condition: isPath("/rest/v1.2/sites/80511/posts/new")) { request in
+        stub(condition: isPath("/rest/v1.2/sites/80511/posts/new")) { _ in
             requestCount += 1
             switch requestCount {
             case 1:
@@ -568,7 +568,7 @@ class PostCoordinatorTests: CoreDataTestCase {
         try mainContext.save()
 
         // GIVEN
-        stub(condition: isPath("/rest/v1.2/sites/80511/posts/974")) { request in
+        stub(condition: isPath("/rest/v1.2/sites/80511/posts/974")) { _ in
             HTTPStubsResponse(error: URLError(.notConnectedToInternet))
         }
 

--- a/Tests/KeystoneTests/Tests/Services/PostRepositorySaveTests.swift
+++ b/Tests/KeystoneTests/Tests/Services/PostRepositorySaveTests.swift
@@ -689,7 +689,7 @@ class PostRepositorySaveTests: CoreDataTestCase {
             ], statusCode: 409, headers: nil)
         }
 
-        stub(condition: isPath("/rest/v1.1/sites/80511/posts/974")) { request in
+        stub(condition: isPath("/rest/v1.1/sites/80511/posts/974")) { _ in
             var post = WordPressComPost.mock
             post.modified = serverDateModified
             post.content = "content-c"
@@ -794,7 +794,7 @@ class PostRepositorySaveTests: CoreDataTestCase {
             throw URLError(.unknown)
         }
 
-        stub(condition: isPath("/rest/v1.1/sites/80511/posts/974")) { request in
+        stub(condition: isPath("/rest/v1.1/sites/80511/posts/974")) { _ in
             try HTTPStubsResponse(value: serverPost, statusCode: 200)
         }
 
@@ -897,7 +897,7 @@ class PostRepositorySaveTests: CoreDataTestCase {
             throw URLError(.unknown)
         }
 
-        stub(condition: isPath("/rest/v1.1/sites/80511/posts/974")) { request in
+        stub(condition: isPath("/rest/v1.1/sites/80511/posts/974")) { _ in
             try HTTPStubsResponse(value: serverPost, statusCode: 200)
         }
 
@@ -983,7 +983,7 @@ class PostRepositorySaveTests: CoreDataTestCase {
             throw URLError(.unknown)
         }
 
-        stub(condition: isPath("/rest/v1.1/sites/80511/posts/974")) { request in
+        stub(condition: isPath("/rest/v1.1/sites/80511/posts/974")) { _ in
             try HTTPStubsResponse(value: serverPost, statusCode: 200)
         }
 
@@ -1292,12 +1292,12 @@ class PostRepositorySaveTests: CoreDataTestCase {
         revision2.remoteStatus = .syncNeeded
 
         // GIVEN a server with the an updated content (but not title)
-        stub(condition: isPath("/rest/v1.2/sites/80511/posts/974")) { request in
+        stub(condition: isPath("/rest/v1.2/sites/80511/posts/974")) { _ in
             XCTFail("No POST requests should be made")
             return HTTPStubsResponse(error: URLError(.unknown))
         }
 
-        stub(condition: isPath("/rest/v1.1/sites/80511/posts/974")) { request in
+        stub(condition: isPath("/rest/v1.1/sites/80511/posts/974")) { _ in
             XCTFail("No GET requests should be made")
             return HTTPStubsResponse(error: URLError(.unknown))
         }
@@ -1396,10 +1396,10 @@ class PostRepositorySaveTests: CoreDataTestCase {
         revision.content = "content-b"
 
         // GIVEN
-        stub(condition: isPath("/rest/v1.1/sites/80511/posts/974")) { request in
+        stub(condition: isPath("/rest/v1.1/sites/80511/posts/974")) { _ in
             try HTTPStubsResponse(value: WordPressComPost.mock, statusCode: 200)
         }
-        stub(condition: isPath("/rest/v1.1/sites/80511/posts/974/delete")) { request in
+        stub(condition: isPath("/rest/v1.1/sites/80511/posts/974/delete")) { _ in
             var mock = WordPressComPost.mock
             mock.status = BasePost.Status.trash.rawValue
             return try HTTPStubsResponse(value: mock, statusCode: 201)
@@ -1426,7 +1426,7 @@ class PostRepositorySaveTests: CoreDataTestCase {
         }
 
         // GIVEN post trashed on the remote (and updated)
-        stub(condition: isPath("/rest/v1.1/sites/80511/posts/974")) { request in
+        stub(condition: isPath("/rest/v1.1/sites/80511/posts/974")) { _ in
             var mock = WordPressComPost.mock
             mock.status = BasePost.Status.trash.rawValue
             return try HTTPStubsResponse(value: mock, statusCode: 200)
@@ -1454,7 +1454,7 @@ class PostRepositorySaveTests: CoreDataTestCase {
         }
 
         // GIVEN post permanently deleted on the remote
-        stub(condition: isPath("/rest/v1.1/sites/80511/posts/974")) { request in
+        stub(condition: isPath("/rest/v1.1/sites/80511/posts/974")) { _ in
             return try HTTPStubsResponse(value: [
                 "error": "unknown_post",
                 "message": "Unknown post"

--- a/Tests/KeystoneTests/Tests/Services/SharingServiceTests.swift
+++ b/Tests/KeystoneTests/Tests/Services/SharingServiceTests.swift
@@ -39,7 +39,7 @@ class SharingServiceTests: CoreDataTestCase {
         let sharingService = SharingSyncService(coreDataStack: contextManager)
         sharingService.syncPublicizeConnectionsForBlog(blog) {
             expect.fulfill()
-        } failure: { (error) in
+        } failure: { (_) in
             expect.fulfill()
         }
 

--- a/Tests/KeystoneTests/Tests/Services/SiteManagementServiceTests.swift
+++ b/Tests/KeystoneTests/Tests/Services/SiteManagementServiceTests.swift
@@ -211,7 +211,7 @@ class SiteManagementServiceTests: CoreDataTestCase {
         let expect = expectation(description: "GetActivePurchases success expectation")
         mockRemoteService.reset()
         siteManagementService.getActivePurchasesForBlog(blog,
-            success: { purchases in
+            success: { _ in
                 expect.fulfill()
             }, failure: nil)
         mockRemoteService.successResultBlockPassedIn?([])

--- a/Tests/WordPressKitTests/CoreAPITests/WordPressComOAuthClientTests.swift
+++ b/Tests/WordPressKitTests/CoreAPITests/WordPressComOAuthClientTests.swift
@@ -267,7 +267,7 @@ class WordPressComOAuthClientTests: XCTestCase {
                 expect.fulfill()
                 XCTFail("This call should need multifactor")
             },
-            failure: { (error) in
+            failure: { (_) in
                 expect.fulfill()
                 XCTFail("This call should need multifactor")
             }

--- a/Tests/WordPressKitTests/CoreAPITests/WordPressComRestApiTests.swift
+++ b/Tests/WordPressKitTests/CoreAPITests/WordPressComRestApiTests.swift
@@ -541,7 +541,7 @@ class WordPressComRestApiTests: XCTestCase {
                 complete.fulfill()
                 XCTFail("The API call should complete with a failure")
             },
-            failure: { error, _ in
+            failure: { _, _ in
                 complete.fulfill()
             }
         )

--- a/Tests/WordPressKitTests/CoreAPITests/WordPressOrgXMLRPCApiTests.swift
+++ b/Tests/WordPressKitTests/CoreAPITests/WordPressOrgXMLRPCApiTests.swift
@@ -54,7 +54,7 @@ class WordPressOrgXMLRPCApiTests: XCTestCase {
         api.callMethod(
             "wp.getPost",
             parameters: nil,
-            success: { (responseObject, _) in
+            success: { (_, _) in
                 expect.fulfill()
                 XCTFail("This call should fail")
             },
@@ -83,7 +83,7 @@ class WordPressOrgXMLRPCApiTests: XCTestCase {
         api.callMethod(
             "wp.getPost",
             parameters: nil,
-            success: { (responseObject, _) in
+            success: { (_, _) in
                 expect.fulfill()
                 XCTFail("This call should fail")
             },
@@ -112,7 +112,7 @@ class WordPressOrgXMLRPCApiTests: XCTestCase {
         api.callMethod(
             "wp.getPost",
             parameters: nil,
-            success: { (responseObject, _) in
+            success: { (_, _) in
                 expect.fulfill()
                 XCTFail("This call should fail")
             },
@@ -141,7 +141,7 @@ class WordPressOrgXMLRPCApiTests: XCTestCase {
         api.callMethod(
             "wp.getPost",
             parameters: nil,
-            success: { (responseObject, _) in
+            success: { (_, _) in
                 expect.fulfill()
                 XCTFail("This call should fail")
             },
@@ -169,7 +169,7 @@ class WordPressOrgXMLRPCApiTests: XCTestCase {
         api.callMethod(
             "wp.getPost",
             parameters: nil,
-            success: { (responseObject, _) in
+            success: { (_, _) in
                 expect.fulfill()
                 XCTFail("This call should fail")
             },
@@ -198,7 +198,7 @@ class WordPressOrgXMLRPCApiTests: XCTestCase {
         api.callMethod(
             "wp.getPost",
             parameters: nil,
-            success: { (responseObject, _) in
+            success: { (_, _) in
                 expect.fulfill()
                 XCTFail("This call should fail")
             },
@@ -231,7 +231,7 @@ class WordPressOrgXMLRPCApiTests: XCTestCase {
         api.callMethod(
             "wp.getPost",
             parameters: nil,
-            success: { (responseObject, _) in
+            success: { (_, _) in
                 expect.fulfill()
                 XCTFail("This call should fail")
             },
@@ -259,7 +259,7 @@ class WordPressOrgXMLRPCApiTests: XCTestCase {
         api.callMethod(
             "wp.getPost",
             parameters: nil,
-            success: { (responseObject, _) in
+            success: { (_, _) in
                 expect.fulfill()
                 XCTFail("This call should fail")
             },

--- a/Tests/WordPressKitTests/WordPressKitTests/Tests/ActivityServiceRemoteTests.swift
+++ b/Tests/WordPressKitTests/WordPressKitTests/Tests/ActivityServiceRemoteTests.swift
@@ -432,7 +432,7 @@ class ActivityServiceRemoteTests: RemoteTestCase, RESTTestable {
         remote.getRewindStatus(siteID) {
             expect.fulfill()
             XCTAssertEqual($0.state, .unavailable)
-        } failure: { error in
+        } failure: { _ in
             expect.fulfill()
             XCTFail("The success block should be called")
         }

--- a/Tests/WordPressKitTests/WordPressKitTests/Tests/DashboardServiceRemoteTests.swift
+++ b/Tests/WordPressKitTests/WordPressKitTests/Tests/DashboardServiceRemoteTests.swift
@@ -87,7 +87,7 @@ class DashboardServiceRemoteTests: RemoteTestCase, RESTTestable {
             deviceId: "Test"
         ) { _ in
             XCTFail("This call should not suceed")
-        } failure: { error in
+        } failure: { _ in
             expect.fulfill()
         }
 
@@ -106,7 +106,7 @@ class DashboardServiceRemoteTests: RemoteTestCase, RESTTestable {
             deviceId: "Test"
         ) { _ in
             XCTFail("This call should not suceed")
-        } failure: { error in
+        } failure: { _ in
             expect.fulfill()
         }
 
@@ -125,7 +125,7 @@ class DashboardServiceRemoteTests: RemoteTestCase, RESTTestable {
             deviceId: "Test"
         ) { _ in
             XCTFail("This call should not suceed")
-        } failure: { error in
+        } failure: { _ in
             expect.fulfill()
         }
 

--- a/Tests/WordPressKitTests/WordPressKitTests/Tests/DomainsServiceRemoteRESTTests.swift
+++ b/Tests/WordPressKitTests/WordPressKitTests/Tests/DomainsServiceRemoteRESTTests.swift
@@ -305,7 +305,7 @@ class DomainsServiceRemoteRESTTests: RemoteTestCase, RESTTestable {
             let matchesURL = containsQueryParams && matchesPath
             XCTAssertTrue(matchesURL)
             return matchesURL
-        } response: { request in
+        } response: { _ in
             let path = OHPathForFile(self.allDomainsMockFilename, type(of: self))!
             return fixture(filePath: path, status: 200, headers: nil)
         }

--- a/Tests/WordPressKitTests/WordPressKitTests/Tests/IPLocationRemoteTests.swift
+++ b/Tests/WordPressKitTests/WordPressKitTests/Tests/IPLocationRemoteTests.swift
@@ -29,7 +29,7 @@ final class IPLocationRemoteTests: XCTestCase {
 
         let data = jsonString.data(using: .utf8)
 
-        MockURLProtocol.requestHandler = { request in
+        MockURLProtocol.requestHandler = { _ in
           let response = HTTPURLResponse(url: self.apiURL, statusCode: 200, httpVersion: nil, headerFields: nil)!
           return (response, data)
         }

--- a/Tests/WordPressKitTests/WordPressKitTests/Tests/QRLoginServiceRemoteTests.swift
+++ b/Tests/WordPressKitTests/WordPressKitTests/Tests/QRLoginServiceRemoteTests.swift
@@ -99,9 +99,9 @@ class QRLoginServiceRemoteTests: RemoteTestCase, RESTTestable {
         let expect = expectation(description: "Failed Authentication")
         stubRemoteResponse("wpcom/v2/auth/qr-code/authenticate", filename: "qrlogin-authenticate-failed-400.json", contentType: .ApplicationJSON, status: 400)
 
-        qrLoginServiceRemote.authenticate(token: "valid_token", data: "valid_data") { authenticated in
+        qrLoginServiceRemote.authenticate(token: "valid_token", data: "valid_data") { _ in
             XCTFail("This request should not succeed")
-        } failure: { error in
+        } failure: { _ in
             expect.fulfill()
         }
 
@@ -113,9 +113,9 @@ class QRLoginServiceRemoteTests: RemoteTestCase, RESTTestable {
         let expect = expectation(description: "Failed Authentication")
         stubRemoteResponse("wpcom/v2/auth/qr-code/authenticate", data: "foo".data(using: .utf8)!, contentType: .ApplicationJSON)
 
-        qrLoginServiceRemote.authenticate(token: "valid_token", data: "valid_data") { authenticated in
+        qrLoginServiceRemote.authenticate(token: "valid_token", data: "valid_data") { _ in
             XCTFail("This request should not succeed")
-        } failure: { error in
+        } failure: { _ in
             expect.fulfill()
         }
 

--- a/Tests/WordPressKitTests/WordPressKitTests/Tests/Utilities/FeatureFlagRemoteTests.swift
+++ b/Tests/WordPressKitTests/WordPressKitTests/Tests/Utilities/FeatureFlagRemoteTests.swift
@@ -27,7 +27,7 @@ class FeatureFlagRemoteTests: RemoteTestCase, RESTTestable {
             let matchesURL = containsQueryParams && matchesPath
             XCTAssertTrue(matchesURL)
             return matchesURL
-        } response: { request in
+        } response: { _ in
             return response
         }
 

--- a/WordPress/Classes/Jetpack/JetpackMigration/Common/MigrationEmailService.swift
+++ b/WordPress/Classes/Jetpack/JetpackMigration/Common/MigrationEmailService.swift
@@ -54,7 +54,7 @@ final class MigrationEmailService {
 
     private func sendMigrationEmail(path: String) async throws -> SendMigrationEmailResponse {
         return try await withCheckedThrowingContinuation { continuation in
-            api.POST(path, parameters: nil) { responseObject, httpResponse in
+            api.POST(path, parameters: nil) { responseObject, _ in
                 do {
                     let decoder = JSONDecoder()
                     let data = try JSONSerialization.data(withJSONObject: responseObject)
@@ -63,7 +63,7 @@ final class MigrationEmailService {
                 } catch let error {
                     continuation.resume(throwing: error)
                 }
-            } failure: { error, httpResponse in
+            } failure: { error, _ in
                 continuation.resume(throwing: error)
             }
         }

--- a/WordPress/Classes/Login/SelfHostedSiteAuthenticator.swift
+++ b/WordPress/Classes/Login/SelfHostedSiteAuthenticator.swift
@@ -194,7 +194,7 @@ struct SelfHostedSiteAuthenticator {
             let session = ASWebAuthenticationSession(
                 url: url,
                 callbackURLScheme: callbackURL.scheme!
-            ) { url, error in
+            ) { url, _ in
                 if let url {
                     continuation.resume(returning: url)
                 } else {

--- a/WordPress/Classes/Services/AuthenticationService.swift
+++ b/WordPress/Classes/Services/AuthenticationService.swift
@@ -164,7 +164,7 @@ class AuthenticationService {
         }
         request.setValue(WPUserAgent.wordPress(), forHTTPHeaderField: "User-Agent")
 
-        let task = session.dataTask(with: request) { data, response, error in
+        let task = session.dataTask(with: request) { _, response, error in
             if let error {
                 DispatchQueue.main.async {
                     failure(error)

--- a/WordPress/Classes/Services/NotificationSettingsService.swift
+++ b/WordPress/Classes/Services/NotificationSettingsService.swift
@@ -60,7 +60,7 @@ class NotificationSettingsService {
 
                     let localSettings = self.loadLocalSettings(for: blog)
 
-                    let updatedPreferences = preferences.merging(localSettings) { first, second in
+                    let updatedPreferences = preferences.merging(localSettings) { _, second in
                         second
                     }
 

--- a/WordPress/Classes/Services/SiteAssemblyService.swift
+++ b/WordPress/Classes/Services/SiteAssemblyService.swift
@@ -190,7 +190,7 @@ final class EnhancedSiteCreationService: SiteAssemblyService {
                     self.createdBlog = blog
                     self.endSuccessfulAssembly()
                 },
-                failure: { error in self.endFailedAssembly() }
+                failure: { _ in self.endFailedAssembly() }
             )
         })
     }

--- a/WordPress/Classes/Services/SiteSuggestionService.swift
+++ b/WordPress/Classes/Services/SiteSuggestionService.swift
@@ -73,7 +73,7 @@ class SiteSuggestionService {
         // add this blog to currently being requested list
         blogsCurrentlyBeingRequested.append(blogId)
 
-        defaultAccount()?.wordPressComRestApi?.GET(suggestPath, parameters: params, success: { [weak self] responseObject, httpResponse in
+        defaultAccount()?.wordPressComRestApi?.GET(suggestPath, parameters: params, success: { [weak self] responseObject, _ in
             guard let `self` = self else { return }
 
             let context = ContextManager.shared.mainContext

--- a/WordPress/Classes/Services/SuggestionService.swift
+++ b/WordPress/Classes/Services/SuggestionService.swift
@@ -56,7 +56,7 @@ class SuggestionService {
         // add this blog to currently being requested list
         blogsCurrentlyBeingRequested.append(blogId)
 
-        defaultAccount()?.wordPressComRestApi?.GET(suggestPath, parameters: params, success: { [weak self] responseObject, httpResponse in
+        defaultAccount()?.wordPressComRestApi?.GET(suggestPath, parameters: params, success: { [weak self] responseObject, _ in
             guard let `self` = self else { return }
             guard let payload = responseObject as? [String: Any] else { return }
             guard let restSuggestions = payload["suggestions"] as? [[String: Any]] else { return }

--- a/WordPress/Classes/Stores/PluginStore.swift
+++ b/WordPress/Classes/Stores/PluginStore.swift
@@ -502,7 +502,7 @@ private extension PluginStore {
         }
         remote(site: site)?.activateAndEnableAutoupdates(pluginID: plugin.state.id,
                                                          success: {},
-                                                         failure: { [weak self] error in
+                                                         failure: { [weak self] _ in
                                                             self?.state.modifyPlugin(id: pluginID, site: site) { plugin in
                                                                 plugin.autoupdate = false
                                                                 plugin.active = false

--- a/WordPress/Classes/System/Root View/RootViewPresenter+AppSettingsNavigation.swift
+++ b/WordPress/Classes/System/Root View/RootViewPresenter+AppSettingsNavigation.swift
@@ -16,7 +16,7 @@ extension RootViewPresenter {
     ///
     /// The "Me" scene's navigation controller is popped to the root in case the "Me" scene was already presented.
     private func navigateToMeScene() -> ViewControllerNavigationAction {
-        return .init { [weak self] context, completion in
+        return .init { [weak self] _, completion in
             self?.showMeScreen(completion: completion)
         }
     }

--- a/WordPress/Classes/System/WordPressAppDelegate.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate.swift
@@ -848,7 +848,7 @@ extension WordPressAppDelegate {
         }
 
         let service = WordPressComSyncService()
-        service.syncWPCom(authToken: "valid_token", isJetpackLogin: false, onSuccess: { account in
+        service.syncWPCom(authToken: "valid_token", isJetpackLogin: false, onSuccess: { _ in
             if let blog = try? BlogQuery().hostname(containing: wpComSiteAddress).blog(in: ContextManager.shared.mainContext) {
                 self.windowManager.showUI(for: blog)
             } else {

--- a/WordPress/Classes/Users/Views/UserDetailsView.swift
+++ b/WordPress/Classes/Users/Views/UserDetailsView.swift
@@ -264,7 +264,7 @@ private extension View {
             UserDetailsView.Strings.deleteUserConfirmationTitle,
             isPresented: view.$presentDeleteConfirmation,
             presenting: view.deleteUserViewModel.selectedUser,
-            actions: { attribution in
+            actions: { _ in
                 Button(role: .destructive) {
                     Task { @MainActor in
                         do {

--- a/WordPress/Classes/Utility/BackgroundTasks/WeeklyRoundupBackgroundTask.swift
+++ b/WordPress/Classes/Utility/BackgroundTasks/WeeklyRoundupBackgroundTask.swift
@@ -145,7 +145,7 @@ private class WeeklyRoundupDataProvider {
     /// definition of "best" through a sorting mechanism where the "best" sites are placed first.
     ///
     private func filterBest(_ count: Int, minimumViewsCount: Int = 5, from blogStats: SiteStats) -> SiteStats {
-        let filteredAndSorted = blogStats.filter { (site, stats) in
+        let filteredAndSorted = blogStats.filter { (_, stats) in
             stats.viewsCount >= minimumViewsCount
         }.sorted { (first: (_, value: StatsSummaryData), second: (_, value: StatsSummaryData)) in
             first.value.viewsCount >= second.value.viewsCount
@@ -738,7 +738,7 @@ class WeeklyRoundupNotificationScheduler {
     }
 
     func cancelStaticNotification(completion: @escaping (Bool) -> Void = { _ in }) {
-        userNotificationCenter.getPendingNotificationRequests { requests in
+        userNotificationCenter.getPendingNotificationRequests { _ in
             completion(true)
         }
     }

--- a/WordPress/Classes/Utility/Blogging Reminders/BloggingRemindersScheduleFormatter.swift
+++ b/WordPress/Classes/Utility/Blogging Reminders/BloggingRemindersScheduleFormatter.swift
@@ -128,7 +128,7 @@ private extension BloggingRemindersScheduleFormatter {
 
         // This loop applies the default font to the whole text, while keeping any symbolic attributes the previous font may
         // have had (such as bold style).
-        attributedString.enumerateAttribute(.font, in: NSRange(location: 0, length: attributedString.length)) { (value, range, stop) in
+        attributedString.enumerateAttribute(.font, in: NSRange(location: 0, length: attributedString.length)) { (value, range, _) in
 
             guard let oldFont = value as? UIFont,
                   let newDescriptor = UIFontDescriptor.preferredFontDescriptor(withTextStyle: .body)

--- a/WordPress/Classes/Utility/In-App Feedback/AppRatingsUtility.swift
+++ b/WordPress/Classes/Utility/In-App Feedback/AppRatingsUtility.swift
@@ -284,7 +284,7 @@ class AppRatingUtility {
         var state = [String: Any]()
         defaults.dictionaryRepresentation()
             .filter({ key, _ in key.hasPrefix("AppRating") })
-            .forEach { key, value in
+            .forEach { key, _ in
                 let cleanKey = (try? key.removingPrefix(pattern: "AppRatings?")) ?? key
                 state[cleanKey] = defaults.object(forKey: key)
         }

--- a/WordPress/Classes/Utility/Media/MediaThumbnailExporter.swift
+++ b/WordPress/Classes/Utility/Media/MediaThumbnailExporter.swift
@@ -145,7 +145,7 @@ class MediaThumbnailExporter: MediaExporter {
             onError(exporterErrorWith(error: ThumbnailExportError.failedToGenerateThumbnailFileURL))
             return Progress.discreteCompletedProgress()
         }
-        return exportThumbnail(forFile: fileURL, onCompletion: { (identifier, export) in
+        return exportThumbnail(forFile: fileURL, onCompletion: { (_, export) in
             onCompletion(export)
         }, onError: onError)
     }

--- a/WordPress/Classes/Utility/Media/MediaVideoExporter.swift
+++ b/WordPress/Classes/Utility/Media/MediaVideoExporter.swift
@@ -208,7 +208,7 @@ class MediaVideoExporter: MediaExporter {
             generator.cancelAllCGImageGeneration()
         }
         generator.generateCGImagesAsynchronously(forTimes: [NSValue(time: CMTimeMake(value: 0, timescale: 1))],
-                                                 completionHandler: { (time, cgImage, actualTime, result, error) in
+                                                 completionHandler: { (_, cgImage, _, _, _) in
                                                     progress.completedUnitCount = MediaExportProgressUnits.halfDone
                                                     guard let cgImage else {
                                                         onError(VideoExportError.failedGeneratingVideoPreviewImage)

--- a/WordPress/Classes/Utility/Notifications/InteractiveNotificationsManager.swift
+++ b/WordPress/Classes/Utility/Notifications/InteractiveNotificationsManager.swift
@@ -320,7 +320,7 @@ private extension InteractiveNotificationsManager {
         commentService.likeComment(withID: commentID, siteID: siteID, success: {
             self.notificationSyncMediator?.markAsReadAndSync(noteID.stringValue)
             DDLogInfo("Liked comment from push notification")
-        }, failure: { error in
+        }, failure: { _ in
             DDLogInfo("Couldn't like comment from push notification")
         })
     }
@@ -335,7 +335,7 @@ private extension InteractiveNotificationsManager {
         commentService.approveComment(withID: commentID, siteID: siteID, success: {
             self.notificationSyncMediator?.markAsReadAndSync(noteID.stringValue)
             DDLogInfo("Successfully moderated comment from push notification")
-        }, failure: { error in
+        }, failure: { _ in
             DDLogInfo("Couldn't moderate comment from push notification")
         })
     }
@@ -359,7 +359,7 @@ private extension InteractiveNotificationsManager {
         commentService.replyToComment(withID: commentID, siteID: siteID, content: content, success: {
             self.notificationSyncMediator?.markAsReadAndSync(noteID.stringValue)
             DDLogInfo("Successfully replied comment from push notification")
-        }, failure: { error in
+        }, failure: { _ in
             DDLogInfo("Couldn't reply to comment from push notification")
         })
     }

--- a/WordPress/Classes/Utility/Notifications/PushNotificationsManager.swift
+++ b/WordPress/Classes/Utility/Notifications/PushNotificationsManager.swift
@@ -395,7 +395,7 @@ extension PushNotificationsManager {
 
         DDLogInfo("Running Notifications Background Fetch...")
 
-        mediator.sync { error, newData in
+        mediator.sync { _, newData in
             DDLogInfo("Finished Notifications Background Fetch!")
 
             let result = newData ? UIBackgroundFetchResult.newData : .noData

--- a/WordPress/Classes/Utility/Sharing/ShareExtensionSessionManager.swift
+++ b/WordPress/Classes/Utility/Sharing/ShareExtensionSessionManager.swift
@@ -271,7 +271,7 @@ import WordPressKit
         media?.forEach { mediaItem in
             syncGroup.enter()
             mediaItem.postID = NSNumber(value: postID)
-            service.update(mediaItem, success: { updatedRemoteMedia in
+            service.update(mediaItem, success: { _ in
                 syncGroup.leave()
             }, failure: { error in
                 var errorString = "Error creating post in share extension"

--- a/WordPress/Classes/Utility/WPContentSyncHelper.swift
+++ b/WordPress/Classes/Utility/WPContentSyncHelper.swift
@@ -56,7 +56,7 @@ public class WPContentSyncHelper: NSObject {
             self?.hasMoreContent = hasMore
             self?.syncContentEnded()
         }, failure: {
-            [weak self] (error: NSError) -> Void in
+            [weak self] (_: NSError) -> Void in
             self?.syncContentEnded(error: true)
         })
 

--- a/WordPress/Classes/Utility/ZendeskUtils.swift
+++ b/WordPress/Classes/Utility/ZendeskUtils.swift
@@ -206,7 +206,7 @@ class ZendeskUtils: NSObject, ZendeskUtilsProtocol {
         let planService = planService ?? PlanService(coreDataStack: contextManager)
         planService.getAllSitesNonLocalizedPlanDescriptionsForAccount(account, success: { plans in
             self.sitePlansCache = plans
-        }, failure: { error in })
+        }, failure: { _ in })
     }
 
     func createRequest(planServiceRemote: PlanServiceRemote? = nil,
@@ -426,7 +426,7 @@ extension ZendeskUtils {
 
         status?(.identifyingUser)
 
-        ZendeskUtils.createIdentity(alertOptions: alertOptions) { success, newIdentity in
+        ZendeskUtils.createIdentity(alertOptions: alertOptions) { success, _ in
             guard success else {
                 if alertOptions.optionalIdentity {
                     let identity = Identity.createAnonymous()
@@ -588,7 +588,7 @@ private extension ZendeskUtils {
                 return
         }
 
-        ZDKPushProvider(zendesk: zendeskInstance).register(deviceIdentifier: deviceID, locale: appLanguage) { (pushResponse, error) in
+        ZDKPushProvider(zendesk: zendeskInstance).register(deviceIdentifier: deviceID, locale: appLanguage) { (_, error) in
             if let error {
                 DDLogInfo("Zendesk couldn't register device: \(deviceID). Error: \(error)")
             } else {

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -1190,7 +1190,7 @@ private extension AztecPostViewController {
 
     @IBAction func displayCancelMediaUploads() {
         let alertController = UIAlertController(title: MediaUploadingCancelAlert.title, message: MediaUploadingCancelAlert.message, preferredStyle: .alert)
-        alertController.addDefaultActionWithTitle(MediaUploadingCancelAlert.acceptTitle) { alertAction in
+        alertController.addDefaultActionWithTitle(MediaUploadingCancelAlert.acceptTitle) { _ in
             self.mediaCoordinator.cancelUploadOfAllMedia(for: self.post)
         }
         alertController.addCancelActionWithTitle(MediaUploadingCancelAlert.cancelTitle)
@@ -2143,7 +2143,7 @@ extension AztecPostViewController {
 
     func findAttachment(withUploadID uploadID: String) -> MediaAttachment? {
         var result: MediaAttachment?
-        self.richTextView.textStorage.enumerateAttachments { (attachment, range) in
+        self.richTextView.textStorage.enumerateAttachments { (attachment, _) in
             if let mediaAttachment = attachment as? MediaAttachment, mediaAttachment.uploadID == uploadID {
                 result = mediaAttachment
             }
@@ -2456,7 +2456,7 @@ extension AztecPostViewController {
 
     fileprivate var failedMediaIDs: [String] {
         var failedIDs = [String]()
-        richTextView.textStorage.enumerateAttachments { (attachment, range) in
+        richTextView.textStorage.enumerateAttachments { (attachment, _) in
             guard let mediaAttachment = attachment as? MediaAttachment,
                 let mediaUploadID = mediaAttachment.uploadID,
                 let media = self.mediaCoordinator.media(withObjectID: mediaUploadID),
@@ -2490,7 +2490,7 @@ extension AztecPostViewController {
 
     fileprivate func processMediaAttachments() {
         refreshGlobalProgress()
-        richTextView.textStorage.enumerateAttachments { (attachment, range) in
+        richTextView.textStorage.enumerateAttachments { (attachment, _) in
             guard let mediaAttachment = attachment as? MediaAttachment else {
                 return
             }
@@ -2553,7 +2553,7 @@ extension AztecPostViewController {
         let title: String = MediaAttachmentActionSheet.title
         var message: String?
         let alertController = UIAlertController(title: title, message: nil, preferredStyle: .actionSheet)
-        let dismissAction = UIAlertAction(title: MediaAttachmentActionSheet.dismissActionTitle, style: .cancel) { (action) in
+        let dismissAction = UIAlertAction(title: MediaAttachmentActionSheet.dismissActionTitle, style: .cancel) { (_) in
             if attachment == self.currentSelectedAttachment {
                 self.currentSelectedAttachment = nil
                 self.resetMediaAttachmentOverlay(attachment)
@@ -2570,14 +2570,14 @@ extension AztecPostViewController {
                 showDefaultActions = false
                 alertController.addActionWithTitle(MediaAttachmentActionSheet.stopUploadActionTitle,
                                                    style: .destructive,
-                                                   handler: { (action) in
+                                                   handler: { (_) in
                                                     self.mediaCoordinator.cancelUpload(of: media)
                 })
             }
         } else {
             alertController.addActionWithTitle(attachment is ImageAttachment ? MediaAttachmentActionSheet.removeImageActionTitle : MediaAttachmentActionSheet.removeVideoActionTitle,
                 style: .destructive,
-                handler: { (action) in
+                handler: { (_) in
                     self.richTextView.remove(attachmentID: attachmentID)
             })
         }
@@ -2591,14 +2591,14 @@ extension AztecPostViewController {
                 if failedMediaIDs.count > 1 {
                     alertController.addActionWithTitle(MediaAttachmentActionSheet.retryAllFailedUploadsActionTitle,
                                                        style: .default,
-                                                       handler: { [weak self] (action) in
+                                                       handler: { [weak self] (_) in
                                                         self?.retryAllFailedMediaUploads()
                     })
                 }
 
                 alertController.addActionWithTitle(MediaAttachmentActionSheet.retryUploadActionTitle,
                                                    style: .default,
-                                                   handler: { [weak self] (action) in
+                                                   handler: { [weak self] (_) in
                                                     guard let strongSelf = self,
                                                         let attachment = strongSelf.richTextView.attachment(withId: attachmentID) else {
                                                             return
@@ -2612,21 +2612,21 @@ extension AztecPostViewController {
             if let imageAttachment = attachment as? ImageAttachment {
                 alertController.preferredAction = alertController.addActionWithTitle(MediaAttachmentActionSheet.settingsActionTitle,
                                                                                      style: .default,
-                                                                                     handler: { (action) in
+                                                                                     handler: { (_) in
                                                                                         self.displayDetails(forAttachment: imageAttachment)
                 })
 
                 if imageAttachment.isLoaded {
                     alertController.addActionWithTitle(MediaAttachmentActionSheet.editActionTitle,
                                                                                          style: .default,
-                                                                                         handler: { (action) in
+                                                                                         handler: { (_) in
                                                                                             self.edit(imageAttachment)
                     })
                 }
             } else if let videoAttachment = attachment as? VideoAttachment {
                 alertController.preferredAction = alertController.addActionWithTitle(MediaAttachmentActionSheet.playVideoActionTitle,
                                                                                      style: .default,
-                                                                                     handler: { (action) in
+                                                                                     handler: { (_) in
                                                                                         self.displayPlayerFor(videoAttachment: videoAttachment, atPosition: position)
                 })
             }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/BlogDashboardViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/BlogDashboardViewController.swift
@@ -191,7 +191,7 @@ final class BlogDashboardViewController: UIViewController {
 extension BlogDashboardViewController {
 
     private func createLayout() -> UICollectionViewLayout {
-        UICollectionViewCompositionalLayout { [weak self] sectionIndex, layoutEnvironment in
+        UICollectionViewCompositionalLayout { [weak self] sectionIndex, _ in
             self?.createLayoutSection(for: sectionIndex)
         }
     }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Helpers/DashboardPostsSyncManager.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Helpers/DashboardPostsSyncManager.swift
@@ -64,7 +64,7 @@ class DashboardPostsSyncManager {
             syncAuthors(blog: blog, success: { [weak self] in
                 postType.stopSyncingStatuses(toBeSynced, for: blog)
                 self?.syncPosts(blog: blog, postType: postType, statuses: toBeSynced)
-            }, failure: { [weak self] error in
+            }, failure: { [weak self] _ in
                 postType.stopSyncingStatuses(toBeSynced, for: blog)
                 self?.notifyListenersOfPostsSync(success: false, blog: blog, postType: postType, for: toBeSynced)
             })

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Models/DashboardCardModel.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Models/DashboardCardModel.swift
@@ -126,7 +126,7 @@ extension DashboardDynamicCardModel: BlogDashboardPersonalizable, BlogDashboardA
 
     var analyticProperties: [AnyHashable: Any] {
         let properties: [AnyHashable: Any] = ["id": payload.id]
-        return cardType.analyticProperties.merging(properties, uniquingKeysWith: { first, second in
+        return cardType.analyticProperties.merging(properties, uniquingKeysWith: { first, _ in
             return first
         })
     }

--- a/WordPress/Classes/ViewRelated/Blog/Blogging Prompts/BloggingPromptCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blogging Prompts/BloggingPromptCoordinator.swift
@@ -137,7 +137,7 @@ private extension BloggingPromptCoordinator {
             context.perform {
                 // Reschedule the prompt reminders.
                 let schedule = BloggingRemindersScheduler.Schedule.weekdays(activeWeekdays)
-                self.scheduler.schedule(schedule, for: blog, time: reminderTimeDate) { result in
+                self.scheduler.schedule(schedule, for: blog, time: reminderTimeDate) { _ in
                     completion()
                 }
             }

--- a/WordPress/Classes/ViewRelated/Blog/BloggingReminders/BloggingRemindersFlowSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/BloggingReminders/BloggingRemindersFlowSettingsViewController.swift
@@ -790,7 +790,7 @@ private extension BloggingRemindersFlowSettingsViewController {
             return
         }
 
-        service.updateSettings(settings: newSettings) { updatedSettings in
+        service.updateSettings(settings: newSettings) { _ in
             completion()
         } failure: { error in
             DDLogError("Error saving prompt reminder schedule: \(String(describing: error))")

--- a/WordPress/Classes/ViewRelated/Blog/BloggingReminders/BloggingRemindersTracker.swift
+++ b/WordPress/Classes/ViewRelated/Blog/BloggingReminders/BloggingRemindersTracker.swift
@@ -127,7 +127,7 @@ class BloggingRemindersTracker {
     private func event(_ event: Event, properties: [String: String]) -> AnalyticsEvent {
         let finalProperties = sharedProperties().merging(
             properties,
-            uniquingKeysWith: { (first, second) in
+            uniquingKeysWith: { (first, _) in
                 return first
         })
 

--- a/WordPress/Classes/ViewRelated/Blog/My Site/Header/HomeSiteHeaderViewController+SiteIcon.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/Header/HomeSiteHeaderViewController+SiteIcon.swift
@@ -114,7 +114,7 @@ extension HomeSiteHeaderViewController {
                 self.blogDetailHeaderView.refreshIconImage()
             }, failure: { _ in })
 
-        }, failure: { [weak self] error in
+        }, failure: { [weak self] _ in
             self?.showErrorForSiteIconUpdate()
         })
     }
@@ -140,7 +140,7 @@ extension HomeSiteHeaderViewController {
                     success: {
                         self?.updateBlogIconWithMedia(media)
                         completion()
-                    }, failure: { error in
+                    }, failure: { _ in
                         self?.showErrorForSiteIconUpdate()
                         completion()
                     })
@@ -161,7 +161,7 @@ extension HomeSiteHeaderViewController {
             self?.blogDetailHeaderView.updatingIcon = false
         }
 
-        imageCropController.onCompletion = { [weak self] image, modified in
+        imageCropController.onCompletion = { [weak self] image, _ in
             self?.dismiss(animated: true)
             self?.uploadDroppedSiteIcon(image, completion: {
                 self?.blogDetailHeaderView.updatingIcon = false

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -407,7 +407,7 @@ final class MySiteViewController: UIViewController, UIScrollViewDelegate, NoSite
 
         blogService.syncBlogs(for: account) {
             finishSync()
-        } failure: { (error) in
+        } failure: { (_) in
             finishSync()
         }
     }

--- a/WordPress/Classes/ViewRelated/Blog/Onboarding Questions Prompt/OnboardingEnableNotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Onboarding Questions Prompt/OnboardingEnableNotificationsViewController.swift
@@ -43,7 +43,7 @@ extension OnboardingEnableNotificationsViewController {
     @IBAction func enableButtonTapped(_ sender: Any) {
         WPAnalytics.track(.onboardingEnableNotificationsEnableTapped)
 
-        InteractiveNotificationsManager.shared.requestAuthorization { authorized in
+        InteractiveNotificationsManager.shared.requestAuthorization { _ in
             DispatchQueue.main.async {
                 self.completion()
             }

--- a/WordPress/Classes/ViewRelated/Blog/Sharing/SharingAccountViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Sharing/SharingAccountViewController.swift
@@ -164,7 +164,7 @@ import WordPressUI
     /// - Returns: An ImmuTableAction instance.
     ///
     fileprivate func actionForRow(_ keyringAccount: KeyringAccount) -> ImmuTableAction {
-        return { [unowned self] row in
+        return { [unowned self] _ in
             self.tableView.deselectSelectedRowWithAnimation(true)
 
             self.delegate?.sharingAccountViewController(self,

--- a/WordPress/Classes/ViewRelated/Blog/Site Monitoring/PHPLogsView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Monitoring/PHPLogsView.swift
@@ -21,7 +21,7 @@ struct PHPLogsView: View {
         .onAppear {
             loadLogs(searchCriteria: searchCriteria)
         }
-        .onChange(of: searchCriteria) { oldValue, newValue in
+        .onChange(of: searchCriteria) { _, newValue in
             loadLogs(searchCriteria: newValue, reset: true)
         }
     }

--- a/WordPress/Classes/ViewRelated/Blog/Site Monitoring/WebServerLogsView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Monitoring/WebServerLogsView.swift
@@ -21,7 +21,7 @@ struct WebServerLogsView: View {
         .onAppear {
             loadLogs(searchCriteria: searchCriteria)
         }
-        .onChange(of: searchCriteria) { oldValue, newValue in
+        .onChange(of: searchCriteria) { _, newValue in
             loadLogs(searchCriteria: newValue, reset: true)
         }
     }

--- a/WordPress/Classes/ViewRelated/Blog/Site Settings/DateAndTimeFormatSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Settings/DateAndTimeFormatSettingsViewController.swift
@@ -111,7 +111,7 @@ open class DateAndTimeFormatSettingsViewController: UITableViewController {
     // MARK: - Row Handlers
 
     func pressedDateFormat() -> ImmuTableAction {
-        return { [unowned self] row in
+        return { [unowned self] _ in
             let settingsViewController = SettingsSelectionViewController(style: .insetGrouped)
             settingsViewController.title = NSLocalizedString("Date Format",
                                                              comment: "Writing Date Format Settings Title")
@@ -145,7 +145,7 @@ open class DateAndTimeFormatSettingsViewController: UITableViewController {
     }
 
     func pressedTimeFormat() -> ImmuTableAction {
-        return { [unowned self] row in
+        return { [unowned self] _ in
             let settingsViewController = SettingsSelectionViewController(style: .insetGrouped)
             settingsViewController.title = NSLocalizedString("Time Format",
                                                              comment: "Writing Time Format Settings Title")
@@ -180,7 +180,7 @@ open class DateAndTimeFormatSettingsViewController: UITableViewController {
     }
 
     func pressedStartOfWeek() -> ImmuTableAction {
-        return { [unowned self] row in
+        return { [unowned self] _ in
             let settingsViewController = SettingsSelectionViewController(style: .insetGrouped)
             settingsViewController.title = NSLocalizedString("Week starts on",
                                                              comment: "Blog Writing Settings: Weeks starts on")

--- a/WordPress/Classes/ViewRelated/Blog/Site Settings/DiscussionSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Settings/DiscussionSettingsViewController.swift
@@ -311,7 +311,7 @@ open class DiscussionSettingsViewController: UITableViewController {
         pickerViewController.pickerMinimumValue = commentsLinksMinimumValue
         pickerViewController.pickerMaximumValue = commentsLinksMaximumValue
         pickerViewController.pickerSelectedValue = settings.commentsMaximumLinks as? Int
-        pickerViewController.onChange = { [weak self] (enabled: Bool, newValue: Int) in
+        pickerViewController.onChange = { [weak self] (_: Bool, newValue: Int) in
             self?.settings.commentsMaximumLinks = newValue as NSNumber
             self?.didChangeSetting("comments_links", value: newValue as Any)
         }

--- a/WordPress/Classes/ViewRelated/Blog/Site Settings/HomepageSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Settings/HomepageSettingsViewController.swift
@@ -289,7 +289,7 @@ import WordPressShared
                                  homePageID: homepagePageID,
                                  success: { [weak self] in
             self?.endUpdating()
-        }, failure: { [weak self] error in
+        }, failure: { [weak self] _ in
             self?.endUpdating()
 
             let notice = Notice(title: Strings.updateErrorTitle, message: Strings.updateErrorMessage, feedbackType: .error)

--- a/WordPress/Classes/ViewRelated/Blog/Site Settings/LanguageSelectorViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Settings/LanguageSelectorViewController.swift
@@ -102,7 +102,7 @@ class LanguageSelectorViewController: UITableViewController, UISearchResultsUpda
     }
 
     private func action(language: Language) -> ImmuTableAction {
-        return { [weak self] row in
+        return { [weak self] _ in
             guard let strongSelf = self else {
                 return
             }

--- a/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteSettingsViewController+Swift.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteSettingsViewController+Swift.swift
@@ -164,7 +164,7 @@ extension SiteSettingsViewController {
         } else {
             pickerViewController.pickerMaximumValue = maxNumberOfPostPerPage
         }
-        pickerViewController.onChange = { [weak self] (enabled: Bool, newValue: Int) in
+        pickerViewController.onChange = { [weak self] (_: Bool, newValue: Int) in
             self?.blog.settings?.postsPerPage = newValue as NSNumber?
             self?.saveSettings()
             self?.trackSettingsChange(fieldName: "posts_per_page", value: newValue as Any)

--- a/WordPress/Classes/ViewRelated/Comments/Controllers/CommentDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Comments/Controllers/CommentDetailViewController.swift
@@ -664,7 +664,7 @@ private extension CommentDetailViewController {
                                         // The comment might have changed its approval status
                                         self?.refreshData()
                                      },
-                                     failure: { [weak self] error in
+                                     failure: { [weak self] _ in
                                         let message = NSLocalizedString("There has been an unexpected error while editing your comment",
                                                                         comment: "Error displayed if a comment fails to get updated")
                                         self?.displayNotice(title: message)
@@ -747,7 +747,7 @@ private extension CommentDetailViewController {
         commentService.unapproveComment(comment, success: { [weak self] in
             self?.showActionableNotice(title: ModerationMessages.pendingSuccess)
             self?.refreshData()
-        }, failure: { [weak self] error in
+        }, failure: { [weak self] _ in
             self?.displayNotice(title: ModerationMessages.pendingFail)
             self?.commentStatus = CommentStatusType.typeForStatus(self?.comment.status)
         })
@@ -762,7 +762,7 @@ private extension CommentDetailViewController {
         commentService.approve(comment, success: { [weak self] in
             self?.showActionableNotice(title: ModerationMessages.approveSuccess)
             self?.refreshData()
-        }, failure: { [weak self] error in
+        }, failure: { [weak self] _ in
             self?.displayNotice(title: ModerationMessages.approveFail)
             self?.commentStatus = CommentStatusType.typeForStatus(self?.comment.status)
         })
@@ -777,7 +777,7 @@ private extension CommentDetailViewController {
         commentService.spamComment(comment, success: { [weak self] in
             self?.showActionableNotice(title: ModerationMessages.spamSuccess)
             self?.refreshData()
-        }, failure: { [weak self] error in
+        }, failure: { [weak self] _ in
             self?.displayNotice(title: ModerationMessages.spamFail)
             self?.commentStatus = CommentStatusType.typeForStatus(self?.comment.status)
         })
@@ -795,7 +795,7 @@ private extension CommentDetailViewController {
             self?.trashButtonCell.isLoading = false
             self?.showActionableNotice(title: ModerationMessages.trashSuccess)
             self?.refreshData()
-        }, failure: { [weak self] error in
+        }, failure: { [weak self] _ in
             self?.trashButtonCell.isLoading = false
             self?.displayNotice(title: ModerationMessages.trashFail)
             self?.commentStatus = CommentStatusType.typeForStatus(self?.comment.status)
@@ -809,7 +809,7 @@ private extension CommentDetailViewController {
         commentService.delete(comment, success: { [weak self] in
             self?.showActionableNotice(title: ModerationMessages.deleteSuccess)
             completion?(true)
-        }, failure: { [weak self] error in
+        }, failure: { [weak self] _ in
             self?.deleteButtonCell.isLoading = false
             self?.displayNotice(title: ModerationMessages.deleteFail)
             completion?(false)

--- a/WordPress/Classes/ViewRelated/Comments/Controllers/EditCommentTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Comments/Controllers/EditCommentTableViewController.swift
@@ -207,7 +207,7 @@ private extension EditCommentTableViewController {
         let alertController = UIAlertController(title: title, message: nil, preferredStyle: .actionSheet)
         alertController.addCancelActionWithTitle(keepEditingTitle)
 
-        alertController.addDestructiveActionWithTitle(discardTitle) { [weak self] action in
+        alertController.addDestructiveActionWithTitle(discardTitle) { [weak self] _ in
             self?.finishWithoutUpdates()
         }
 

--- a/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainDetails/ViewController/RegisterDomainDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainDetails/ViewController/RegisterDomainDetailsViewController.swift
@@ -133,7 +133,7 @@ class RegisterDomainDetailsViewController: UITableViewController {
         let gestureRecognizer = UITapGestureRecognizer()
         gestureRecognizer.cancelsTouchesInView = false
 
-        gestureRecognizer.on { [weak self] (gesture) in
+        gestureRecognizer.on { [weak self] (_) in
             self?.view.endEditing(true)
         }
 

--- a/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainDetails/ViewModel/RegisterDomainDetailsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainDetails/ViewModel/RegisterDomainDetailsViewModel.swift
@@ -217,7 +217,7 @@ class RegisterDomainDetailsViewModel {
                             // the user we could opt to show a Notice in the future.
                             onChange?(.registerSucceeded(domain))
                         })
-                }, failure: { error in
+                }, failure: { _ in
                     // Same as above. If adding items to cart fails, not much we can do to recover :(
                     WPAnalytics.track(.automatedTransferCustomDomainPurchaseFailed)
                     self?.isLoading = false
@@ -287,7 +287,7 @@ class RegisterDomainDetailsViewModel {
                 } else {
                     prefillSuccessBlock()
                 }
-        }) { [weak self] (error) in
+        }) { [weak self] (_) in
             guard let strongSelf = self else {
                 return
             }
@@ -319,7 +319,7 @@ class RegisterDomainDetailsViewModel {
             }
             strongSelf.countries = result
             successCompletion()
-        }) { [weak self] (error) in
+        }) { [weak self] (_) in
             guard let strongSelf = self else {
                 return
             }
@@ -351,7 +351,7 @@ class RegisterDomainDetailsViewModel {
                 }
                 strongSelf.states = result
                 successCompletion?()
-        }) { [weak self] (error) in
+        }) { [weak self] (_) in
             guard let strongSelf = self else {
                 return
             }
@@ -500,7 +500,7 @@ extension RegisterDomainDetailsViewModel {
                     strongSelf.updateValidationErrors(with: response.messages)
                     strongSelf.onChange?(.remoteValidationFinished)
                 }
-        }) { [weak self] (error) in
+        }) { [weak self] (_) in
             guard let strongSelf = self else {
                 return
             }

--- a/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/RegisterDomainCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/RegisterDomainCoordinator.swift
@@ -252,7 +252,7 @@ class RegisterDomainCoordinator {
     private func track(_ event: WPAnalyticsEvent, properties: [AnyHashable: Any]? = nil) {
         let defaultProperties: [AnyHashable: Any] = [WPAppAnalyticsKeySource: analyticsSource]
 
-        let properties = defaultProperties.merging(properties ?? [:]) { first, second in
+        let properties = defaultProperties.merging(properties ?? [:]) { first, _ in
             return first
         }
 

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergNetworking.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergNetworking.swift
@@ -43,7 +43,7 @@ struct GutenbergNetworkRequest {
     // MARK: - dotCom
 
     private func dotComGetRequest(with dotComID: NSNumber, completion: @escaping CompletionHandler) {
-        blog.wordPressComRestApi?.GET(dotComPath(with: dotComID), parameters: nil, success: { (response, httpResponse) in
+        blog.wordPressComRestApi?.GET(dotComPath(with: dotComID), parameters: nil, success: { (response, _) in
             completion(.success(response))
         }, failure: { (error, httpResponse) in
             completion(.failure(error.nsError(with: httpResponse)))
@@ -51,7 +51,7 @@ struct GutenbergNetworkRequest {
     }
 
     private func dotComPostRequest(with dotComID: NSNumber, data: [String: AnyObject]?, completion: @escaping CompletionHandler) {
-        blog.wordPressComRestApi?.POST(dotComPath(with: dotComID), parameters: data, success: { (response, httpResponse) in
+        blog.wordPressComRestApi?.POST(dotComPath(with: dotComID), parameters: data, success: { (response, _) in
             completion(.success(response))
         }, failure: { (error, httpResponse) in
             completion(.failure(error.nsError(with: httpResponse)))

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
@@ -130,7 +130,7 @@ class GutenbergViewController: UIViewController, PostEditor, PublishingEditor {
         mediaEditor.editingAlreadyPublishedImage = true
 
         mediaEditor.edit(from: self,
-                         onFinishEditing: { [weak self] images, actions in
+                         onFinishEditing: { [weak self] images, _ in
                             guard let image = images.first?.editedImage else {
                                 // If the image wasn't edited, do nothing
                                 return
@@ -731,7 +731,7 @@ extension GutenbergViewController: GutenbergBridgeDelegate {
                                                 message: NSLocalizedString("You already have a featured image set. Do you want to replace it with the new image?", comment: "Main message on dialog that prompts user to confirm or cancel the replacement of a featured image."),
                                                 preferredStyle: .actionSheet)
 
-        let replaceAction = UIAlertAction(title: NSLocalizedString("Replace featured image", comment: "Button to confirm the replacement of a featured image."), style: .default) { (action) in
+        let replaceAction = UIAlertAction(title: NSLocalizedString("Replace featured image", comment: "Button to confirm the replacement of a featured image."), style: .default) { (_) in
             self.featuredImageHelper.setFeaturedImage(mediaID: mediaID)
         }
 
@@ -754,13 +754,13 @@ extension GutenbergViewController: GutenbergBridgeDelegate {
         let title: String = MediaAttachmentActionSheet.title
         var message: String? = nil
         let alertController = UIAlertController(title: title, message: nil, preferredStyle: .actionSheet)
-        let dismissAction = UIAlertAction(title: MediaAttachmentActionSheet.dismissActionTitle, style: .cancel) { (action) in
+        let dismissAction = UIAlertAction(title: MediaAttachmentActionSheet.dismissActionTitle, style: .cancel) { (_) in
 
         }
         alertController.addAction(dismissAction)
 
         if media.remoteStatus == .failed || media.remoteStatus == .processing || media.remoteStatus == .local || media.remoteStatus == .pushing {
-            let cancelUploadAction = UIAlertAction(title: MediaAttachmentActionSheet.stopUploadActionTitle, style: .destructive) { (action) in
+            let cancelUploadAction = UIAlertAction(title: MediaAttachmentActionSheet.stopUploadActionTitle, style: .destructive) { (_) in
                 self.mediaInserterHelper.cancelUploadOf(media: media)
             }
             alertController.addAction(cancelUploadAction)
@@ -769,7 +769,7 @@ extension GutenbergViewController: GutenbergBridgeDelegate {
         if media.remoteStatus == .failed, let error = media.error {
             message = error.localizedDescription
             if media.canRetry {
-                let retryUploadAction = UIAlertAction(title: MediaAttachmentActionSheet.retryUploadActionTitle, style: .default) { (action) in
+                let retryUploadAction = UIAlertAction(title: MediaAttachmentActionSheet.retryUploadActionTitle, style: .default) { (_) in
                     self.mediaInserterHelper.retryFailedMediaUploads()
                 }
                 alertController.addAction(retryUploadAction)
@@ -789,7 +789,7 @@ extension GutenbergViewController: GutenbergBridgeDelegate {
         let title: String = (self.post is Page) ? EmptyPostActionSheet.titlePage : EmptyPostActionSheet.titlePost
         let message: String = EmptyPostActionSheet.message
         let alertController = UIAlertController(title: title, message: message, preferredStyle: .actionSheet)
-        let dismissAction = UIAlertAction(title: MediaAttachmentActionSheet.dismissActionTitle, style: .cancel) { (action) in
+        let dismissAction = UIAlertAction(title: MediaAttachmentActionSheet.dismissActionTitle, style: .cancel) { (_) in
 
         }
         alertController.addAction(dismissAction)

--- a/WordPress/Classes/ViewRelated/Gutenberg/Utils/GutenbergMediaEditorImage.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Utils/GutenbergMediaEditorImage.swift
@@ -40,7 +40,7 @@ class GutenbergMediaEditorImage: AsyncImage {
      If a thumbnail doesn't exist in cache, fetch one
      */
     func thumbnail(finishedRetrievingThumbnail: @escaping (UIImage?) -> ()) {
-        let task = ImageDownloader.shared.downloadImage(at: originalURL, completion: { image, error in
+        let task = ImageDownloader.shared.downloadImage(at: originalURL, completion: { image, _ in
             guard let image else {
                 finishedRetrievingThumbnail(nil)
                 return

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Settings/JetpackConnectionViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Settings/JetpackConnectionViewController.swift
@@ -82,7 +82,7 @@ open class JetpackConnectionViewController: UITableViewController {
     // MARK: - Row Handler
 
     func disconnectJetpackTapped() -> ImmuTableAction {
-        return { [unowned self] row in
+        return { [unowned self] _ in
             self.tableView.deselectSelectedRowWithAnimation(true)
             let message = NSLocalizedString("Are you sure you want to disconnect Jetpack from the site?",
                                             comment: "Message prompting the user to confirm that they want to disconnect Jetpack from the site.")
@@ -93,7 +93,7 @@ open class JetpackConnectionViewController: UITableViewController {
             alertController.addCancelActionWithTitle(NSLocalizedString("Cancel", comment: "Verb. A button title. Tapping cancels an action."))
             alertController.addDestructiveActionWithTitle(NSLocalizedString("Disconnect",
                                                                             comment: "Title for button that disconnects Jetpack from the site"),
-                                                          handler: { action in
+                                                          handler: { _ in
                                                               self.disconnectJetpack()
                                                           })
             WPAnalytics.trackEvent(.jetpackDisconnectTapped)

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Settings/JetpackSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Settings/JetpackSettingsViewController.swift
@@ -235,7 +235,7 @@ open class JetpackSettingsViewController: UITableViewController {
     }
 
     func pressedAllowlistedIPAddresses() -> ImmuTableAction {
-        return { [unowned self] row in
+        return { [unowned self] _ in
             let allowListedIPs = self.settings.jetpackLoginAllowListedIPAddresses
             let settingsViewController = SettingsListEditorViewController(collection: allowListedIPs)
 
@@ -307,7 +307,7 @@ open class JetpackSettingsViewController: UITableViewController {
     }
 
     fileprivate func pressedManageConnection() -> ImmuTableAction {
-        return { [unowned self] row in
+        return { [unowned self] _ in
             WPAnalytics.trackEvent(.jetpackManageConnectionViewed)
             let jetpackConnectionVC = JetpackConnectionViewController(blog: blog)
             jetpackConnectionVC.delegate = self

--- a/WordPress/Classes/ViewRelated/Me/Account Settings/AccountSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/Account Settings/AccountSettingsViewController.swift
@@ -181,7 +181,7 @@ private class AccountSettingsController: SettingsController {
     }
 
     func changePassword(with settings: AccountSettings?, service: AccountSettingsService) -> (ImmuTableRow) -> SettingsTextViewController {
-        return { row in
+        return { _ in
             return ChangePasswordViewController(username: settings?.username ?? "") { [weak self] value in
                 DispatchQueue.main.async {
                     SVProgressHUD.show(withStatus: Constants.changingPassword)
@@ -356,7 +356,7 @@ private class AccountSettingsController: SettingsController {
     }
 
     private var contactSupportAction: ((UIAlertAction) -> Void) {
-        return { action in
+        return { _ in
             if ZendeskUtils.zendeskEnabled {
                 guard let leafViewController = UIApplication.shared.leafViewController else {
                     return

--- a/WordPress/Classes/ViewRelated/Me/All Domains/Coordinators/AllDomainsAddDomainCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Me/All Domains/Coordinators/AllDomainsAddDomainCoordinator.swift
@@ -12,7 +12,7 @@ import WordPressData
             coordinator: coordinator
         )
 
-        let domainPurchasedCallback = { (domainViewController: UIViewController, domainName: String) in
+        let domainPurchasedCallback = { (domainViewController: UIViewController, _: String) in
             domainViewController.dismiss(animated: true) {
                 allDomainsViewController.reloadDomains()
             }

--- a/WordPress/Classes/ViewRelated/Me/All Domains/Views/DomainPurchaseChoicesView.swift
+++ b/WordPress/Classes/ViewRelated/Me/All Domains/Views/DomainPurchaseChoicesView.swift
@@ -135,7 +135,7 @@ struct DomainPurchaseChoicesView: View {
             return [WPAppAnalyticsKeySource: source]
         }()
 
-        let properties = defaultProperties.merging(properties ?? [:]) { first, second in
+        let properties = defaultProperties.merging(properties ?? [:]) { first, _ in
             return first
         }
 

--- a/WordPress/Classes/ViewRelated/Me/App Settings/About/AppAboutScreenConfiguration.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/About/AppAboutScreenConfiguration.swift
@@ -41,7 +41,7 @@ class AppAboutScreenConfiguration: AboutScreenConfiguration {
             [
                 AboutItem(
                     title: TextContent.rateUs,
-                    action: { [weak self] context in
+                    action: { [weak self] _ in
                         WPAnalytics.track(.appReviewsRatedApp)
                         self?.tracker.buttonPressed(.rateUs)
                         AppRatingUtility.shared.ratedCurrentVersion()

--- a/WordPress/Classes/ViewRelated/Me/App Settings/AppSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/AppSettingsViewController.swift
@@ -169,7 +169,7 @@ class AppSettingsViewController: UITableViewController {
     }
 
     func pushVideoResolutionSettings() -> ImmuTableAction {
-        return { [weak self] row in
+        return { [weak self] _ in
             let values = [MediaSettings.VideoResolution.size640x480,
                           MediaSettings.VideoResolution.size1280x720,
                           MediaSettings.VideoResolution.size1920x1080,
@@ -201,7 +201,7 @@ class AppSettingsViewController: UITableViewController {
     }
 
     func pushImageQualitySettings() -> ImmuTableAction {
-        return { [weak self] row in
+        return { [weak self] _ in
             let values = [MediaSettings.ImageQuality.low,
                           MediaSettings.ImageQuality.medium,
                           MediaSettings.ImageQuality.high,
@@ -267,7 +267,7 @@ class AppSettingsViewController: UITableViewController {
     }
 
     func pushAppearanceSettings() -> ImmuTableAction {
-        return { [weak self] row in
+        return { [weak self] _ in
             let values = UIUserInterfaceStyle.allStyles
 
             let rawValues = values.map({ $0.rawValue })
@@ -307,21 +307,21 @@ class AppSettingsViewController: UITableViewController {
     }
 
     func pushDebugMenu() -> ImmuTableAction {
-        return { [weak self] row in
+        return { [weak self] _ in
             let controller = DebugMenuViewController()
             self?.navigationController?.pushViewController(controller, animated: true)
         }
     }
 
     func pushDesignSystemGallery() -> ImmuTableAction {
-        return { [weak self] row in
+        return { [weak self] _ in
             let controller = UIHostingController(rootView: DesignSystemGallery())
             self?.navigationController?.pushViewController(controller, animated: true)
         }
     }
 
     func pushAppIconSwitcher() -> ImmuTableAction {
-        return { [weak self] row in
+        return { [weak self] _ in
             let controller = AppIconViewController()
             self?.navigationController?.pushViewController(controller, animated: true)
         }
@@ -334,7 +334,7 @@ class AppSettingsViewController: UITableViewController {
     }
 
     func openApplicationSettings() -> ImmuTableAction {
-        return { [weak self] row in
+        return { [weak self] _ in
             WPAnalytics.track(.appSettingsOpenDeviceSettingsTapped)
 
             if let targetURL = URL(string: UIApplication.openSettingsURLString) {
@@ -362,7 +362,7 @@ class AppSettingsViewController: UITableViewController {
     }
 
     func clearSpotlightCache() -> ImmuTableAction {
-        return { [weak self] row in
+        return { [weak self] _ in
             WPAnalytics.track(.appSettingsClearSpotlightIndexTapped)
 
             self?.tableView.deselectSelectedRowWithAnimation(true)
@@ -374,7 +374,7 @@ class AppSettingsViewController: UITableViewController {
     }
 
     func presentWhatIsNew() -> ImmuTableAction {
-        return { [weak self] row in
+        return { [weak self] _ in
             guard let self else {
                 return
             }
@@ -386,7 +386,7 @@ class AppSettingsViewController: UITableViewController {
     private let experimentalFeaturesVM = ExperimentalFeaturesViewModel(dataProvider: ExperimentalFeaturesDataProvider())
 
     func pushExperimentalFeatures() -> ImmuTableAction {
-        return { [weak self] row in
+        return { [weak self] _ in
             guard let self else {
                 return
             }

--- a/WordPress/Classes/ViewRelated/Me/App Settings/MediaCacheSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/MediaCacheSettingsViewController.swift
@@ -53,7 +53,7 @@ class MediaCacheSettingsViewController: UITableViewController {
         let mediaClearCacheRow = BrandedNavigationRow(
             title: NSLocalizedString("Clear Device Media Cache",
                                      comment: "Label for button that clears all media cache."),
-            action: { [weak self] row in
+            action: { [weak self] _ in
                 self?.clearMediaCache()
             },
             accessibilityIdentifier: "mediaClearCacheButton")
@@ -121,7 +121,7 @@ class MediaCacheSettingsViewController: UITableViewController {
         setMediaCacheRowDescription(status: .clearingCache)
         MediaFileManager.clearAllMediaCacheFiles(onCompletion: { [weak self] in
             self?.updateMediaCacheSize()
-            }, onError: { [weak self] (error) in
+            }, onError: { [weak self] (_) in
                 self?.updateMediaCacheSize()
         })
     }

--- a/WordPress/Classes/ViewRelated/Me/Me Main/MeViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/Me Main/MeViewController.swift
@@ -158,7 +158,7 @@ public class MeViewController: UITableViewController {
             icon: UIImage(named: "wpl-globe")?.withRenderingMode(.alwaysTemplate),
             tintColor: .label,
             accessoryType: accessoryType,
-            action: { [weak self] action in
+            action: { [weak self] _ in
                 self?.showOrPushController(AllDomainsListViewController())
                 WPAnalytics.track(.meDomainsTapped)
             },
@@ -253,7 +253,7 @@ public class MeViewController: UITableViewController {
     // MARK: - Actions
 
     fileprivate func presentGravatarAboutEditorAction() -> ImmuTableAction {
-        return { [unowned self] row in
+        return { [unowned self] _ in
             presentGravatarQuickEditor(initialPage: .aboutEditor)
         }
     }
@@ -276,7 +276,7 @@ public class MeViewController: UITableViewController {
     }
 
     fileprivate func pushAccountSettings() -> ImmuTableAction {
-        return { [unowned self] row in
+        return { [unowned self] _ in
             if let account = self.defaultAccount() {
                 WPAppAnalytics.track(.openedAccountSettings)
                 guard let controller = AccountSettingsViewController(account: account) else {
@@ -288,7 +288,7 @@ public class MeViewController: UITableViewController {
     }
 
     private func presentQRLogin() -> ImmuTableAction {
-        return { [weak self] row in
+        return { [weak self] _ in
             guard let self else {
                 return
             }
@@ -299,13 +299,13 @@ public class MeViewController: UITableViewController {
     }
 
     func pushAppSettings() -> ImmuTableAction {
-        return { [unowned self] row in
+        return { [unowned self] _ in
             self.navigateToAppSettings()
         }
     }
 
     func pushHelp() -> ImmuTableAction {
-        return { [unowned self] row in
+        return { [unowned self] _ in
             if FeatureFlag.newSupport.enabled == true {
                 let controller = RootSupportViewController(dataProvider: SupportDataProvider.shared)
                 self.showOrPushController(controller)
@@ -329,7 +329,7 @@ public class MeViewController: UITableViewController {
     }
 
     func displayShareFlow() -> ImmuTableAction {
-        return { [unowned self] row in
+        return { [unowned self] _ in
             defer {
                 self.tableView.deselectSelectedRowWithAnimation(true)
             }
@@ -344,14 +344,14 @@ public class MeViewController: UITableViewController {
     }
 
     fileprivate func presentLogin() -> ImmuTableAction {
-        return { [unowned self] row in
+        return { [unowned self] _ in
             self.tableView.deselectSelectedRowWithAnimation(true)
             self.promptForLoginOrSignup()
         }
     }
 
     fileprivate func logoutRowWasPressed() -> ImmuTableAction {
-        return { [unowned self] row in
+        return { [unowned self] _ in
             self.tableView.deselectSelectedRowWithAnimation(true)
             self.displayLogOutAlert()
         }

--- a/WordPress/Classes/ViewRelated/Me/My Profile/Gravatar/GravatarUploader.swift
+++ b/WordPress/Classes/ViewRelated/Me/My Profile/Gravatar/GravatarUploader.swift
@@ -23,7 +23,7 @@ extension GravatarUploader {
         updateGravatarStatus(.uploading(image: newGravatar))
 
         let service = GravatarService()
-        service.uploadImage(newGravatar, forAccount: account) { [weak self] error in
+        service.uploadImage(newGravatar, forAccount: account) { [weak self] _ in
             DispatchQueue.main.async(execute: {
                 WPAppAnalytics.track(.gravatarUploaded)
                 self?.updateGravatarStatus(.finished)

--- a/WordPress/Classes/ViewRelated/Media/MediaItemViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaItemViewController.swift
@@ -268,7 +268,7 @@ final class MediaItemViewController: UITableViewController {
         let alertController = UIAlertController(title: nil,
                                                 message: Strings.deleteConfirmation, preferredStyle: .alert)
         alertController.addCancelActionWithTitle(Strings.cancel)
-        alertController.addDestructiveActionWithTitle(Strings.delete, handler: { action in
+        alertController.addDestructiveActionWithTitle(Strings.delete, handler: { _ in
             self.deleteMediaItem()
         })
 

--- a/WordPress/Classes/ViewRelated/Media/SiteMedia/Views/SiteMediaCollectionCellViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Media/SiteMedia/Views/SiteMediaCollectionCellViewModel.swift
@@ -53,7 +53,7 @@ final class SiteMediaCollectionCellViewModel {
             self?.updateOverlayState()
         })
 
-        observations.append(media.observe(\.localURL, options: [.new]) { [weak self] media, _ in
+        observations.append(media.observe(\.localURL, options: [.new]) { [weak self] _, _ in
             self?.didUpdateLocalThumbnail()
         })
 

--- a/WordPress/Classes/ViewRelated/Media/StockPhotos/AztecMediaPickingCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Media/StockPhotos/AztecMediaPickingCoordinator.swift
@@ -37,19 +37,19 @@ final class AztecMediaPickingCoordinator {
     }
 
     private func freePhotoAction(origin: UIViewController, blog: Blog) -> UIAlertAction {
-        return UIAlertAction(title: .freePhotosLibrary, style: .default, handler: { [weak self] action in
+        return UIAlertAction(title: .freePhotosLibrary, style: .default, handler: { [weak self] _ in
             self?.showStockPhotos(origin: origin, blog: blog)
         })
     }
 
     private func tenorAction(origin: UIViewController, blog: Blog) -> UIAlertAction {
-        return UIAlertAction(title: .tenor, style: .default, handler: { [weak self] action in
+        return UIAlertAction(title: .tenor, style: .default, handler: { [weak self] _ in
             self?.showTenor(origin: origin, blog: blog)
         })
     }
 
     private func otherAppsAction(origin: UIViewController & UIDocumentPickerDelegate, blog: Blog) -> UIAlertAction {
-        return UIAlertAction(title: .otherApps, style: .default, handler: { [weak self] action in
+        return UIAlertAction(title: .otherApps, style: .default, handler: { [weak self] _ in
             self?.showDocumentPicker(origin: origin, blog: blog)
         })
     }

--- a/WordPress/Classes/ViewRelated/Media/StockPhotos/DefaultStockPhotosService.swift
+++ b/WordPress/Classes/ViewRelated/Media/StockPhotos/DefaultStockPhotosService.swift
@@ -22,7 +22,7 @@ final class DefaultStockPhotosService: StockPhotosService {
     }
 
     func search(params: StockPhotosSearchParams, completion: @escaping (StockPhotosResultsPage) -> Void) {
-        api.GET(endPoint, parameters: parameters(params: params), success: { results, response in
+        api.GET(endPoint, parameters: parameters(params: params), success: { results, _ in
             if let media = results[ParsingKeys.media], let meta = results[ParsingKeys.meta] as? [String: Int] {
                 do {
                     let mediaJSON = try JSONSerialization.data(withJSONObject: media as Any)
@@ -39,7 +39,7 @@ final class DefaultStockPhotosService: StockPhotosService {
                     completion(StockPhotosResultsPage.empty())
                 }
             }
-        }) { error, response in
+        }) { _, _ in
             // I am not sure how we are going to handle errors. In the meantime, I'm returning an empty result
             completion(StockPhotosResultsPage.empty())
         }

--- a/WordPress/Classes/ViewRelated/NUX/Controllers/Social Signup/SignupUsernameTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/Controllers/Social Signup/SignupUsernameTableViewController.swift
@@ -71,7 +71,7 @@ class SignupUsernameTableViewController: UITableViewController, SearchTableViewC
 
     func setupBackgroundTapGestureRecognizer() {
         let gestureRecognizer = UITapGestureRecognizer()
-        gestureRecognizer.on(call: { [weak self] (gesture) in
+        gestureRecognizer.on(call: { [weak self] (_) in
             self?.view.endEditing(true)
         })
         gestureRecognizer.cancelsTouchesInView = false

--- a/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
@@ -415,7 +415,7 @@ extension NewGutenbergViewController {
         let title: String = (self.post is Page) ? EmptyPostActionSheet.titlePage : EmptyPostActionSheet.titlePost
         let message: String = EmptyPostActionSheet.message
         let alertController = UIAlertController(title: title, message: message, preferredStyle: .actionSheet)
-        let dismissAction = UIAlertAction(title: MediaAttachmentActionSheet.dismissActionTitle, style: .cancel) { (action) in
+        let dismissAction = UIAlertAction(title: MediaAttachmentActionSheet.dismissActionTitle, style: .cancel) { (_) in
 
         }
         alertController.addAction(dismissAction)

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
@@ -163,7 +163,7 @@ class NotificationDetailsViewController: UIViewController, NoResultsViewHost {
 
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
         super.viewWillTransition(to: size, with: coordinator)
-        coordinator.animate(alongsideTransition: { context in
+        coordinator.animate(alongsideTransition: { _ in
             self.refreshInterfaceIfNeeded()
         })
     }

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingDetailsViewController.swift
@@ -310,7 +310,7 @@ class NotificationSettingDetailsViewController: UITableViewController {
             success: {
                 WPAnalytics.track(.notificationsSettingsUpdated, withProperties: ["success": true])
             },
-            failure: { (error: Error?) in
+            failure: { (_: Error?) in
                 WPAnalytics.track(.notificationsSettingsUpdated, withProperties: ["success": false])
                 self.handleUpdateError()
             })
@@ -327,7 +327,7 @@ class NotificationSettingDetailsViewController: UITableViewController {
 
         alertController.addCancelActionWithTitle(cancelText, handler: nil)
 
-        alertController.addDefaultActionWithTitle(retryText) { (action: UIAlertAction) in
+        alertController.addDefaultActionWithTitle(retryText) { (_: UIAlertAction) in
             self.saveSettingsIfNeeded()
         }
 

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingsViewController.swift
@@ -229,11 +229,11 @@ class NotificationSettingsViewController: UIViewController {
 
         let alertController = UIAlertController(title: title, message: message, preferredStyle: .alert)
 
-        alertController.addCancelActionWithTitle(cancelText) { (action: UIAlertAction) in
+        alertController.addCancelActionWithTitle(cancelText) { (_: UIAlertAction) in
             _ = self.navigationController?.popViewController(animated: true)
         }
 
-        alertController.addDefaultActionWithTitle(retryText) { (action: UIAlertAction) in
+        alertController.addDefaultActionWithTitle(retryText) { (_: UIAlertAction) in
             self.reloadSettings()
         }
 

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController+AppRatings.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController+AppRatings.swift
@@ -15,11 +15,11 @@ extension NotificationsViewController {
         let noTitle = NSLocalizedString("notifications.appRatings.prompt.no.buttonTitle", value: "Could improve",
                                         comment: "This is one of the buttons we display inside of the prompt to review the app")
 
-        inlinePromptView.setupYesButton(title: yesTitle) { [weak self] button in
+        inlinePromptView.setupYesButton(title: yesTitle) { [weak self] _ in
             self?.likedApp()
         }
 
-        inlinePromptView.setupNoButton(title: noTitle) { [weak self] button in
+        inlinePromptView.setupNoButton(title: noTitle) { [weak self] _ in
             self?.dislikedApp()
         }
 
@@ -61,10 +61,10 @@ extension NotificationsViewController {
                                              comment: "This is one of the buttons we display when prompting the user for a review")
             let noTitle = NSLocalizedString("notifications.appRatings.sendFeedback.no.buttonTitle", value: "No thanks",
                                             comment: "This is one of the buttons we display when prompting the user for a review")
-            self?.inlinePromptView.setupYesButton(title: yesTitle) { [weak self] button in
+            self?.inlinePromptView.setupYesButton(title: yesTitle) { [weak self] _ in
                 self?.gatherFeedback()
             }
-            self?.inlinePromptView.setupNoButton(title: noTitle) { [weak self] button in
+            self?.inlinePromptView.setupNoButton(title: noTitle) { [weak self] _ in
                 self?.dismissRatingsPrompt()
             }
         }

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController+PushPrimer.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController+PushPrimer.swift
@@ -41,7 +41,7 @@ extension NotificationsViewController {
         let noTitle = NSLocalizedString("Not now",
                                         comment: "Button label for denying our request to allow push notifications")
 
-        inlinePromptView.setupYesButton(title: yesTitle) { [weak self] button in
+        inlinePromptView.setupYesButton(title: yesTitle) { [weak self] _ in
             defer {
                 WPAnalytics.track(.pushNotificationPrimerAllowTapped, withProperties: [Analytics.locationKey: Analytics.inlineKey])
             }
@@ -53,7 +53,7 @@ extension NotificationsViewController {
             }
         }
 
-        inlinePromptView.setupNoButton(title: noTitle) { [weak self] button in
+        inlinePromptView.setupNoButton(title: noTitle) { [weak self] _ in
             defer {
                 WPAnalytics.track(.pushNotificationPrimerNoTapped, withProperties: [Analytics.locationKey: Analytics.inlineKey])
             }
@@ -88,7 +88,7 @@ extension NotificationsViewController {
         let noTitle = NSLocalizedString("No thanks",
                                         comment: "Button label for denying our request to re-allow push notifications")
 
-        inlinePromptView.setupYesButton(title: yesTitle) { [weak self] button in
+        inlinePromptView.setupYesButton(title: yesTitle) { [weak self] _ in
             defer {
                 WPAnalytics.track(.pushNotificationWinbackSettingsTapped, withProperties: [Analytics.locationKey: Analytics.inlineKey])
             }
@@ -98,7 +98,7 @@ extension NotificationsViewController {
             UserPersistentStoreFactory.instance().notificationPrimerInlineWasAcknowledged = true
         }
 
-        inlinePromptView.setupNoButton(title: noTitle) { [weak self] button in
+        inlinePromptView.setupNoButton(title: noTitle) { [weak self] _ in
             defer {
                 WPAnalytics.track(.pushNotificationWinbackNoTapped, withProperties: [Analytics.locationKey: Analytics.inlineKey])
             }

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController/NotificationsViewController.swift
@@ -384,7 +384,7 @@ class NotificationsViewController: UIViewController, UITableViewDataSource, UITa
         let title = isRead ? NSLocalizedString("Mark Unread", comment: "Marks a notification as unread") :
                              NSLocalizedString("Mark Read", comment: "Marks a notification as unread")
 
-        let action = UIContextualAction(style: .normal, title: title, handler: { (action, view, completionHandler) in
+        let action = UIContextualAction(style: .normal, title: title, handler: { (_, _, completionHandler) in
             if isRead {
                 WPAnalytics.track(.notificationMarkAsUnreadTapped)
                 self.markAsUnread(note: note)
@@ -1646,7 +1646,7 @@ private extension NotificationsViewController {
 
         DDLogInfo("Sync'ing Notification [\(noteId)]")
 
-        mediator?.syncNote(with: noteId) { error, note in
+        mediator?.syncNote(with: noteId) { _, note in
             guard abs(startDate.timeIntervalSinceNow) <= timeout else {
                 DDLogError("Error: Timeout while trying to load Notification [\(noteId)]")
                 return

--- a/WordPress/Classes/ViewRelated/Notifications/Tools/NotificationMediaDownloader.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Tools/NotificationMediaDownloader.swift
@@ -51,7 +51,7 @@ class NotificationMediaDownloader: NSObject {
 
             group.enter()
 
-            downloadImage(url) { (error, image) in
+            downloadImage(url) { (_, image) in
                 guard let image else {
                     group.leave()
                     return
@@ -153,7 +153,7 @@ class NotificationMediaDownloader: NSObject {
             return
         }
 
-        imageDownloader.downloadImage(at: url) { (image, error) in
+        imageDownloader.downloadImage(at: url) { (image, _) in
             guard let image else {
                 self.downloadImage(url, retryCount: retryCount + 1, completion: completion)
                 return

--- a/WordPress/Classes/ViewRelated/Pages/Controllers/EditPageViewController.swift
+++ b/WordPress/Classes/ViewRelated/Pages/Controllers/EditPageViewController.swift
@@ -88,7 +88,7 @@ class EditPageViewController: UIViewController {
             localizedFeatureName: feature,
             source: "block_editor",
             presentingViewController: self
-        ) { [weak self] client in
+        ) { [weak self] _ in
             // Once authenticated, dismiss the application password view and show editor
             guard let self else { return EmptyView() }
 

--- a/WordPress/Classes/ViewRelated/Pages/Controllers/PageListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Pages/Controllers/PageListViewController.swift
@@ -395,7 +395,7 @@ final class PageListViewController: AbstractPostListViewController {
         homepageSettingsService?.setHomepageType(.page, homePageID: homePageID, success: { [weak self] in
             self?.refreshAndReload()
             self?.handleHomepageSettingsSuccess()
-        }, failure: { [weak self] error in
+        }, failure: { [weak self] _ in
             self?.refreshControl.endRefreshing()
             self?.handleHomepageSettingsFailure()
         })
@@ -408,7 +408,7 @@ final class PageListViewController: AbstractPostListViewController {
         homepageSettingsService?.setHomepageType(.page, withPostsPageID: postsPageID, success: { [weak self] in
             self?.refreshAndReload()
             self?.handleHomepagePostsPageSettingsSuccess(isPostsPage: newValue)
-        }, failure: { [weak self] error in
+        }, failure: { [weak self] _ in
             self?.refreshControl.endRefreshing()
             self?.handleHomepageSettingsFailure()
         })

--- a/WordPress/Classes/ViewRelated/People/Controllers/InvitePersonViewController.swift
+++ b/WordPress/Classes/ViewRelated/People/Controllers/InvitePersonViewController.swift
@@ -427,7 +427,7 @@ extension InvitePersonViewController {
             SVProgressHUD.showDismissibleSuccess(status: success)
 
             WPAnalytics.track(.peopleUserInvited, properties: ["role": role], blog: blog)
-        }, failure: { error in
+        }, failure: { _ in
             self.handleSendError() {
                 self.sendInvitation(blog, recipient: recipient, role: role, message: message)
             }
@@ -442,7 +442,7 @@ extension InvitePersonViewController {
         let alertController = UIAlertController(title: nil, message: message, preferredStyle: .alert)
 
         alertController.addCancelActionWithTitle(cancelText)
-        alertController.addDefaultActionWithTitle(retryText) { action in
+        alertController.addDefaultActionWithTitle(retryText) { _ in
             onRetry()
         }
 

--- a/WordPress/Classes/ViewRelated/People/Controllers/PersonViewController.swift
+++ b/WordPress/Classes/ViewRelated/People/Controllers/PersonViewController.swift
@@ -217,7 +217,7 @@ private extension PersonViewController {
 
         alert.addCancelActionWithTitle(cancelTitle)
 
-        alert.addDestructiveActionWithTitle(removeTitle) { [weak self] action in
+        alert.addDestructiveActionWithTitle(removeTitle) { [weak self] _ in
             guard let strongSelf = self else {
                 return
             }
@@ -344,7 +344,7 @@ private extension PersonViewController {
         let alertController = UIAlertController(title: title, message: messageText, preferredStyle: .alert)
 
         alertController.addCancelActionWithTitle(cancelTitle, handler: nil)
-        alertController.addDefaultActionWithTitle(retryTitle) { action in
+        alertController.addDefaultActionWithTitle(retryTitle) { _ in
             self.updateUserRole(newRole)
         }
 

--- a/WordPress/Classes/ViewRelated/Plugins/ViewModels/PluginDirectoryViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Plugins/ViewModels/PluginDirectoryViewModel.swift
@@ -36,7 +36,7 @@ class PluginDirectoryViewModel: Observable {
         popularReceipt = store.query(.feed(type: .popular))
         newReceipt = store.query(.feed(type: .newest))
 
-        actionReceipt = ActionDispatcher.global.subscribe { [changeDispatcher, throttle] action in
+        actionReceipt = ActionDispatcher.global.subscribe { [changeDispatcher, throttle] _ in
             // Fairly often, a bunch of those network calls can finish very close to each other — within few hundred
             // milliseconds or so. Doing a reload in this case is both wasteful and noticably slow.
             // Instead, we throttle the call so we trigger the reload at most once a second.

--- a/WordPress/Classes/ViewRelated/Plugins/ViewModels/PluginViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Plugins/ViewModels/PluginViewModel.swift
@@ -494,7 +494,7 @@ class PluginViewModel: Observable {
             WPAnalytics.track(.automatedTransferCustomDomainDialogCancelled)
         }
 
-        let registerDomainAction = alertController.addDefaultActionWithTitle(registerDomainActionTitle) { [weak self] (action) in
+        let registerDomainAction = alertController.addDefaultActionWithTitle(registerDomainActionTitle) { [weak self] (_) in
             self?.presentDomainRegistration(for: directoryEntry)
         }
 
@@ -540,7 +540,7 @@ class PluginViewModel: Observable {
             return
         }
 
-        let coordinator = RegisterDomainCoordinator(site: blog, domainPurchasedCallback: { [weak self] _, domain in
+        let coordinator = RegisterDomainCoordinator(site: blog, domainPurchasedCallback: { [weak self] _, _ in
 
             guard let strongSelf = self,
                 let atHelper = AutomatedTransferHelper(site: strongSelf.site, plugin: directoryEntry) else {

--- a/WordPress/Classes/ViewRelated/Post/Categories/PostCategoriesViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Categories/PostCategoriesViewController.swift
@@ -114,7 +114,7 @@ import WordPressUI
             self?.reloadCategories()
             self?.refreshControl?.endRefreshing()
             self?.hasSyncedCategories = true
-        }) { [weak self] error in
+        }) { [weak self] _ in
             self?.refreshControl?.endRefreshing()
         }
     }

--- a/WordPress/Classes/ViewRelated/Post/EditPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/EditPostViewController.swift
@@ -148,7 +148,7 @@ class EditPostViewController: UIViewController {
             localizedFeatureName: feature,
             source: "block_editor",
             presentingViewController: self
-        ) { [weak self] client in
+        ) { [weak self] _ in
             // Once authenticated, dismiss the application password view and show editor
             guard let self else { return EmptyView() }
 

--- a/WordPress/Classes/ViewRelated/Post/PostSharingController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSharingController.swift
@@ -16,7 +16,7 @@ import WordPressData
         if let title {
             controller.setValue(title, forKey: "subject")
         }
-        controller.completionWithItemsHandler = { (activityType, completed, returnedItems, error) in
+        controller.completionWithItemsHandler = { (activityType, completed, _, _) in
             if completed {
                 WPActivityDefaults.trackActivityType((activityType).map { $0.rawValue })
             }

--- a/WordPress/Classes/ViewRelated/Post/Publishing/PublishPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Publishing/PublishPostViewController.swift
@@ -52,7 +52,7 @@ final class PublishPostViewController<ViewModel: PostSettingsViewModelProtocol>:
         // - warning: Has to be UIKit because some of the  `PostSettingsView` rows rely on it.
         let navigationVC = UINavigationController(rootViewController: publishVC)
         navigationVC.sheetPresentationController?.detents = [
-            .custom(identifier: .medium, resolver: { context in 526 }),
+            .custom(identifier: .medium, resolver: { _ in 526 }),
             .large()
         ]
         presentingViewController.present(navigationVC, animated: true)

--- a/WordPress/Classes/ViewRelated/Post/Search/PostSearchViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Search/PostSearchViewController.swift
@@ -10,7 +10,7 @@ final class PostSearchViewController: UIViewController, UITableViewDelegate, UIS
 
     private let tableView = UITableView(frame: .zero, style: .plain)
 
-    private lazy var dataSource = UITableViewDiffableDataSource<SectionID, ItemID> (tableView: tableView) { [weak self] tableView, indexPath, itemIdentifier in
+    private lazy var dataSource = UITableViewDiffableDataSource<SectionID, ItemID> (tableView: tableView) { [weak self] tableView, indexPath, _ in
         self?.tableView(tableView, cellForRowAt: indexPath)
     }
 

--- a/WordPress/Classes/ViewRelated/QR Login/Coordinators/QRLoginVerifyCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/QR Login/Coordinators/QRLoginVerifyCoordinator.swift
@@ -90,11 +90,11 @@ extension QRLoginVerifyCoordinator {
         view.showAuthenticating()
         state = .authenticating
 
-        service.authenticate(token: token) { success in
+        service.authenticate(token: token) { _ in
             self.parentCoordinator.track(.qrLoginAuthenticated)
             self.state = .done
             self.view.renderCompletion()
-        } failure: { error in
+        } failure: { _ in
             self.state = .error
 
             guard self.connectionChecker.connectionAvailable else {

--- a/WordPress/Classes/ViewRelated/QR Login/Helpers/QRLoginCameraPermissionsHandler.swift
+++ b/WordPress/Classes/ViewRelated/QR Login/Helpers/QRLoginCameraPermissionsHandler.swift
@@ -17,7 +17,7 @@ struct QRLoginCameraPermissionsHandler: QRCameraPermissionsHandler {
                                       preferredStyle: .alert)
 
         alert.addActionWithTitle(Strings.dismiss, style: .cancel)
-        alert.addDefaultActionWithTitle(Strings.openSettings) { action in
+        alert.addDefaultActionWithTitle(Strings.openSettings) { _ in
             UIApplication.shared.openSettings()
         }
 

--- a/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsFollowPresenter.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsFollowPresenter.swift
@@ -139,7 +139,7 @@ private extension ReaderCommentsFollowPresenter {
                 title: Messages.promptTitle,
                 message: Messages.promptMessage,
                 actionTitle: Messages.undoActionTitle,
-                actionHandler: { (accepted: Bool) in
+                actionHandler: { (_: Bool) in
                 self.handleNotificationsButtonTapped(canUndo: false)
             })
         }, failure: { [weak self] error in

--- a/WordPress/Classes/ViewRelated/Reader/Controllers/ReaderPostActions/ReaderSubscribeCommentsAction.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Controllers/ReaderPostActions/ReaderSubscribeCommentsAction.swift
@@ -15,7 +15,7 @@ final class ReaderSubscribeCommentsAction {
 
         followCommentsService.toggleSubscribed(post.isSubscribedComments, success: { subscribeSuccess in
             followCommentsService.toggleNotificationSettings(subscribing, success: {
-                ReaderHelpers.dispatchToggleSubscribeCommentMessage(subscribing: subscribing, success: subscribeSuccess) { actionSuccess in
+                ReaderHelpers.dispatchToggleSubscribeCommentMessage(subscribing: subscribing, success: subscribeSuccess) { _ in
                     self.disableNotificationSettings(followCommentsService: followCommentsService)
                     Self.trackNotificationUndo(post: post, sourceViewController: sourceViewController)
                 }

--- a/WordPress/Classes/ViewRelated/Reader/Controllers/ReaderStreamViewController+Sharing.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Controllers/ReaderStreamViewController+Sharing.swift
@@ -49,7 +49,7 @@ extension ReaderStreamViewController {
 
         let activities = WPActivityDefaults.defaultActivities() as! [UIActivity]
         let activityViewController = UIActivityViewController(activityItems: [sitePendingPost], applicationActivities: activities)
-        activityViewController.completionWithItemsHandler = { (activityType, completed, returnedItems, error) in
+        activityViewController.completionWithItemsHandler = { (activityType, completed, _, _) in
             if completed {
                 WPActivityDefaults.trackActivityType((activityType).map { $0.rawValue })
             }

--- a/WordPress/Classes/ViewRelated/Reader/Controllers/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Controllers/ReaderStreamViewController.swift
@@ -415,7 +415,7 @@ import AutomatticTracks
         let service = ReaderTopicService(coreDataStack: ContextManager.shared)
         service.siteTopicForSite(withID: siteID,
             isFeed: isFeed,
-            success: { [weak self] (objectID: NSManagedObjectID?, isFollowing: Bool) in
+            success: { [weak self] (objectID: NSManagedObjectID?, _: Bool) in
 
                 let context = ContextManager.shared.mainContext
                 guard let objectID,
@@ -430,7 +430,7 @@ import AutomatticTracks
                 self?.readerTopic = topic
 
             },
-            failure: { [weak self] (error: Error?) in
+            failure: { [weak self] (_: Error?) in
                 if self?.isLoadingDiscover ?? false {
                     self?.updateContent(synchronize: false)
                 }
@@ -936,7 +936,7 @@ import AutomatticTracks
 
         let objectID = topic.objectID
 
-        let successBlock = { [weak self] (count: Int, hasMore: Bool) in
+        let successBlock = { [weak self] (_: Int, hasMore: Bool) in
             DispatchQueue.main.async {
                 if let strongSelf = self {
                     // swiftlint:disable:next empty_count
@@ -1007,7 +1007,7 @@ import AutomatticTracks
                 return
             }
 
-            let successBlock = { [weak self] (count: Int, hasMore: Bool) in
+            let successBlock = { [weak self] (_: Int, hasMore: Bool) in
                 DispatchQueue.main.async {
                     if let strongSelf = self {
                         // swiftlint:disable:next empty_count
@@ -1049,7 +1049,7 @@ import AutomatticTracks
 
         footerView.isHidden = false
 
-        let successBlock = { (count: Int, hasMore: Bool) in
+        let successBlock = { (_: Int, hasMore: Bool) in
             DispatchQueue.main.async(execute: {
                 success?(hasMore)
             })
@@ -1184,7 +1184,7 @@ import AutomatticTracks
         let service = ReaderTopicService(coreDataStack: ContextManager.shared)
         service.toggleFollowing(forTag: topic, success: {
             completion?(true)
-        }, failure: { (error: Error?) in
+        }, failure: { (_: Error?) in
             generator.notificationOccurred(.error)
             completion?(false)
         })
@@ -1497,7 +1497,7 @@ extension ReaderStreamViewController: WPTableViewHandlerDelegate {
         }
 
         if traitCollection.horizontalSizeClass == .regular, #available(iOS 18, *) {
-            controller.preferredTransition = .zoom { [weak self] context in
+            controller.preferredTransition = .zoom { [weak self] _ in
                 guard let self, let cell = self.tableView.cellForRow(at: indexPath) else {
                     return nil
                 }

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailCoordinator.swift
@@ -171,7 +171,7 @@ class ReaderDetailCoordinator {
 
         // Fetch a full page of Likes but only return the `maxAvatarsDisplayed` number.
         // That way the first page will already be cached if the user displays the full Likes list.
-        postService.getLikesFor(postID: postID, siteID: siteID, success: { [weak self] users, totalLikes, _ in
+        postService.getLikesFor(postID: postID, siteID: siteID, success: { [weak self] users, _, _ in
             guard let self else { return }
 
             var filteredUsers = users

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -599,7 +599,7 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
             /// (except for a few times when it returns a very big weird number)
             /// We use that value so the content is not displayed with weird empty space at the bottom
             ///
-            self.webView.evaluateJavaScript("document.body.scrollHeight", completionHandler: { [weak self] (webViewHeight, error) in
+            self.webView.evaluateJavaScript("document.body.scrollHeight", completionHandler: { [weak self] (webViewHeight, _) in
                 guard let self else { return }
                 guard let webViewHeight = webViewHeight as? CGFloat else {
                     self.webViewHeight.constant = height

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailToolbar.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailToolbar.swift
@@ -363,7 +363,7 @@ private extension ReaderDetailToolbar {
 
 private extension ReaderDetailToolbar {
     func subscribePostChanges() {
-        likeCountObserver = post?.observe(\.likeCount, options: [.old, .new]) { [weak self] updatedPost, change in
+        likeCountObserver = post?.observe(\.likeCount, options: [.old, .new]) { [weak self] _, change in
             // ensure that we only update the like button when there's actual change.
             let oldValue = change.oldValue??.intValue ?? 0
             let newValue = change.newValue??.intValue ?? 0

--- a/WordPress/Classes/ViewRelated/Reader/Subscriptions/ReaderSubscriptionHelper.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Subscriptions/ReaderSubscriptionHelper.swift
@@ -53,7 +53,7 @@ struct ReaderSubscriptionHelper {
         service.toggleFollowing(forSite: topic, success: { follow in
             ReaderHelpers.dispatchToggleFollowSiteMessage(site: topic, follow: follow, success: true)
             completion?(true)
-        }, failure: { (follow, error) in
+        }, failure: { (follow, _) in
             ReaderHelpers.dispatchToggleFollowSiteMessage(site: topic, follow: follow, success: false)
             completion?(false)
         })

--- a/WordPress/Classes/ViewRelated/Stats/Insights/Insights Management/InsightsManagementViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/Insights Management/InsightsManagementViewController.swift
@@ -245,7 +245,7 @@ private extension InsightsManagementViewController {
     }
 
     func rowActionFor(_ statSection: StatSection) -> ImmuTableAction {
-        return { [unowned self] row in
+        return { [unowned self] _ in
             toggleRow(for: statSection)
         }
     }

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsInsightsDetailsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsInsightsDetailsViewModel.swift
@@ -268,7 +268,7 @@ class SiteStatsInsightsDetailsViewModel: Observable {
 
         switch statSection {
         case .insightsViewsVisitors:
-            return periodImmuTable(for: revampStore.viewsAndVisitorsStatus) { status in
+            return periodImmuTable(for: revampStore.viewsAndVisitorsStatus) { _ in
                 var rows = [any HashableImmutableRow]()
 
                 let viewsAndVisitorsData = revampStore.getViewsAndVisitorsData()
@@ -380,7 +380,7 @@ class SiteStatsInsightsDetailsViewModel: Observable {
                 return rows
             }
         case .insightsLikesTotals:
-            return periodImmuTable(for: revampStore.likesTotalsStatus) { status in
+            return periodImmuTable(for: revampStore.likesTotalsStatus) { _ in
                 var rows = [any HashableImmutableRow]()
 
                 let likesTotalsData = revampStore.getLikesTotalsData()

--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboardViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboardViewController.swift
@@ -208,7 +208,7 @@ public class SiteStatsDashboardViewController: UIViewController {
             statsMenuButton.menu = createStatsMenu()
 
             // Set up observer for navigation item changes
-            navigationItemObserver = trafficTableViewController.navigationItem.observe(\.trailingItemGroups, options: [.initial, .new]) { [weak self] navigationItem, _ in
+            navigationItemObserver = trafficTableViewController.navigationItem.observe(\.trailingItemGroups, options: [.initial, .new]) { [weak self] _, _ in
                 guard let self else { return }
                 DispatchQueue.main.async {
                     self.updateParentNavigationItems(with: self.trafficTableViewController)

--- a/WordPress/Classes/ViewRelated/Stats/Subscribers/StatsSubscribersStore.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Subscribers/StatsSubscribersStore.swift
@@ -72,7 +72,7 @@ struct StatsSubscribersStore: StatsSubscribersStoreProtocol {
             chartSummary.send(.loading)
         }
 
-        statsService.getData(for: unit, endingOn: StatsDataHelper.currentDateForSite(), limit: 30) { (data: StatsSubscribersSummaryData?, error: Error?) in
+        statsService.getData(for: unit, endingOn: StatsDataHelper.currentDateForSite(), limit: 30) { (data: StatsSubscribersSummaryData?, _: Error?) in
             DispatchQueue.main.async {
                 if let data {
                     cache.setValue(data, key: cacheKey)

--- a/WordPress/Classes/ViewRelated/Support/SupportChatBot/SupportChatBotViewController.swift
+++ b/WordPress/Classes/ViewRelated/Support/SupportChatBot/SupportChatBotViewController.swift
@@ -136,7 +136,7 @@ private extension SupportChatBotViewController {
 
 extension SupportChatBotViewController: WKNavigationDelegate {
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
-        webView.evaluateJavaScript(createDocsBotInitCode(), completionHandler: { (result, error) in
+        webView.evaluateJavaScript(createDocsBotInitCode(), completionHandler: { (_, error) in
             if let error {
                 DDLogError("Failed to initialize docs bot code: \(error)")
             }

--- a/WordPress/Classes/ViewRelated/Support/SupportTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Support/SupportTableViewController.swift
@@ -289,7 +289,7 @@ private extension SupportTableViewController {
     }
 
     func contactUsSelected() -> ImmuTableAction {
-        return { [weak self] row in
+        return { [weak self] _ in
             guard let self else { return }
             self.tableView.deselectSelectedRowWithAnimation(true)
 
@@ -300,7 +300,7 @@ private extension SupportTableViewController {
     }
 
     func myTicketsSelected() -> ImmuTableAction {
-        return { [weak self] row in
+        return { [weak self] _ in
             guard let self else { return }
             showTicketView()
         }
@@ -316,7 +316,7 @@ private extension SupportTableViewController {
     }
 
     func supportEmailSelected() -> ImmuTableAction {
-        return { [unowned self] row in
+        return { [unowned self] _ in
 
             self.tableView.deselectSelectedRowWithAnimation(true)
 
@@ -339,7 +339,7 @@ private extension SupportTableViewController {
     }
 
     func visitForumsSelected() -> ImmuTableAction {
-        return { [weak self] row in
+        return { [weak self] _ in
             guard let self else { return }
             self.tableView.deselectSelectedRowWithAnimation(true)
             self.launchForum(url: Constants.forumsURL)
@@ -414,7 +414,7 @@ private extension SupportTableViewController {
     }
 
     func activityLogsSelected() -> ImmuTableAction {
-        return { [unowned self] row in
+        return { [unowned self] _ in
             let activityLogView = SupportActivityLogView()
             let hostingController = UIHostingController(rootView: activityLogView)
             self.navigationController?.pushViewController(hostingController, animated: true)
@@ -422,7 +422,7 @@ private extension SupportTableViewController {
     }
 
     private func logOutTapped() -> ImmuTableAction {
-        return { [weak self] row in
+        return { [weak self] _ in
             guard let self else {
                 return
             }

--- a/WordPress/Classes/ViewRelated/System/Floating Create Button/CreateButtonCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Floating Create Button/CreateButtonCoordinator.swift
@@ -135,7 +135,7 @@ final class CreateButtonCoordinator: NSObject {
         // Pre-compute `preferredContentSize`
         viewController.view.layoutIfNeeded()
 
-        viewController.popoverPresentationController?.adaptiveSheetPresentationController.detents = [.custom { [weak viewController] context in
+        viewController.popoverPresentationController?.adaptiveSheetPresentationController.detents = [.custom { [weak viewController] _ in
             viewController?.preferredContentSize.height ?? 320
         }]
 
@@ -277,7 +277,7 @@ private extension UIButton {
         let scaleFinal = Constants.Minimize.finalScale
         let duration = Constants.Minimize.duration
 
-        scaleAnimation(duration: duration, damping: damping, scaleInitial: scaleInitial, scaleFinal: scaleFinal) { [weak self] success in
+        scaleAnimation(duration: duration, damping: damping, scaleInitial: scaleInitial, scaleFinal: scaleFinal) { [weak self] _ in
             self?.transform = .identity
             self?.isHidden = true
         }
@@ -301,7 +301,7 @@ private extension UIButton {
         let animator = UIViewPropertyAnimator(duration: duration, dampingRatio: damping) {
             self.transform = CGAffineTransform(scaleX: scaleFinal, y: scaleFinal)
         }
-        animator.addCompletion { (position) in
+        animator.addCompletion { (_) in
             completion?(true)
         }
         animator.startAnimation()

--- a/WordPress/Classes/ViewRelated/System/Notices/NoticePresenter.swift
+++ b/WordPress/Classes/ViewRelated/System/Notices/NoticePresenter.swift
@@ -201,7 +201,7 @@ class NoticePresenter {
                                             content: content,
                                             trigger: nil)
 
-        UNUserNotificationCenter.current().add(request, withCompletionHandler: { error in
+        UNUserNotificationCenter.current().add(request, withCompletionHandler: { _ in
             DispatchQueue.main.async {
                 ActionDispatcher.dispatch(NoticeAction.clear(notice))
             }

--- a/WordPress/Classes/ViewRelated/Themes/ThemeBrowserCell.swift
+++ b/WordPress/Classes/ViewRelated/Themes/ThemeBrowserCell.swift
@@ -249,7 +249,7 @@ open class ThemeBrowserCell: UICollectionViewCell {
         themeActions.forEach { themeAction in
             alertController.addActionWithTitle(themeAction.title,
                                                style: .default,
-                                               handler: { (action: UIAlertAction) in
+                                               handler: { (_: UIAlertAction) in
                                                 themeAction.present(theme, presenter)
             })
         }

--- a/WordPress/Classes/ViewRelated/Themes/ThemeBrowserViewController.swift
+++ b/WordPress/Classes/ViewRelated/Themes/ThemeBrowserViewController.swift
@@ -460,7 +460,7 @@ public protocol ThemePresenter: AnyObject {
             page: themesSyncingPage,
             search: search,
             sync: page == 1,
-            success: {[weak self](themes: [Theme]?, hasMore: Bool, themeCount: NSInteger) in
+            success: {[weak self](_: [Theme]?, hasMore: Bool, themeCount: NSInteger) in
                 if let success {
                     success(hasMore)
                 }
@@ -478,7 +478,7 @@ public protocol ThemePresenter: AnyObject {
     fileprivate func syncCustomThemes(success: ((_ hasMore: Bool) -> Void)?, failure: ((_ error: NSError) -> Void)?) {
         _ = themeService.getCustomThemes(for: blog,
             sync: true,
-            success: {[weak self](themes: [Theme]?, hasMore: Bool, themeCount: NSInteger) in
+            success: {[weak self](_: [Theme]?, hasMore: Bool, themeCount: NSInteger) in
                 if let success {
                     success(hasMore)
                 }
@@ -861,7 +861,7 @@ public protocol ThemePresenter: AnyObject {
                     preferredStyle: .alert)
                 alertController.addActionWithTitle(manageTitle,
                     style: .default,
-                    handler: { [weak self] (action: UIAlertAction) in
+                    handler: { [weak self] (_: UIAlertAction) in
                         _ = self?.navigationController?.popViewController(animated: true)
                     })
             alertController.addDefaultActionWithTitle(SharedStrings.Button.ok, handler: nil)

--- a/WordPress/Classes/ViewRelated/Views/RichTextView/NSAttributedString+RichTextView.swift
+++ b/WordPress/Classes/ViewRelated/Views/RichTextView/NSAttributedString+RichTextView.swift
@@ -6,7 +6,7 @@ extension NSAttributedString {
         let range = NSMakeRange(0, length)
 
         enumerateAttribute(.attachment, in: range, options: .longestEffectiveRangeNotRequired) {
-            (value: Any?, range: NSRange, stop: UnsafeMutablePointer<ObjCBool>) -> Void in
+            (value: Any?, range: NSRange, _: UnsafeMutablePointer<ObjCBool>) -> Void in
 
             if let attachment = value as? NSTextAttachment {
                 block(attachment, range)

--- a/WordPress/WordPressNotificationServiceExtension/Sources/NotificationService.swift
+++ b/WordPress/WordPressNotificationServiceExtension/Sources/NotificationService.swift
@@ -232,7 +232,7 @@ private extension NotificationService {
         }
 
         let session = URLSession(configuration: .default)
-        let task = session.dataTask(with: request) { data, response, error in
+        let task = session.dataTask(with: request) { data, response, _ in
             guard let data, let mimeType = response?.mimeType else {
                 completion(nil, nil)
                 return

--- a/WordPress/WordPressScreenshotGeneration/SnapshotHelper.swift
+++ b/WordPress/WordPressScreenshotGeneration/SnapshotHelper.swift
@@ -203,7 +203,7 @@ open class Snapshot: NSObject {
                 let format = UIGraphicsImageRendererFormat()
                 format.scale = image.scale
                 let renderer = UIGraphicsImageRenderer(size: image.size, format: format)
-                return renderer.image { context in
+                return renderer.image { _ in
                     image.draw(in: CGRect(x: 0, y: 0, width: image.size.width, height: image.size.height))
                 }
             } else {

--- a/WordPress/WordPressShareExtension/Sources/Services/AppExtensionsService.swift
+++ b/WordPress/WordPressShareExtension/Sources/Services/AppExtensionsService.swift
@@ -492,7 +492,7 @@ fileprivate extension AppExtensionsService {
         media.forEach { mediaItem in
             syncGroup.enter()
             mediaItem.postID = NSNumber(value: postID)
-            service.update(mediaItem, success: { updatedRemoteMedia in
+            service.update(mediaItem, success: { _ in
                 syncGroup.leave()
             }, failure: { error in
                 var errorString = "Error assigning media items to post in share extension"

--- a/WordPress/WordPressShareExtension/Sources/Services/ShareExtractor.swift
+++ b/WordPress/WordPressShareExtension/Sources/Services/ShareExtractor.swift
@@ -263,7 +263,7 @@ private extension TypeBasedExtensionContentExtractor {
         for provider in itemProviders {
             syncGroup.enter()
             // Remember, this is an async call....
-            provider.loadItem(forTypeIdentifier: acceptedType, options: nil) { (payload, error) in
+            provider.loadItem(forTypeIdentifier: acceptedType, options: nil) { (payload, _) in
                 let payload = payload as? Payload
                 let result = payload.flatMap(self.convert(payload:))
                 if let result {
@@ -403,7 +403,7 @@ private struct URLExtractor: TypeBasedExtensionContentExtractor {
         var returnedItem = ExtractedItem()
 
         var cachedImages = [String: ExtractedImage]()
-        bundleWrapper.assetsFileWrapper.fileWrappers?.forEach { (key: String, fileWrapper: FileWrapper) in
+        bundleWrapper.assetsFileWrapper.fileWrappers?.forEach { (_: String, fileWrapper: FileWrapper) in
             guard let fileName = fileWrapper.filename else {
                 return
             }

--- a/WordPress/WordPressShareExtension/Sources/UI/ShareExtensionAbstractViewController.swift
+++ b/WordPress/WordPressShareExtension/Sources/UI/ShareExtensionAbstractViewController.swift
@@ -138,7 +138,7 @@ extension ShareExtensionAbstractViewController {
         let accept = AppLocalizedString("Cancel sharing", comment: "Share extension dialog dismiss button label - displayed when user is missing a login token.")
 
         let alertController = UIAlertController(title: title, message: message, preferredStyle: .alert)
-        let alertAction = UIAlertAction(title: accept, style: .default) { (action) in
+        let alertAction = UIAlertAction(title: accept, style: .default) { (_) in
             self.cleanUpSharedContainerAndCache()
             self.dismissalCompletionBlock?(false)
         }

--- a/WordPress/WordPressShareExtension/Sources/UI/ShareExtensionEditorViewController.swift
+++ b/WordPress/WordPressShareExtension/Sources/UI/ShareExtensionEditorViewController.swift
@@ -735,7 +735,7 @@ extension ShareExtensionEditorViewController {
         })
 
         // Action: Insert
-        let insertAction = alertController.addDefaultActionWithTitle(insertButtonTitle) { [weak self] action in
+        let insertAction = alertController.addDefaultActionWithTitle(insertButtonTitle) { [weak self] _ in
             self?.richTextView.becomeFirstResponder()
             let linkURLString = alertController.textFields?.first?.text
             var linkTitle = alertController.textFields?.last?.text
@@ -756,7 +756,7 @@ extension ShareExtensionEditorViewController {
 
         // Action: Remove
         if !isInsertingNewLink {
-            alertController.addDestructiveActionWithTitle(removeTitle) { [weak self] action in
+            alertController.addDestructiveActionWithTitle(removeTitle) { [weak self] _ in
                 self?.richTextView.becomeFirstResponder()
                 self?.richTextView.removeLink(inRange: range)
             }
@@ -961,7 +961,7 @@ extension ShareExtensionEditorViewController {
                 comment: "User action to dismiss media options."
             ),
             style: .cancel,
-            handler: { (action) in
+            handler: { (_) in
                 if attachment == self.currentSelectedAttachment {
                     self.currentSelectedAttachment = nil
                     self.resetMediaAttachmentOverlay(attachment)
@@ -977,7 +977,7 @@ extension ShareExtensionEditorViewController {
                     comment: "User action to remove media."
                 ),
                 style: .destructive,
-                handler: { (action) in
+                handler: { (_) in
                     self.richTextView.remove(attachmentID: mediaID)
                 }
             )

--- a/WordPress/WordPressShareExtension/Sources/UI/ShareModularViewController.swift
+++ b/WordPress/WordPressShareExtension/Sources/UI/ShareModularViewController.swift
@@ -891,13 +891,13 @@ fileprivate extension ShareModularViewController {
             value: "Try again",
             comment: "Share extension error dialog retry button label."
         )
-        let acceptAction = UIAlertAction(title: acceptButtonText, style: .default) { (action) in
+        let acceptAction = UIAlertAction(title: acceptButtonText, style: .default) { (_) in
             self.savePostToRemoteSite()
         }
         alertController.addAction(acceptAction)
 
         let dismissButtonText = dismiss
-        let dismissAction = UIAlertAction(title: dismissButtonText, style: .cancel) { (action) in
+        let dismissAction = UIAlertAction(title: dismissButtonText, style: .cancel) { (_) in
             self.showCancellingView()
             self.cleanUpSharedContainerAndCache()
             self.dismiss()
@@ -914,7 +914,7 @@ fileprivate extension ShareModularViewController {
 
         let alertController = UIAlertController(title: title, message: message, preferredStyle: .alert)
 
-        let dismissAction = UIAlertAction(title: dismiss, style: .cancel) { [weak self] (action) in
+        let dismissAction = UIAlertAction(title: dismiss, style: .cancel) { [weak self] (_) in
             self?.noResultsViewController.removeFromView()
         }
         alertController.addAction(dismissAction)


### PR DESCRIPTION
## What

Enables the SwiftLint [`unused_closure_parameter`](https://realm.github.io/SwiftLint/unused_closure_parameter.html) rule, which flags closure parameters that are never referenced and recommends replacing them with `_`.

## Stats

- Auto-fixed violations: **340** across **167** files
- Manual fixes: **0**
- `swiftlint:disable` additions: **0**

The rule is autocorrectable and the substitution (`name` → `_`) is type-preserving, so no manual intervention or build breakage was expected or observed.

## Testing

- `bundle exec rake lint` is clean on the modified config.
- Build/test deferred to CI per campaign convention for type-preserving rules.

Part of the Orchard SwiftLint rollout campaign.
