### PR TITLE
Enable SwiftLint rule: sorted_first_last

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -65,6 +65,9 @@ only_rules:
   # Prefer `someBool.toggle()` over `someBool = !someBool`.
   - toggle_bool
 
+  # Prefer `min(by:)` / `max(by:)` over `sorted { ... }.first` / `.last`.
+  - sorted_first_last
+
   # Files should have a single trailing newline.
   - trailing_newline
 

--- a/Modules/Sources/JetpackStatsWidgetsCore/WidgetDataCacheReader.swift
+++ b/Modules/Sources/JetpackStatsWidgetsCore/WidgetDataCacheReader.swift
@@ -17,7 +17,7 @@ public extension WidgetDataCacheReader {
         } else {
             if userLoggedIn {
                 /// In rare cases there could be no default site and no defaultSiteId set
-                if let firstSiteData: T = widgetData()?.sorted(by: { $0.siteID < $1.siteID }).first {
+                if let firstSiteData: T = widgetData()?.min(by: { $0.siteID < $1.siteID }) {
                     return .success(firstSiteData)
                 } else {
                     return .failure(.noSite)

--- a/WordPress/Classes/Services/CommentService+Swift.swift
+++ b/WordPress/Classes/Services/CommentService+Swift.swift
@@ -36,7 +36,7 @@ extension CommentService {
             // Filter for comments authored by the current user, and return the most recent commentID (if any).
             success(remoteComments
                         .filter { $0.authorID == userID }
-                        .sorted { $0.date > $1.date }.first?.commentID ?? 0)
+                        .max { $0.date < $1.date }?.commentID ?? 0)
         } failure: { error in
             failure(error)
         }

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/View Models/JetpackScanThreatViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/View Models/JetpackScanThreatViewModel.swift
@@ -421,7 +421,7 @@ private extension JetpackThreatContext {
 
     func attributedString(with config: JetpackThreatContextRendererConfig) -> NSAttributedString? {
 
-        guard let longestLine = lines.sorted(by: { $0.contents.count > $1.contents.count }).first else {
+        guard let longestLine = lines.max(by: { $0.contents.count < $1.contents.count }) else {
             return nil
         }
 


### PR DESCRIPTION
## Summary

Enables SwiftLint's [`sorted_first_last`](https://realm.github.io/SwiftLint/sorted_first_last.html) rule.

The rule prefers `min(by:)` / `max(by:)` over `sorted { ... }.first` / `.last`. This avoids materialising the entire sorted array when only one element is needed.

- See commit message for the violation count and any rewrites.
- The change is type-preserving (`Element?`→`Element?`) — local build deferred to CI.

Part of the [Orchard SwiftLint rollout campaign](https://github.com/Automattic/orchard-swiftlint).

## Test plan

- [ ] CI build is green.
- [ ] `swiftlint lint --strict --no-cache` is clean against the rule.

🤖 Generated with [Claude Code](https://claude.ai/code)
