### PR TITLE
Enable SwiftLint rule: flatmap_over_map_reduce

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -51,6 +51,9 @@ only_rules:
   # Prefer `first(where:)` over `filter { }.first`.
   - first_where
 
+  # Prefer `flatMap { ... }` over `map { ... }.reduce([], +)`.
+  - flatmap_over_map_reduce
+
   # When calling the `joined` method on an array of strings, omit an
   # explicit empty-string separator since that is the default.
   - joined_default_parameter

--- a/WordPress/Classes/ViewRelated/Gutenberg/Utils/GutenbergFilesAppMediaSource.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Utils/GutenbergFilesAppMediaSource.swift
@@ -13,10 +13,22 @@ class GutenbergFilesAppMediaSource: NSObject {
         self.gutenberg = gutenberg
     }
 
-    func presentPicker(origin: UIViewController, filters: [Gutenberg.MediaType], allowedTypesOnBlog: [String], multipleSelection: Bool, callback: @escaping MediaPickerDidPickMediaCallback) {
+    func presentPicker(
+        origin: UIViewController,
+        filters: [Gutenberg.MediaType],
+        allowedTypesOnBlog: [String],
+        multipleSelection: Bool,
+        callback: @escaping MediaPickerDidPickMediaCallback
+    ) {
         mediaPickerCallback = callback
-        let documentTypes = GutenbergFilesAppMediaSource.getDocumentTypes(filters: filters, allowedTypesOnBlog: allowedTypesOnBlog)
-        let docPicker = UIDocumentPickerViewController(forOpeningContentTypes: documentTypes.compactMap(UTType.init), asCopy: true)
+        let documentTypes = GutenbergFilesAppMediaSource.getDocumentTypes(
+            filters: filters,
+            allowedTypesOnBlog: allowedTypesOnBlog
+        )
+        let docPicker = UIDocumentPickerViewController(
+            forOpeningContentTypes: documentTypes.compactMap(UTType.init),
+            asCopy: true
+        )
         docPicker.delegate = self
         docPicker.allowsMultipleSelection = multipleSelection
         origin.present(docPicker, animated: true)
@@ -26,7 +38,7 @@ class GutenbergFilesAppMediaSource: NSObject {
         if filters.contains(.any) {
             return allowedTypesOnBlog
         } else {
-            return filters.map { $0.filterTypesConformingTo(allTypes: allowedTypesOnBlog) }.reduce(into: []) { $0 += $1 }
+            return filters.flatMap { $0.filterTypesConformingTo(allTypes: allowedTypesOnBlog) }
         }
     }
 }
@@ -58,7 +70,12 @@ extension GutenbergFilesAppMediaSource: UIDocumentPickerDelegate {
                 return nil
             }
             let mediaUploadID = media.gutenbergUploadID
-            return MediaInfo(id: mediaUploadID, url: url.absoluteString, type: media.mediaTypeString, title: url.lastPathComponent)
+            return MediaInfo(
+                id: mediaUploadID,
+                url: url.absoluteString,
+                type: media.mediaTypeString,
+                title: url.lastPathComponent
+            )
         })
 
         callback(mediaInfo)


### PR DESCRIPTION
## Summary

Enables SwiftLint's [`flatmap_over_map_reduce`](https://realm.github.io/SwiftLint/flatmap_over_map_reduce.html) rule.

The rule prefers `flatMap { ... }` over `map { ... }.reduce([], +)` for flattening nested arrays — this avoids materialising an intermediate array of arrays.

- See commit message for the violation count and any rewrites.
- The change is type-preserving — local build deferred to CI.

Part of the [Orchard SwiftLint rollout campaign](https://github.com/Automattic/orchard-swiftlint).

## Test plan

- [ ] CI build is green.
- [ ] `swiftlint lint --strict --no-cache` is clean against the rule.

🤖 Generated with [Claude Code](https://claude.ai/code)
