### PR TITLE
Add Claude Code hook to run swiftlint after edits

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -21,9 +21,15 @@
         "hooks": [
           {
             "type": "command",
-            "command": "jq -r '.tool_input.file_path' | { read -r f; case \"$f\" in *.swift) xcrun swift format --in-place \"$f\" ;; esac; } 2>/dev/null || true",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/Scripts/claude-hooks/swift-format.sh",
             "timeout": 30,
             "statusMessage": "Formatting Swift..."
+          },
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/Scripts/claude-hooks/swiftlint.sh",
+            "timeout": 30,
+            "statusMessage": "Linting Swift..."
           }
         ]
       }

--- a/Scripts/claude-hooks/swift-format.sh
+++ b/Scripts/claude-hooks/swift-format.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+# Claude Code PostToolUse hook: format the just-edited Swift file with `swift format`.
+# Reads the hook payload (JSON) on stdin, extracts the file path, and runs the formatter
+# in-place when the file is Swift. Silent on success or when not applicable.
+
+f=$(jq -r '.tool_input.file_path')
+case "$f" in
+    *.swift)
+        xcrun swift format --in-place "$f" 2>/dev/null || true
+        ;;
+esac

--- a/Scripts/claude-hooks/swiftlint.sh
+++ b/Scripts/claude-hooks/swiftlint.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+# Claude Code PostToolUse hook: lint the just-edited Swift file with SwiftLint.
+# Reads the hook payload (JSON) on stdin, extracts the file path, and runs `swiftlint`
+# when the file is Swift and the binary is available. On violations, prints them to
+# stderr and exits 2 so Claude Code feeds them back to the model for self-correction.
+
+f=$(jq -r '.tool_input.file_path')
+case "$f" in
+    *.swift) ;;
+    *) exit 0 ;;
+esac
+
+command -v swiftlint >/dev/null 2>&1 || exit 0
+
+out=$(swiftlint lint --quiet "$f" 2>&1)
+if [ -n "$out" ]; then
+    echo "$out" >&2
+    exit 2
+fi


### PR DESCRIPTION
Claude Code does not always follow the rules in .swiftlin.yml. Using a post edit hook to enforce the rules.