### PR TITLE
Enable SwiftLint rule: contains_over_range_nil_comparison

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -28,6 +28,9 @@ only_rules:
   # Prefer `contains` over `first(where:) != nil`.
   - contains_over_first_not_nil
 
+  # Prefer `contains` over `range(of:) != nil` and `range(of:) == nil`.
+  - contains_over_range_nil_comparison
+
   # if,for,while,do statements shouldn't wrap their conditionals in parentheses.
   - control_statement
 

--- a/Modules/Sources/WordPressKit/WordPressOrgXMLRPCValidator.swift
+++ b/Modules/Sources/WordPressKit/WordPressOrgXMLRPCValidator.swift
@@ -231,8 +231,8 @@ open class WordPressOrgXMLRPCValidator: NSObject {
                 if httpResponse?.url != url {
                     // we where redirected, let's check the answer content
                     if let data = (error as NSError).userInfo[WordPressOrgXMLRPCApi.WordPressOrgXMLRPCApiErrorKeyData as String] as? Data,
-                        let responseString = String(data: data, encoding: String.Encoding.utf8), responseString.range(of: "<meta name=\"GENERATOR\" content=\"www.dudamobile.com\">") != nil
-                            || responseString.range(of: "dm404Container") != nil {
+                        let responseString = String(data: data, encoding: String.Encoding.utf8), responseString.contains("<meta name=\"GENERATOR\" content=\"www.dudamobile.com\">")
+                            || responseString.contains("dm404Container") {
                         failure(WordPressOrgXMLRPCValidatorError.mobilePluginRedirectedError as NSError)
                         return
                     }

--- a/Sources/WordPressAuthenticator/Helpers/Authenticator/WordPressAuthenticator.swift
+++ b/Sources/WordPressAuthenticator/Helpers/Authenticator/WordPressAuthenticator.swift
@@ -491,7 +491,7 @@ import WordPressKit
 
         if isSiteURLSchemeEmpty {
             path = "https://\(path)"
-        } else if path.isWordPressComPath() && path.range(of: "http://") != nil {
+        } else if path.isWordPressComPath() && path.contains("http://") {
             path = path.replacingOccurrences(of: "http://", with: "https://")
         }
 

--- a/Tests/KeystoneTests/Helpers/OHHTTPStubs+Helpers.swift
+++ b/Tests/KeystoneTests/Helpers/OHHTTPStubs+Helpers.swift
@@ -7,7 +7,7 @@ import OHHTTPStubsSwift
 public extension HTTPStubs {
     static func stubRequest(forEndpoint endpoint: String, withFileAtPath path: String) {
         stub(condition: { request in
-            return request.url?.absoluteString.range(of: endpoint) != nil
+            return request.url?.absoluteString.contains(endpoint) ?? false
         }) { _ in
             return fixture(filePath: path, headers: ["Content-Type" as NSObject: "application/json" as AnyObject])
         }

--- a/Tests/KeystoneTests/Tests/Services/NotificationSettingsServiceTests.swift
+++ b/Tests/KeystoneTests/Tests/Services/NotificationSettingsServiceTests.swift
@@ -29,8 +29,8 @@ class NotificationSettingsServiceTests: CoreDataTestCase {
         service = NotificationSettingsService(coreDataStack: contextManager, wordPressComRestApi: remoteApi)
 
         stub(condition: { request in
-            return request.url?.absoluteString.contains(self.settingsEndpoint) ?? false
-                && request.httpMethod! == "GET"
+            let matchesEndpoint = request.url?.absoluteString.contains(self.settingsEndpoint) ?? false
+            return matchesEndpoint && request.httpMethod! == "GET"
             }) { _ in
                 let stubPath = OHPathForFile(self.settingsFilename, type(of: self))
                 return fixture(filePath: stubPath!, headers: ["Content-Type" as NSObject: self.contentTypeJson as AnyObject])

--- a/Tests/KeystoneTests/Tests/Services/NotificationSettingsServiceTests.swift
+++ b/Tests/KeystoneTests/Tests/Services/NotificationSettingsServiceTests.swift
@@ -29,7 +29,7 @@ class NotificationSettingsServiceTests: CoreDataTestCase {
         service = NotificationSettingsService(coreDataStack: contextManager, wordPressComRestApi: remoteApi)
 
         stub(condition: { request in
-            return request.url?.absoluteString.range(of: self.settingsEndpoint) != nil
+            return request.url?.absoluteString.contains(self.settingsEndpoint) ?? false
                 && request.httpMethod! == "GET"
             }) { _ in
                 let stubPath = OHPathForFile(self.settingsFilename, type(of: self))

--- a/Tests/WordPressKitTests/WordPressKitTests/Tests/RemoteTestCase.swift
+++ b/Tests/WordPressKitTests/WordPressKitTests/Tests/RemoteTestCase.swift
@@ -91,7 +91,7 @@ extension RemoteTestCase {
         }
 
         stub(condition: { request in
-            return request.url?.absoluteString.range(of: endpoint) != nil
+            return request.url?.absoluteString.contains(endpoint) ?? false
         }) { _ in
             var headers: [NSObject: AnyObject]?
 
@@ -112,7 +112,7 @@ extension RemoteTestCase {
     ///
     func stubRemoteResponse(_ endpoint: String, data: Data, contentType: ResponseContentType, status: Int32 = 200) {
         stub(condition: { request in
-            return request.url?.absoluteString.range(of: endpoint) != nil
+            return request.url?.absoluteString.contains(endpoint) ?? false
         }) { _ in
             var headers: [NSObject: AnyObject]?
 
@@ -140,7 +140,7 @@ extension RemoteTestCase {
     func stubRemoteResponse(_ endpoint: String, files: [String], contentType: ResponseContentType, status: Int32 = 200) {
         var callCounter = 0
         stub(condition: { request in
-            return request.url?.absoluteString.range(of: endpoint) != nil
+            return request.url?.absoluteString.contains(endpoint) ?? false
         }) { response in
             guard files.indices.contains(callCounter) else {
                 // An extra call was made to this stub and no corresponding response file existed.


### PR DESCRIPTION
## Summary

Enables SwiftLint's [`contains_over_range_nil_comparison`](https://realm.github.io/SwiftLint/contains_over_range_nil_comparison.html) rule.

The rule prefers `s.contains(...)` over `s.range(of:) != nil` (and `== nil`), which is a clarity win.

- See commit message for the violation count and any rewrites.
- The change is type-preserving (Bool→Bool) — local build deferred to CI.

Part of the [Orchard SwiftLint rollout campaign](https://github.com/Automattic/orchard-swiftlint).

## Test plan

- [ ] CI build is green.
- [ ] `swiftlint lint --strict --no-cache` is clean against the rule.

🤖 Generated with [Claude Code](https://claude.ai/code)
