### PR TITLE
Enable SwiftLint rule: redundant_type_annotation

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -60,6 +60,9 @@ only_rules:
   # Example: CGPoint.zero instead of CGPoint(x: 0, y: 0)
   - prefer_zero_over_explicit_init
 
+  # Type annotations are redundant when the type can be inferred.
+  - redundant_type_annotation
+
   - shorthand_optional_binding
 
   # Prefer `someBool.toggle()` over `someBool = !someBool`.

--- a/Modules/Sources/BuildSettingsKit/BuildSecrets.swift
+++ b/Modules/Sources/BuildSettingsKit/BuildSecrets.swift
@@ -66,7 +66,7 @@ public struct BuildSecrets: Sendable {
 
 extension BuildSecrets {
 
-    public static let dummy: BuildSecrets = BuildSecrets(
+    public static let dummy = BuildSecrets(
         oauth: .init(client: "", secret: ""),
         google: .init(clientId: "", schemeId: "", serverClientId: ""),
         zendesk: .init(appId: "", url: "", clientId: ""),

--- a/Modules/Sources/DesignSystem/Foundation/AppColor.swift
+++ b/Modules/Sources/DesignSystem/Foundation/AppColor.swift
@@ -141,11 +141,11 @@ extension UIAppColor {
     public static let appBarText = UIColor.systemOrange
 
     public static let placeholderElement = UIColor(light: .systemGray5, dark: .systemGray4)
-    public static let placeholderElementFaded: UIColor = UIColor(light: .systemGray6, dark: .systemGray5)
+    public static let placeholderElementFaded = UIColor(light: .systemGray6, dark: .systemGray5)
 
     public static let prologueBackground = UIColor(light: blue(.shade0), dark: .systemBackground)
 
-    public static let switchStyle: SwitchToggleStyle = SwitchToggleStyle(tint: Color(UIAppColor.primary))
+    public static let switchStyle = SwitchToggleStyle(tint: Color(UIAppColor.primary))
 }
 
 public enum AppColor {

--- a/Modules/Sources/Support/UI/Bot Conversations/CompositionView.swift
+++ b/Modules/Sources/Support/UI/Bot Conversations/CompositionView.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 struct CompositionView: View {
 
-    private let cornerSize: CGSize = CGSize(width: 9, height: 8)
+    private let cornerSize = CGSize(width: 9, height: 8)
 
     private let action: (String) -> Void
     private let isDisabled: Bool

--- a/Modules/Sources/WordPressCore/DiskCache.swift
+++ b/Modules/Sources/WordPressCore/DiskCache.swift
@@ -7,7 +7,7 @@ public actor DiskCache: DiskCacheProtocol {
 
     public static let shared = DiskCache()
 
-    private let cacheRoot: URL = URL.cachesDirectory
+    private let cacheRoot = URL.cachesDirectory
 
     public init() {}
 

--- a/Modules/Sources/WordPressKit/WordPressComRestApi.swift
+++ b/Modules/Sources/WordPressKit/WordPressComRestApi.swift
@@ -84,7 +84,7 @@ open class WordPressComRestApi: NSObject {
     public typealias FailureReponseBlock = (_ error: NSError, _ httpResponse: HTTPURLResponse?) -> Void
     public typealias APIResult<T> = WordPressAPIResult<HTTPAPIResponse<T>, WordPressComRestApiEndpointError>
 
-    @objc public static let apiBaseURL: URL = URL(string: "https://public-api.wordpress.com/")!
+    @objc public static let apiBaseURL = URL(string: "https://public-api.wordpress.com/")!
 
     @objc public static let defaultBackgroundSessionIdentifier = "org.wordpress.wpcomrestapi"
 

--- a/Modules/Sources/WordPressShared/Utility/Double+Stats.swift
+++ b/Modules/Sources/WordPressShared/Utility/Double+Stats.swift
@@ -109,7 +109,7 @@ extension Double {
             return self.formatWithCommas()
         }
 
-        let exp: Int = Int(log10(absValue) / 3.0)
+        let exp = Int(log10(absValue) / 3.0)
         let unsignedRoundedNum: Double = Foundation.round(10 * absValue / pow(1000.0, Double(exp))) / 10
 
         var roundedNum: Double

--- a/Modules/Sources/WordPressUI/Extensions/UIView+Animations.swift
+++ b/Modules/Sources/WordPressUI/Extensions/UIView+Animations.swift
@@ -162,7 +162,7 @@ extension UIView {
         let duration: TimeInterval = userInfo[UIResponder.keyboardAnimationDurationUserInfoKey] as? TimeInterval ?? 0
         let beginFrame: CGRect = (userInfo[UIResponder.keyboardFrameBeginUserInfoKey] as? NSValue)?.cgRectValue ?? CGRect.zero
         let endFrame: CGRect = (userInfo[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue)?.cgRectValue ?? CGRect.zero
-        let animationCurve: AnimationOptions = AnimationOptions(rawValue: (userInfo[UIResponder.keyboardAnimationCurveUserInfoKey] as? UInt ?? 0))
+        let animationCurve = AnimationOptions(rawValue: (userInfo[UIResponder.keyboardAnimationCurveUserInfoKey] as? UInt ?? 0))
 
         UIView.animate(withDuration: duration, delay: 0, options: animationCurve, animations: {
             animations(beginFrame, endFrame)

--- a/Modules/Tests/WordPressCoreTests/DataStoreTests.swift
+++ b/Modules/Tests/WordPressCoreTests/DataStoreTests.swift
@@ -7,7 +7,7 @@ struct InMemoryDataStoreTests {
 
     @Test
     func testUpdatesAfterCreation() async {
-        let store: InMemoryUserDataStore = InMemoryUserDataStore()
+        let store = InMemoryUserDataStore()
         let stream = await store.listStream(query: .all)
 
         await confirmation("The stream produces an update") { confirmation in
@@ -19,7 +19,7 @@ struct InMemoryDataStoreTests {
 
     @Test
     func testUpdatesAfterStore() async {
-        let store: InMemoryUserDataStore = InMemoryUserDataStore()
+        let store = InMemoryUserDataStore()
         let stream = await store.listStream(query: .all)
 
         Task.detached {
@@ -36,7 +36,7 @@ struct InMemoryDataStoreTests {
 
     @Test
     func testUpdatesAfterDelete() async throws {
-        let store: InMemoryUserDataStore = InMemoryUserDataStore()
+        let store = InMemoryUserDataStore()
         try await store.store([.mockUser])
 
         let stream = await store.listStream(query: .all)

--- a/Sources/WordPressAuthenticator/Features/NUX/NUXTableViewController.swift
+++ b/Sources/WordPressAuthenticator/Features/NUX/NUXTableViewController.swift
@@ -6,7 +6,7 @@ import UIKit
 open class NUXTableViewController: UITableViewController, NUXViewControllerBase, UIViewControllerTransitioningDelegate {
     // MARK: NUXViewControllerBase properties
     /// these properties comply with NUXViewControllerBase and are duplicated with NUXViewController
-    public var helpButton: UIButton = UIButton(type: .custom)
+    public var helpButton = UIButton(type: .custom)
     public var dismissBlock: ((_ cancelled: Bool) -> Void)?
     public var loginFields = LoginFields()
     open var sourceTag: WordPressSupportSourceTag {

--- a/Sources/WordPressAuthenticator/Features/NUX/NUXViewController.swift
+++ b/Sources/WordPressAuthenticator/Features/NUX/NUXViewController.swift
@@ -8,7 +8,7 @@ import UIKit
 open class NUXViewController: UIViewController, NUXViewControllerBase, UIViewControllerTransitioningDelegate {
     // MARK: NUXViewControllerBase properties
     /// these properties comply with NUXViewControllerBase and are duplicated with NUXTableViewController
-    public var helpButton: UIButton = UIButton(type: .custom)
+    public var helpButton = UIButton(type: .custom)
     public var dismissBlock: ((_ cancelled: Bool) -> Void)?
     public var loginFields = LoginFields()
     open var sourceTag: WordPressSupportSourceTag {

--- a/Sources/WordPressAuthenticator/Features/SignIn/AppleAuthenticator.swift
+++ b/Sources/WordPressAuthenticator/Features/SignIn/AppleAuthenticator.swift
@@ -14,7 +14,7 @@ class AppleAuthenticator: NSObject {
 
     // MARK: - Properties
 
-    static var sharedInstance: AppleAuthenticator = AppleAuthenticator()
+    static var sharedInstance = AppleAuthenticator()
     private var showFromViewController: UIViewController?
     private let loginFields = LoginFields()
     weak var delegate: AppleAuthenticatorDelegate?

--- a/Sources/WordPressAuthenticator/Helpers/UnifiedAuth/GoogleAuthenticator.swift
+++ b/Sources/WordPressAuthenticator/Helpers/UnifiedAuth/GoogleAuthenticator.swift
@@ -82,7 +82,7 @@ class GoogleAuthenticator: NSObject {
 
     // MARK: - Properties
 
-    static var sharedInstance: GoogleAuthenticator = GoogleAuthenticator()
+    static var sharedInstance = GoogleAuthenticator()
     weak var loginDelegate: GoogleAuthenticatorLoginDelegate?
     weak var signupDelegate: GoogleAuthenticatorSignupDelegate?
     weak var delegate: GoogleAuthenticatorDelegate?

--- a/Tests/KeystoneTests/Tests/Features/Blog/ReminderScheduleCoordinatorTests.swift
+++ b/Tests/KeystoneTests/Tests/Features/Blog/ReminderScheduleCoordinatorTests.swift
@@ -232,7 +232,7 @@ private extension ReminderScheduleCoordinatorTests {
     struct MockSchedulerBehavior {
         // states
         var scheduleToReturn: BloggingRemindersScheduler.Schedule = .none
-        var scheduledTimeToReturn: Date = Date()
+        var scheduledTimeToReturn = Date()
 
         // schedule
         var scheduleCalled = false

--- a/WordPress/Classes/Services/MediaImportService.swift
+++ b/WordPress/Classes/Services/MediaImportService.swift
@@ -9,7 +9,7 @@ import WordPressData
 ///
 class MediaImportService: NSObject {
 
-    private static let defaultImportQueue: DispatchQueue = DispatchQueue(label: "org.wordpress.mediaImportService", autoreleaseFrequency: .workItem)
+    private static let defaultImportQueue = DispatchQueue(label: "org.wordpress.mediaImportService", autoreleaseFrequency: .workItem)
 
     @objc lazy var importQueue: DispatchQueue = {
         return MediaImportService.defaultImportQueue
@@ -246,7 +246,7 @@ class MediaImportService: NSObject {
     /// - Returns: a progress object that report the current state of the import process.
     ///
     private func `import`(_ exportable: ExportableAsset, to media: Media, options: ExportOptions, completion: @escaping (Error?) -> Void) -> Progress {
-        let progress: Progress = Progress.discreteProgress(totalUnitCount: 1)
+        let progress = Progress.discreteProgress(totalUnitCount: 1)
         importQueue.async {
             guard let exporter = self.makeExporter(for: exportable, options: options) else {
                 preconditionFailure("An exporter needs to be availale")

--- a/WordPress/Classes/Utility/Scheduler.swift
+++ b/WordPress/Classes/Utility/Scheduler.swift
@@ -11,9 +11,9 @@ import Foundation
 /// There are two different algorithms to achieve this: Throttle and Debounce. Both are implemented as a separate function in this class.
 ///
 public class Scheduler {
-    private let queue: DispatchQueue = DispatchQueue.global(qos: .default)
-    private var job: DispatchWorkItem = DispatchWorkItem(block: {})
-    private var previousRun: Date = Date.distantPast
+    private let queue = DispatchQueue.global(qos: .default)
+    private var job = DispatchWorkItem(block: {})
+    private var previousRun = Date.distantPast
     private var maxInterval: Double
 
     init(seconds: Double) {

--- a/WordPress/Classes/Utility/Spotlight/SearchManager.swift
+++ b/WordPress/Classes/Utility/Spotlight/SearchManager.swift
@@ -9,7 +9,7 @@ import WordPressData
 
     // MARK: - Singleton
 
-    @objc static let shared: SearchManager = SearchManager()
+    @objc static let shared = SearchManager()
     private override init() {}
 
     // MARK: - Indexing

--- a/WordPress/Classes/Utility/ZendeskUtils.swift
+++ b/WordPress/Classes/Utility/ZendeskUtils.swift
@@ -46,7 +46,7 @@ protocol ZendeskUtilsProtocol {
 class ZendeskUtils: NSObject, ZendeskUtilsProtocol {
     // MARK: - Public Properties
 
-    static var sharedInstance: ZendeskUtils = ZendeskUtils(contextManager: ContextManager.shared)
+    static var sharedInstance = ZendeskUtils(contextManager: ContextManager.shared)
     static var zendeskEnabled = false
     static var unreadNotificationsCount = 0
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Dynamic/DynamicDashboardCard.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Dynamic/DynamicDashboardCard.swift
@@ -8,7 +8,7 @@ struct DynamicDashboardCard: View {
 
     struct Input {
         struct Row: Identifiable {
-            let id: UUID = UUID()
+            let id = UUID()
 
             let title: String?
             let description: String?

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Pages/PagesCardViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Pages/PagesCardViewModel.swift
@@ -34,7 +34,7 @@ class PagesCardViewModel: NSObject {
 
     private let managedObjectContext: NSManagedObjectContext
 
-    private var filter: PostListFilter = PostListFilter.allNonTrashedFilter()
+    private var filter = PostListFilter.allNonTrashedFilter()
 
     private var fetchedResultsController: NSFetchedResultsController<Page>?
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/PostsCardViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/PostsCardViewModel.swift
@@ -30,7 +30,7 @@ class PostsCardViewModel: NSObject {
 
     private let managedObjectContext: NSManagedObjectContext
 
-    private var postListFilter: PostListFilter = PostListFilter.draftFilter()
+    private var postListFilter = PostListFilter.draftFilter()
 
     private var fetchedResultsController: NSFetchedResultsController<Post>!
 

--- a/WordPress/Classes/ViewRelated/Blog/Sharing/SharingButtonsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Sharing/SharingButtonsViewController.swift
@@ -773,7 +773,7 @@ class SharingButtonsViewController: UITableViewController {
     /// Represents a section in the sharinging management table view.
     ///
     class SharingButtonsSection {
-        var rows: [SharingButtonsRow] = [SharingButtonsRow]()
+        var rows = [SharingButtonsRow]()
         var headerText: String?
         var footerText: String?
         var editing = false

--- a/WordPress/Classes/ViewRelated/Blog/Site Management/DestructiveAlertHelper.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Management/DestructiveAlertHelper.swift
@@ -13,9 +13,9 @@ class DestructiveAlertHelper: DestructiveAlertHelperLogic {
     func makeAlertWithConfirmation(title: String, message: String, valueToConfirm: String, destructiveActionTitle: String, destructiveAction: @escaping () -> Void) -> UIAlertController {
         self.valueToConfirm = valueToConfirm
 
-        let attributedMessage: NSMutableAttributedString = NSMutableAttributedString(string: message)
+        let attributedMessage = NSMutableAttributedString(string: message)
 
-        let attributedValue: NSMutableAttributedString = NSMutableAttributedString(string: valueToConfirm)
+        let attributedValue = NSMutableAttributedString(string: valueToConfirm)
         let paragraphStyle = NSMutableParagraphStyle()
         paragraphStyle.lineBreakMode = .byCharWrapping
         attributedValue.addAttribute(.paragraphStyle, value: paragraphStyle, range: NSMakeRange(0, attributedValue.string.count - 1))

--- a/WordPress/Classes/ViewRelated/Comments/Controllers/CommentDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Comments/Controllers/CommentDetailViewController.swift
@@ -318,7 +318,7 @@ private extension CommentDetailViewController {
         static let deleteButtonNormalColor = UIColor(light: UIAppColor.error, dark: UIAppColor.red(.shade40))
         static let deleteButtonHighlightColor: UIColor = .white
         static let trashButtonBackgroundColor = UIColor.quaternarySystemFill
-        static let trashButtonHighlightColor: UIColor = UIColor.tertiarySystemFill
+        static let trashButtonHighlightColor = UIColor.tertiarySystemFill
         static let notificationDetailSource = ["source": "notification_details"]
     }
 

--- a/WordPress/Classes/ViewRelated/Domains/Views/SiteDomainsPresentationCard.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Views/SiteDomainsPresentationCard.swift
@@ -44,7 +44,7 @@ struct SiteDomainsPresentationCard: View {
 
 extension SiteDomainsPresentationCard {
     struct Destination: Identifiable {
-        let id: UUID = UUID()
+        let id = UUID()
         let title: String
         let style: DSButtonStyle.Emphasis
         let action: (() -> Void)

--- a/WordPress/Classes/ViewRelated/Gutenberg/Collapsable Header/Collabsable Header Filter Bar/CollabsableHeaderFilterCollectionViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Collapsable Header/Collabsable Header Filter Bar/CollabsableHeaderFilterCollectionViewCell.swift
@@ -80,7 +80,7 @@ class CollabsableHeaderFilterCollectionViewCell: UICollectionViewCell, NibLoadab
 
     private func updateSelectedStyle() {
         let oppositeInterfaceStyle: UIUserInterfaceStyle = (traitCollection.userInterfaceStyle == .dark) ? .light : .dark
-        let selectedColor: UIColor = UIColor.systemGray6.color(for: UITraitCollection(userInterfaceStyle: oppositeInterfaceStyle))
+        let selectedColor = UIColor.systemGray6.color(for: UITraitCollection(userInterfaceStyle: oppositeInterfaceStyle))
         pillBackgroundView.backgroundColor = isSelected ? selectedColor : .quaternarySystemFill
 
         if traitCollection.userInterfaceStyle == .dark {

--- a/WordPress/Classes/ViewRelated/Gutenberg/Collapsable Header/Collapsable Header Collection View Cell/CollapsableHeaderCollectionViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Collapsable Header/Collapsable Header Collection View Cell/CollapsableHeaderCollectionViewCell.swift
@@ -102,12 +102,12 @@ class CollapsableHeaderCollectionViewCell: UICollectionViewCell, NibLoadable {
             return
         }
 
-        let borderWidthAnimation: CABasicAnimation = CABasicAnimation(keyPath: "borderWidth")
+        let borderWidthAnimation = CABasicAnimation(keyPath: "borderWidth")
         borderWidthAnimation.fromValue = imageView.layer.borderWidth
         borderWidthAnimation.toValue = imageBorderWidth
         borderWidthAnimation.duration = CollapsableHeaderCollectionViewCell.selectionAnimationSpeed
 
-        let borderColorAnimation: CABasicAnimation = CABasicAnimation(keyPath: "borderColor")
+        let borderColorAnimation = CABasicAnimation(keyPath: "borderColor")
         borderColorAnimation.fromValue = imageView.layer.borderColor
         borderColorAnimation.toValue = imageBorderColor
         borderColorAnimation.duration = CollapsableHeaderCollectionViewCell.selectionAnimationSpeed

--- a/WordPress/Classes/ViewRelated/Me/All Domains/Views/AllDomainsListActivityIndicatorTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Me/All Domains/Views/AllDomainsListActivityIndicatorTableViewCell.swift
@@ -2,7 +2,7 @@ import UIKit
 
 final class AllDomainsListActivityIndicatorTableViewCell: UITableViewCell {
 
-    private let activityIndicator: UIActivityIndicatorView = UIActivityIndicatorView(style: .medium)
+    private let activityIndicator = UIActivityIndicatorView(style: .medium)
 
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)

--- a/WordPress/Classes/ViewRelated/Media/CircularProgressView.swift
+++ b/WordPress/Classes/ViewRelated/Media/CircularProgressView.swift
@@ -66,7 +66,7 @@ class CircularProgressView: UIView {
     // MARK: - public fields
 
     let retryView = AccessoryView()
-    @objc var errorView: UIView = UIView() {
+    @objc var errorView = UIView() {
         didSet {
             oldValue.removeFromSuperview()
             configureErrorView()

--- a/WordPress/Classes/ViewRelated/NewSupport/SupportDataProvider.swift
+++ b/WordPress/Classes/ViewRelated/NewSupport/SupportDataProvider.swift
@@ -213,7 +213,7 @@ actor WpBotConversationDataProvider: BotConversationDataProvider {
                 fatalError("Could not get the current user ID – this should never happen because users should be logged in")
             }
 
-        let params: CreateBotConversationParams = CreateBotConversationParams(
+        let params = CreateBotConversationParams(
             message: message,
             userId: accountId
         )
@@ -228,7 +228,7 @@ actor WpBotConversationDataProvider: BotConversationDataProvider {
     }
 
     private func add(message: String, to conversation: Support.BotConversation) async throws -> Support.BotConversation {
-        let params: AddMessageToBotConversationParams = AddMessageToBotConversationParams(
+        let params = AddMessageToBotConversationParams(
             message: message,
             context: [:]
         )

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController/NotificationTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController/NotificationTableViewCell.swift
@@ -133,7 +133,7 @@ final class NotificationTableViewCell: HostingTableViewCell<NotificationsTableVi
     }
 
     private func likeInlineActionIcon(filled: Bool) -> (image: Image, color: Color?) {
-        let image: Image = Image.DS.icon(named: filled ? .starFill : .starOutline)
+        let image = Image.DS.icon(named: filled ? .starFill : .starOutline)
         let color: Color? = filled ? AppColor.primary : nil
         return (image: image, color: color)
     }

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController/NotificationsTableHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController/NotificationsTableHeaderView.swift
@@ -3,7 +3,7 @@ import DesignSystem
 
 final class NotificationsTableHeaderView: UITableViewHeaderFooterView {
 
-    static let reuseIdentifier: String = String(describing: NotificationsTableHeaderView.self)
+    static let reuseIdentifier = String(describing: NotificationsTableHeaderView.self)
 
     // MARK: - Properties
 

--- a/WordPress/Classes/ViewRelated/Post/Preview/PreviewDeviceSelectionViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Preview/PreviewDeviceSelectionViewController.swift
@@ -53,7 +53,7 @@ class PreviewDeviceSelectionViewController: UIViewController {
         }
     }
 
-    var selectedOption: PreviewDevice = PreviewDevice.default
+    var selectedOption = PreviewDevice.default
 
     var onDeviceChange: ((PreviewDevice) -> Void)?
 

--- a/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderInterestsCollectionViewFlowLayout.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderInterestsCollectionViewFlowLayout.swift
@@ -68,10 +68,10 @@ class ReaderInterestsCollectionViewFlowLayout: UICollectionViewFlowLayout {
         let count = isExpanded ? numberOfItems + 1 : numberOfItems
 
         for item in 0 ..< count {
-            let indexPath: IndexPath = IndexPath(row: item, section: 0)
+            let indexPath = IndexPath(row: item, section: 0)
             let isCollapseItem = item == numberOfItems
             let itemSize = isCollapseItem ? sizeForOverflowItem(at: indexPath) : sizeForItem(at: indexPath)
-            var frame: CGRect = CGRect(origin: .zero, size: itemSize)
+            var frame = CGRect(origin: .zero, size: itemSize)
 
             if item == 0 {
                 let minX: CGFloat = isRightToLeft ? maxContentWidth - frame.width : 0

--- a/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderSelectInterestsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderSelectInterestsViewController.swift
@@ -57,7 +57,7 @@ class ReaderSelectInterestsViewController: UIViewController {
         return ReaderInterestsDataSource(topics: topics)
     }()
 
-    private let coordinator: ReaderSelectInterestsCoordinator = ReaderSelectInterestsCoordinator()
+    private let coordinator = ReaderSelectInterestsCoordinator()
 
     private let noResultsViewController = NoResultsViewController.controller()
 

--- a/WordPress/Classes/ViewRelated/Stats/Charts/InsightsLineChart.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Charts/InsightsLineChart.swift
@@ -132,8 +132,8 @@ class InsightsLineChart {
 
 private extension InsightsLineChart {
     enum Constants {
-        static let primaryHighlightColor: UIColor = UIColor(red: 209.0 / 255.0, green: 209.0 / 255.0, blue: 214.0 / 255.0, alpha: 1.0)
-        static let secondaryLineColor: UIColor = UIColor(light: .quaternaryLabel, dark: .tertiaryLabel)
+        static let primaryHighlightColor = UIColor(red: 209.0 / 255.0, green: 209.0 / 255.0, blue: 214.0 / 255.0, alpha: 1.0)
+        static let secondaryLineColor = UIColor(light: .quaternaryLabel, dark: .tertiaryLabel)
         static let primaryLineColorViews: UIColor = UIAppColor.blue(.shade50)
         static let primaryLineColorVisitors: UIColor = UIAppColor.purple(.shade50)
     }
@@ -152,7 +152,7 @@ private struct ViewsInsightsLineChartStyling: LineChartStyling {
     let primaryLineColor: UIColor
     let secondaryLineColor: UIColor?
     let primaryHighlightColor: UIColor?
-    let labelColor: UIColor = UIColor(light: .secondaryLabel, dark: .tertiaryLabel)
+    let labelColor = UIColor(light: .secondaryLabel, dark: .tertiaryLabel)
     let legendTitle: String? = NSLocalizedString("Views", comment: "Title for Views count in the legend of the Stats Insights views and visitors line chart")
     let lineColor: UIColor = UIAppColor.neutral(.shade5)
     let yAxisValueFormatter: AxisValueFormatter = VerticalAxisFormatter()
@@ -164,7 +164,7 @@ private struct VisitorsInsightsLineChartStyling: LineChartStyling {
     let primaryLineColor: UIColor
     let secondaryLineColor: UIColor?
     let primaryHighlightColor: UIColor?
-    let labelColor: UIColor = UIColor(light: .secondaryLabel, dark: .tertiaryLabel)
+    let labelColor = UIColor(light: .secondaryLabel, dark: .tertiaryLabel)
     let legendColor: UIColor? = UIAppColor.primary(.shade60)
     let legendTitle: String? = NSLocalizedString("Visitors", comment: "Title for Visitors count in the legend of the Stats Insights views and visitors line chart")
     let lineColor: UIColor = UIAppColor.neutral(.shade5)

--- a/WordPress/Classes/ViewRelated/Stats/Charts/StatsChartMarker.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Charts/StatsChartMarker.swift
@@ -8,8 +8,8 @@ class StatsChartMarker: MarkerView {
     var minimumSize = CGSize()
 
     private var tooltipLabel: NSMutableAttributedString?
-    private var labelSize: CGSize = CGSize()
-    private var size: CGSize = CGSize()
+    private var labelSize = CGSize()
+    private var size = CGSize()
     var paragraphStyle: NSMutableParagraphStyle = {
         let paragraphStyle = NSMutableParagraphStyle()
         paragraphStyle.alignment = .center

--- a/WordPress/Classes/ViewRelated/Stats/Helpers/SiteStatsInformation.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Helpers/SiteStatsInformation.swift
@@ -9,7 +9,7 @@ import WordPressShared
     // MARK: - Properties
     typealias SiteInsights = [String: [Int]]
     private let userDefaultsInsightTypesKey = "StatsInsightTypes"
-    @objc public static var sharedInstance: SiteStatsInformation = SiteStatsInformation()
+    @objc public static var sharedInstance = SiteStatsInformation()
     private override init() {}
 
     @objc public var siteID: NSNumber?

--- a/WordPress/Classes/ViewRelated/Stats/Subscribers/StatsSubscribersLineChart.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Subscribers/StatsSubscribersLineChart.swift
@@ -29,7 +29,7 @@ private struct SubscribersLineChartStyling: LineChartStyling {
     let primaryLineColor: UIColor = UIAppColor.blue(.shade50)
     let secondaryLineColor: UIColor? = nil
     let primaryHighlightColor: UIColor? = UIColor(red: 209.0 / 255.0, green: 209.0 / 255.0, blue: 214.0 / 255.0, alpha: 1.0)
-    let labelColor: UIColor = UIColor(light: .secondaryLabel, dark: .tertiaryLabel)
+    let labelColor = UIColor(light: .secondaryLabel, dark: .tertiaryLabel)
     let legendColor: UIColor? = nil
     let legendTitle: String? = NSLocalizedString("stats.subscribers.chart.legend", value: "Subscribers", comment: "Title for the legend of the Stats Subscribers line chart.")
     let lineColor: UIColor = UIAppColor.neutral(.shade5)

--- a/WordPress/Classes/ViewRelated/System/Action Sheet/ActionSheetViewController.swift
+++ b/WordPress/Classes/ViewRelated/System/Action Sheet/ActionSheetViewController.swift
@@ -22,13 +22,13 @@ class ActionSheetViewController: UIViewController {
         static let gripHeight: CGFloat = 5
         static let cornerRadius: CGFloat = 8
         static let buttonSpacing: CGFloat = 8
-        static let additionalSafeAreaInsetsRegular: UIEdgeInsets = UIEdgeInsets(top: 20, left: 0, bottom: 20, right: 0)
+        static let additionalSafeAreaInsetsRegular = UIEdgeInsets(top: 20, left: 0, bottom: 20, right: 0)
         static let minimumWidth: CGFloat = 300
         static let maximumWidth: CGFloat = 600
 
         enum Header {
             static let spacing: CGFloat = 16
-            static let insets: UIEdgeInsets = UIEdgeInsets(top: 0, left: 18, bottom: 0, right: 18)
+            static let insets = UIEdgeInsets(top: 0, left: 18, bottom: 0, right: 18)
         }
 
         enum Button {
@@ -42,7 +42,7 @@ class ActionSheetViewController: UIViewController {
         }
 
         enum Stack {
-            static let insets: UIEdgeInsets = UIEdgeInsets(top: 5, left: 0, bottom: 0, right: 0)
+            static let insets = UIEdgeInsets(top: 5, left: 0, bottom: 0, right: 0)
         }
     }
 


### PR DESCRIPTION
## Summary

Enables SwiftLint's [`redundant_type_annotation`](https://realm.github.io/SwiftLint/redundant_type_annotation.html) rule.

The rule flags `let foo: Int = 5` where the type annotation is implied by the literal/expression on the right.

- Auto-fixed by `swiftlint --fix`.
- The change is type-preserving — local build deferred to CI.

Part of the [Orchard SwiftLint rollout campaign](https://github.com/Automattic/orchard-swiftlint).

## Test plan

- [x] CI build is green.
- [x] `swiftlint lint --strict --no-cache` is clean against the rule.

🤖 Generated with [Claude Code](https://claude.ai/code)
