### PR TITLE
Enable SwiftLint rule: contains_over_first_not_nil

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -19,6 +19,9 @@ only_rules:
   # Prefer `contains` over using `filter(where:).isEmpty`.
   - contains_over_filter_is_empty
 
+  # Prefer `contains` over `first(where:) != nil`.
+  - contains_over_first_not_nil
+
   # if,for,while,do statements shouldn't wrap their conditionals in parentheses.
   - control_statement
 

--- a/Sources/WordPressData/Swift/AbstractPost.swift
+++ b/Sources/WordPressData/Swift/AbstractPost.swift
@@ -202,7 +202,7 @@ public extension AbstractPost {
     /// Returns true if the post has any media that needs manual intervention to be uploaded
     ///
     func hasPermanentFailedMedia() -> Bool {
-        return media.first(where: { !$0.willAttemptToUploadLater() }) != nil
+        return media.contains(where: { !$0.willAttemptToUploadLater() })
     }
 
     /// Returns all revisions of the post including the original one.

--- a/WordPress/Classes/Extensions/NSFetchedResultsController+Helpers.swift
+++ b/WordPress/Classes/Extensions/NSFetchedResultsController+Helpers.swift
@@ -40,6 +40,6 @@ extension NSFetchedResultsController {
     @objc public func isEmpty() -> Bool {
         // We can not return fetchedObjects.count == 0 because of a Swift compiler error:
         // Extension of a generic Objective-C class cannot access the class's generic parameters at runtime
-        return sections?.first(where: { $0.numberOfObjects > 0 }) == nil
+        return sections?.contains(where: { $0.numberOfObjects > 0 }) != true
     }
 }

--- a/WordPress/Classes/Stores/StatsInsightsStore.swift
+++ b/WordPress/Classes/Stores/StatsInsightsStore.swift
@@ -936,7 +936,7 @@ extension StatsInsightsStore {
          * with value .loading. If at least one exists then the store is still fetching the overview.
          */
         let mirror = Mirror(reflecting: state)
-        return mirror.children.compactMap { $0.value as? StoreFetchingStatus }.first { $0 == .loading } != nil
+        return mirror.children.compactMap { $0.value as? StoreFetchingStatus }.contains { $0 == .loading }
     }
 
     var isFetchingAllFollowers: Bool {
@@ -996,7 +996,7 @@ extension StatsInsightsStore {
          * If the result is nil the store failed loading the overview.
          */
         let mirror = Mirror(reflecting: state)
-        return mirror.children.compactMap { $0.value as? StoreFetchingStatus }.first { $0 != .error } == nil
+        return !mirror.children.compactMap { $0.value as? StoreFetchingStatus }.contains { $0 != .error }
     }
 
     func fetchingFailed(for query: InsightQuery) -> Bool {

--- a/WordPress/Classes/Stores/StatsPeriodStore.swift
+++ b/WordPress/Classes/Stores/StatsPeriodStore.swift
@@ -1050,7 +1050,7 @@ private extension StatsPeriodStore {
                 state.topSearchTermsStatus,
                 state.topCountriesStatus,
                 state.topVideosStatus,
-                state.topFileDownloadsStatus].first { $0 == .loading } == nil
+                state.topFileDownloadsStatus].allSatisfy { $0 != .loading }
     }
 
     private func setAllFetchingStatus(_ status: StoreFetchingStatus) {
@@ -1263,7 +1263,7 @@ extension StatsPeriodStore {
                 state.topSearchTermsStatus,
                 state.topCountriesStatus,
                 state.topVideosStatus,
-                state.topFileDownloadsStatus].first { $0 != .error } == nil
+                state.topFileDownloadsStatus].allSatisfy { $0 == .error }
     }
 
     func fetchingFailed(for query: PeriodQuery) -> Bool {

--- a/WordPress/Classes/Stores/StatsRevampStore.swift
+++ b/WordPress/Classes/Stores/StatsRevampStore.swift
@@ -105,11 +105,11 @@ extension StatsRevampStore {
 
 private extension StatsRevampStore {
     func aggregateStatus(for statuses: [StoreFetchingStatus], data: Any?) -> StoreFetchingStatus {
-        if statuses.first(where: { $0 == .loading }) != nil {
+        if statuses.contains(where: { $0 == .loading }) {
             return .loading
-        } else if statuses.first(where: { $0 == .success }) != nil || data != nil {
+        } else if statuses.contains(where: { $0 == .success }) || data != nil {
             return .success
-        } else if statuses.first(where: { $0 == .error }) != nil {
+        } else if statuses.contains(where: { $0 == .error }) {
             return .error
         } else {
             return .idle

--- a/WordPress/Classes/Stores/StatsStore+Cache.swift
+++ b/WordPress/Classes/Stores/StatsStore+Cache.swift
@@ -10,7 +10,7 @@ protocol StatsStoreCacheable {
 
 extension StatsStoreCacheable {
     func containsCachedData(for types: [StatsStoreType]) -> Bool {
-        return types.first { containsCachedData(for: $0) } != nil
+        return types.contains { containsCachedData(for: $0) }
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController/NotificationsViewController.swift
@@ -489,7 +489,7 @@ private extension NotificationsViewController {
             guard let notes = tableViewHandler?.resultsController?.fetchedObjects as? [WordPressData.Notification] else {
                 return nil
             }
-            let isEnabled = notes.first { !$0.read } != nil
+            let isEnabled = notes.contains { !$0.read }
             let attributes = isEnabled ? UIAction.Attributes(rawValue: 0) : .disabled
             return UIAction(
                 title: Strings.NavigationBar.markAllAsReadActionTitle,

--- a/WordPress/Classes/ViewRelated/Stats/Insights/TabbedTotalsCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/TabbedTotalsCell.swift
@@ -118,7 +118,7 @@ private extension TabbedTotalsCell {
 
     func toggleFilterTabBar() {
         // If none of the tabs have data, hide the FilterTabBar.
-        let noTabsData = (tabsData.first { !$0.dataRows.isEmpty }) == nil
+        let noTabsData = !tabsData.contains { !$0.dataRows.isEmpty }
         filterTabBar.isHidden = noTabsData
     }
 

--- a/WordPress/Classes/ViewRelated/Support/SupportTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Support/SupportTableViewController.swift
@@ -359,7 +359,7 @@ private extension SupportTableViewController {
     ///
     func checkForAutomatticEmail() {
         guard let email = ZendeskUtils.userSupportEmail(),
-              (ZendeskUtils.automatticEmails.first { email.contains($0) }) != nil else {
+              ZendeskUtils.automatticEmails.contains(where: { email.contains($0) }) else {
                 return
         }
 


### PR DESCRIPTION
## Summary

Enables SwiftLint's [`contains_over_first_not_nil`](https://realm.github.io/SwiftLint/contains_over_first_not_nil.html) rule and rewrites the 13 existing violations.

The rule prefers `xs.contains { ... }` over `xs.first(where: { ... }) != nil` (and the `firstIndex` variant), which is a performance and clarity win.

- **13 violations fixed** across 9 files.
- 0 suppressions.
- Some inverted forms (`first { } == nil`) were rewritten with `!contains` / `allSatisfy` depending on what reads cleanest.
- The rewrite is type-preserving (Bool→Bool) — local build deferred to CI.

Part of the [Orchard SwiftLint rollout campaign](https://github.com/Automattic/orchard-swiftlint).

## Test plan

- [ ] CI build is green.
- [ ] `swiftlint lint --strict --no-cache` is clean against the rule.

🤖 Generated with [Claude Code](https://claude.ai/code)
