### PR TITLE
Enable SwiftLint rule: last_where

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -46,6 +46,9 @@ only_rules:
   # explicit empty-string separator since that is the default.
   - joined_default_parameter
 
+  # Prefer `last(where:)` over `filter { }.last`.
+  - last_where
+
   # MARK comment should be in valid format.
   - mark
 


### PR DESCRIPTION
## Summary

Enables SwiftLint's [`last_where`](https://realm.github.io/SwiftLint/last_where.html) rule.

The rule prefers `xs.last(where: { ... })` over `xs.filter { ... }.last`, which is a performance and clarity win (avoids materialising an intermediate array).

- **0 violations** in the current codebase, so no code changes — only the rule entry in `.swiftlint.yml`.
- The rule will catch new occurrences in future code.

Part of the [Orchard SwiftLint rollout campaign](https://github.com/Automattic/orchard-swiftlint).

## Test plan

- [ ] CI build is green.
- [ ] `swiftlint lint --strict --no-cache` is clean against the rule.

🤖 Generated with [Claude Code](https://claude.ai/code)
