### PR TITLE
Re-implement the manage connection screen

### DIFF
--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -321,7 +321,13 @@ let package = Package(
         .testTarget(name: "WordPressCoreTests", dependencies: [.target(name: "WordPressCore")]),
         .testTarget(name: "WordPressIntelligenceTests", dependencies: [.target(name: "WordPressIntelligence")]),
         .testTarget(name: "WordPressReaderTests", dependencies: [.target(name: "WordPressReader")]),
-        .testTarget(name: "JetpackSocialTests", dependencies: [.target(name: "JetpackSocial")])
+        .testTarget(
+            name: "JetpackSocialTests",
+            dependencies: [
+                .target(name: "JetpackSocial"),
+                .product(name: "OHHTTPStubsSwift", package: "OHHTTPStubs")
+            ]
+        )
     ]
 )
 

--- a/Modules/Sources/JetpackSocial/Models/SocialKeyringAccount.swift
+++ b/Modules/Sources/JetpackSocial/Models/SocialKeyringAccount.swift
@@ -32,8 +32,15 @@ public struct SocialKeyringAccount: Identifiable, Hashable, Sendable {
     }
 
     /// Flattens a list of keyrings into one account row per (keyring,
-    /// external user) pair. Every keyring yields at least the primary row.
-    public static func flatten(_ keyrings: [SocialKeyringConnection]) -> [SocialKeyringAccount] {
+    /// external user) pair.
+    ///
+    /// `includesPrimary` should be `false` for services where Publicize only
+    /// targets sub-accounts (Facebook → Pages); in that case the keyring's
+    /// primary row is omitted and the result contains only additional users.
+    public static func flatten(
+        _ keyrings: [SocialKeyringConnection],
+        includesPrimary: Bool = true
+    ) -> [SocialKeyringAccount] {
         keyrings.flatMap { keyring -> [SocialKeyringAccount] in
             // The `primary:` and `user:` discriminators keep IDs unique even
             // when a keyring's externalID happens to equal an additional
@@ -54,7 +61,7 @@ public struct SocialKeyringAccount: Identifiable, Hashable, Sendable {
                     externalUserID: user.id
                 )
             }
-            return [primary] + additional
+            return includesPrimary ? [primary] + additional : additional
         }
     }
 }

--- a/Modules/Sources/JetpackSocial/Models/SocialService.swift
+++ b/Modules/Sources/JetpackSocial/Models/SocialService.swift
@@ -11,6 +11,13 @@ public struct SocialService: Identifiable, Hashable, Sendable {
     /// `AccountConfirmationView` uses this to hide the primary row from the picker.
     public let additionalUsersOnly: Bool
     public let isActive: Bool
+    /// URL to load in the WKWebView to connect a social media account in
+    /// this service to Jetpack Social.
+    ///
+    /// Optional only as a parser safety net. The `wpcom/v2/publicize/services`
+    /// schema declares `url` as a non-null string and wordpress-rs deserializes
+    /// it as `String`, so this is nil only when `URL(string:)` rejects a
+    /// malformed wire value, i.e. a server-side anomaly.
     public let connectURL: URL?
 
     public init(

--- a/Modules/Sources/JetpackSocial/Models/SocialSharingError.swift
+++ b/Modules/Sources/JetpackSocial/Models/SocialSharingError.swift
@@ -6,6 +6,11 @@ public enum SocialSharingError: Error, Sendable {
     case connectionNotFound(id: String)
     case keyringNotFound(id: Int64)
     case noKeyringForService(serviceLabel: String)
+    /// Surfaced after a successful Facebook OAuth when the keyring exposes no
+    /// Pages — Publicize cannot post to a personal Facebook profile, so the
+    /// connection cannot be completed. Distinct from `noKeyringForService` so
+    /// the UI can offer the dedicated "Learn more" link.
+    case noPagesForFacebook
     case decoding(Error)
     case unknown(Error)
 }
@@ -23,10 +28,25 @@ extension SocialSharingError: LocalizedError {
             return String.localizedStringWithFormat(Strings.Errors.keyringNotFoundFormat, String(id))
         case .noKeyringForService(let label):
             return String.localizedStringWithFormat(Strings.Errors.noKeyringForServiceFormat, label)
+        case .noPagesForFacebook:
+            return Strings.Errors.noPagesForFacebook
         case .decoding:
             return Strings.Errors.decoding
         case .unknown:
             return Strings.Errors.unknown
+        }
+    }
+}
+
+extension SocialSharingError {
+    /// URL pointing at user-facing documentation that explains how to recover
+    /// from this error, when one exists.
+    public var helpURL: URL? {
+        switch self {
+        case .noPagesForFacebook:
+            return URL(string: "https://en.support.wordpress.com/publicize/#facebook-pages")
+        default:
+            return nil
         }
     }
 }

--- a/Modules/Sources/JetpackSocial/Services/PublicizeConnectionURLMatcher.swift
+++ b/Modules/Sources/JetpackSocial/Services/PublicizeConnectionURLMatcher.swift
@@ -1,8 +1,8 @@
 import Foundation
 
 /// Used to detect whether a URL matches a particular Publicize authorization success or failure route.
-struct PublicizeConnectionURLMatcher {
-    enum MatchComponent {
+public struct PublicizeConnectionURLMatcher {
+    public enum MatchComponent {
         case verifyActionItem
         case denyActionItem
         case requestActionItem
@@ -60,7 +60,7 @@ struct PublicizeConnectionURLMatcher {
 
     /// @return True if the url matches the current authorization component
     ///
-    static func url(_ url: URL, contains matchComponent: MatchComponent) -> Bool {
+    public static func url(_ url: URL, contains matchComponent: MatchComponent) -> Bool {
         if let queryItem = matchComponent.queryItem {
             return self.url(url, contains: queryItem)
         }
@@ -100,7 +100,7 @@ struct PublicizeConnectionURLMatcher {
 
     /// Classify actions taken by the web API
     ///
-    enum AuthorizeAction: Int {
+    public enum AuthorizeAction: Int {
         case none
         case unknown
         case request
@@ -108,7 +108,7 @@ struct PublicizeConnectionURLMatcher {
         case deny
     }
 
-    static func authorizeAction(for matchURL: URL) -> AuthorizeAction {
+    public static func authorizeAction(for matchURL: URL) -> AuthorizeAction {
         // Path oauth declines are handled by a redirect to a path.com URL, so check this first.
         if url(matchURL, contains: .declinePath) {
             return .deny

--- a/Modules/Sources/JetpackSocial/Services/SiteSocialConnectionsService.swift
+++ b/Modules/Sources/JetpackSocial/Services/SiteSocialConnectionsService.swift
@@ -238,7 +238,7 @@ public final class SiteSocialConnectionsService: ObservableObject {
     }
 }
 
-private let log: Logger = Logger(label: "org.wordpress.jetpack-social")
+private let log = Logger(label: "org.wordpress.jetpack-social")
 
 private extension Task where Success == Result<[SocialConnection], SocialSharingError>, Failure == Never {
     var socialConnectionValue: [SocialConnection] {

--- a/Modules/Sources/JetpackSocial/Services/SiteSocialConnectionsService.swift
+++ b/Modules/Sources/JetpackSocial/Services/SiteSocialConnectionsService.swift
@@ -1,0 +1,254 @@
+import Foundation
+import Logging
+import WordPressAPI
+
+@MainActor
+public final class SiteSocialConnectionsService: ObservableObject {
+    @Published public private(set) var connections: SocialConnectionsState = .loading
+    @Published public private(set) var services: SocialServicesState = .loading
+    @Published public private(set) var canMarkAsShared: Bool
+
+    private let client: WPComApiClient
+    private let siteId: Int64
+
+    /// In-flight load tasks, used to coalesce concurrent callers onto a
+    /// single network request. Cleared by each task before it resolves.
+    private var loadConnectionsTask: Task<Result<[SocialConnection], SocialSharingError>, Never>?
+    private var loadServicesTask: Task<Void, Never>?
+
+    /// Per-connection correlation token, refreshed at the start of every
+    /// `updateConnection` call. The post-network state mutation is applied
+    /// only when the captured token still matches the current value, so a
+    /// late-arriving response from a superseded tap is dropped instead of
+    /// clobbering a newer one.
+    private var updateTokens: [String: UUID] = [:]
+
+    /// Only sites hosted on or connected to WP.com are supported. The
+    /// factory is responsible for not constructing this service when the
+    /// blog has no WP.com account.
+    public init(client: WPComApiClient, siteId: Int64, canMarkAsShared: Bool) {
+        self.client = client
+        self.siteId = siteId
+        self.canMarkAsShared = canMarkAsShared
+    }
+
+    public func updatePermissions(canMarkAsShared: Bool) {
+        self.canMarkAsShared = canMarkAsShared
+    }
+
+    // MARK: - Reads
+
+    @discardableResult
+    public func loadConnections(force: Bool = false) async throws(SocialSharingError) -> [SocialConnection] {
+        if !force, case .loaded(let connections) = connections {
+            return connections
+        }
+        if let inFlight = loadConnectionsTask {
+            return try await inFlight.socialConnectionValue
+        }
+        let task = Task<Result<[SocialConnection], SocialSharingError>, Never> { [weak self] in
+            guard let self else {
+                // This is defensive plumbing, not a user-facing edge case:
+                // the service was released before the coalesced load task ran.
+                let error = NSError(domain: "org.wordpress.jetpack-social", code: 1)
+                return .failure(.unknown(error))
+            }
+            do throws(SocialSharingError) {
+                return .success(try await self.runLoadConnections())
+            } catch {
+                return .failure(error)
+            }
+        }
+        loadConnectionsTask = task
+        return try await task.socialConnectionValue
+    }
+
+    private func runLoadConnections() async throws(SocialSharingError) -> [SocialConnection] {
+        defer { loadConnectionsTask = nil }
+        connections = .loading
+        do {
+            let wireResponse = try await client.publicize.listConnections(wpComSiteId: UInt64(siteId))
+            let mapped = wireResponse.data.map(SocialConnection.init(from:))
+            connections = .loaded(mapped)
+            return mapped
+        } catch {
+            let wrapped = wrap(error)
+            log.error("loadConnections failed: \(wrapped)")
+            connections = .failed(wrapped)
+            throw wrapped
+        }
+    }
+
+    public func loadServices(force: Bool = false) async {
+        if !force, case .loaded = services {
+            return
+        }
+        if let inFlight = loadServicesTask {
+            await inFlight.value
+            return
+        }
+        let task = Task<Void, Never> { [weak self] in
+            guard let self else { return }
+            await self.runLoadServices()
+        }
+        loadServicesTask = task
+        await task.value
+    }
+
+    private func runLoadServices() async {
+        defer { loadServicesTask = nil }
+        services = .loading
+        do {
+            let wireResponse = try await client.publicize.listServices(wpComSiteId: UInt64(siteId))
+            let mapped = wireResponse.data.map(SocialService.init(from:))
+            services = .loaded(mapped)
+        } catch {
+            let wrapped = wrap(error)
+            log.error("loadServices failed: \(wrapped)")
+            services = .failed(wrapped)
+        }
+    }
+
+    public func fetchKeyringConnections() async throws(SocialSharingError) -> [SocialKeyringConnection] {
+        do {
+            let wireResponse = try await client.meConnections.list()
+            return wireResponse.data.connections.map(SocialKeyringConnection.init(from:))
+        } catch {
+            let wrapped = wrap(error)
+            log.error("fetchKeyringConnections failed: \(wrapped)")
+            throw wrapped
+        }
+    }
+
+    /// Snapshot of the currently loaded connection IDs. Returns `[]` if
+    /// `connections` has not been loaded yet.
+    public func currentConnectionIDs() -> [String] {
+        connections.value?.map(\.id) ?? []
+    }
+
+    // MARK: - Mutations
+
+    @discardableResult
+    public func createConnection(
+        keyringID: Int64,
+        externalUserID: String? = nil,
+        shared: Bool? = nil
+    ) async throws(SocialSharingError) -> SocialConnection {
+        do {
+            let params = CreatePublicizeConnectionParams(
+                keyringConnectionId: keyringID,
+                externalUserId: externalUserID,
+                shared: shared
+            )
+            let wireResponse = try await client.publicize.createConnection(
+                wpComSiteId: UInt64(siteId),
+                params: params
+            )
+            let connection = SocialConnection(from: wireResponse.data)
+            appendOrReplace(connection)
+            return connection
+        } catch {
+            let wrapped = wrap(error)
+            log.error("createConnection keyringID=\(keyringID) failed: \(wrapped)")
+            throw wrapped
+        }
+    }
+
+    public func deleteConnection(id: String) async throws(SocialSharingError) {
+        do {
+            _ = try await client.publicize.deleteConnection(
+                wpComSiteId: UInt64(siteId),
+                publicizeConnectionId: id
+            )
+            remove(connectionWithID: id)
+        } catch {
+            let wrapped = wrap(error)
+            log.error("deleteConnection id=\(id) failed: \(wrapped)")
+            throw wrapped
+        }
+    }
+
+    @discardableResult
+    public func updateConnection(
+        id: String,
+        shared: Bool
+    ) async throws(SocialSharingError) -> SocialConnection {
+        let token = UUID()
+        updateTokens[id] = token
+
+        // Optimistically reflect the change in the @Published state before
+        // the network round-trip so SwiftUI can render immediately. Capture
+        // the pre-change connection for rollback on failure.
+        let rollback = findConnection(id: id)
+        if let rollback, rollback.isShared != shared {
+            var optimistic = rollback
+            optimistic.isShared = shared
+            appendOrReplace(optimistic)
+        }
+
+        do {
+            let params = UpdatePublicizeConnectionParams(shared: shared)
+            let wireResponse = try await client.publicize.updateConnection(
+                wpComSiteId: UInt64(siteId),
+                publicizeConnectionId: id,
+                params: params
+            )
+            let connection = SocialConnection(from: wireResponse.data)
+            if updateTokens[id] == token {
+                appendOrReplace(connection)
+            }
+            return connection
+        } catch {
+            let wrapped = wrap(error)
+            log.error("updateConnection id=\(id) failed: \(wrapped)")
+            if updateTokens[id] == token, let rollback {
+                appendOrReplace(rollback)
+            }
+            throw wrapped
+        }
+    }
+
+    // MARK: - State mutation helpers
+
+    private func appendOrReplace(_ connection: SocialConnection) {
+        var current = connections.value ?? []
+        if let idx = current.firstIndex(where: { $0.id == connection.id }) {
+            current[idx] = connection
+        } else {
+            current.append(connection)
+        }
+        connections = .loaded(current)
+    }
+
+    private func findConnection(id: String) -> SocialConnection? {
+        connections.value?.first(where: { $0.id == id })
+    }
+
+    private func remove(connectionWithID id: String) {
+        guard var current = connections.value else { return }
+        current.removeAll { $0.id == id }
+        connections = .loaded(current)
+    }
+
+    nonisolated private func wrap(_ error: Error) -> SocialSharingError {
+        if let already = error as? SocialSharingError {
+            return already
+        }
+        return .network(error)
+    }
+}
+
+private let log: Logger = Logger(label: "org.wordpress.jetpack-social")
+
+private extension Task where Success == Result<[SocialConnection], SocialSharingError>, Failure == Never {
+    var socialConnectionValue: [SocialConnection] {
+        get async throws(SocialSharingError) {
+            switch await value {
+            case .success(let connections):
+                return connections
+            case .failure(let error):
+                throw error
+            }
+        }
+    }
+}

--- a/Modules/Sources/JetpackSocial/Services/SocialConnectionsState.swift
+++ b/Modules/Sources/JetpackSocial/Services/SocialConnectionsState.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+public enum SocialConnectionsState: Sendable {
+    case loading
+    case loaded([SocialConnection])
+    case failed(SocialSharingError)
+
+    public var value: [SocialConnection]? {
+        if case .loaded(let v) = self { return v }
+        return nil
+    }
+
+    public var error: SocialSharingError? {
+        if case .failed(let e) = self { return e }
+        return nil
+    }
+}

--- a/Modules/Sources/JetpackSocial/Services/SocialOAuthAuthenticator.swift
+++ b/Modules/Sources/JetpackSocial/Services/SocialOAuthAuthenticator.swift
@@ -1,0 +1,20 @@
+import Foundation
+@preconcurrency import WebKit
+
+/// Authentication hook for the OAuth kick-off web view inside
+/// `JetpackSocial`. The caller seeds any cookies the wp.com
+/// authorize page needs into the web view's cookie store and returns
+/// an authenticated `URLRequest` ready to load.
+///
+/// `WKHTTPCookieStore` is exposed directly because the app's existing
+/// `CookieJar` protocol (in `WordPress/Classes/Utility/WebViewController/
+/// CookieJar.swift`) already has a `CookieJar` conformance on it — the
+/// app-side adapter can pass the store straight through to
+/// `RequestAuthenticator.request(url:cookieJar:completion:)` without
+/// any wrapping type.
+public protocol SocialOAuthAuthenticator: Sendable {
+    func authenticatedRequest(
+        for url: URL,
+        into cookieStore: WKHTTPCookieStore
+    ) async -> URLRequest
+}

--- a/Modules/Sources/JetpackSocial/Services/SocialServicesState.swift
+++ b/Modules/Sources/JetpackSocial/Services/SocialServicesState.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+public enum SocialServicesState: Sendable {
+    case loading
+    case loaded([SocialService])
+    case failed(SocialSharingError)
+
+    public var value: [SocialService]? {
+        if case .loaded(let v) = self { return v }
+        return nil
+    }
+
+    public var error: SocialSharingError? {
+        if case .failed(let e) = self { return e }
+        return nil
+    }
+}

--- a/Modules/Sources/JetpackSocial/Strings/Strings.swift
+++ b/Modules/Sources/JetpackSocial/Strings/Strings.swift
@@ -33,6 +33,20 @@ public enum Strings {
                 "Error when the WP.com account has no authorized keyring for a given service. %1$@ is the service label (e.g. 'Mastodon')."
         )
 
+        public static let noPagesForFacebook = NSLocalizedString(
+            "jetpackSocial.error.noPagesForFacebook",
+            value:
+                "The Facebook connection cannot find any Pages. Publicize cannot connect to Facebook Profiles, only published Pages.",
+            comment:
+                "Error shown after Facebook OAuth when the user's account doesn't manage any Facebook Pages, since Publicize only targets Pages."
+        )
+
+        public static let learnMore = NSLocalizedString(
+            "jetpackSocial.error.learnMore",
+            value: "Learn more",
+            comment: "Link label that opens documentation explaining how to resolve a social sharing error."
+        )
+
         public static let decoding = NSLocalizedString(
             "jetpackSocial.error.decoding",
             value: "Received an unexpected response from the server.",
@@ -147,6 +161,21 @@ public enum Strings {
             comment: "Explanation text shown at the top of the account confirmation screen."
         )
 
+        public static let allConnectedDescription = NSLocalizedString(
+            "jetpackSocial.accountConfirmation.allConnectedDescription",
+            value:
+                "You're all set. Every available account is already connected to this site, and your new posts will be shared automatically. You can change this when writing a post.",
+            comment:
+                "Message shown at the top of the account confirmation screen when every available account is already connected to the site."
+        )
+
+        public static let done = NSLocalizedString(
+            "jetpackSocial.accountConfirmation.done",
+            value: "Done",
+            comment:
+                "Button that dismisses the account confirmation screen when every account is already connected and there is nothing to confirm."
+        )
+
         public static let markAsSharedLabel = NSLocalizedString(
             "jetpackSocial.accountConfirmation.markAsSharedLabel",
             value: "Mark the connection as shared",
@@ -228,6 +257,18 @@ public enum Strings {
             "jetpackSocial.connectionDetail.availableToAllUsersFooter",
             value: "Allow this connection to be used by all admins and users of your site.",
             comment: "Footer caption below the 'Available to all users' toggle."
+        )
+
+        public static let updateFailedTitle = NSLocalizedString(
+            "jetpackSocial.connectionDetail.updateFailedTitle",
+            value: "Couldn't Update Connection",
+            comment: "Title of the alert shown when updating a social connection setting fails."
+        )
+
+        public static let updateFailedDismiss = NSLocalizedString(
+            "jetpackSocial.connectionDetail.updateFailedDismiss",
+            value: "OK",
+            comment: "Dismiss button in the social connection update failure alert."
         )
     }
 

--- a/Modules/Sources/JetpackSocial/Views/AccountConfirmationView.swift
+++ b/Modules/Sources/JetpackSocial/Views/AccountConfirmationView.swift
@@ -1,0 +1,301 @@
+import AsyncImageKit
+import SwiftUI
+
+public struct AccountConfirmationView: View {
+    private let service: SocialService
+    @ObservedObject private var connectionsService: SiteSocialConnectionsService
+    private let onCancel: () -> Void
+    private let onFinish: (Result<SocialKeyringAccount, SocialSharingError>) -> Void
+
+    @State private var state: LoadingState = .loading
+    @State private var connectedExternalIDs: Set<String> = []
+    @State private var selectedAccountID: String?
+    @State private var sharedEnabled: Bool = true
+    @State private var submitting: Bool = false
+    @State private var submitTask: Task<Void, Never>?
+
+    public init(
+        service: SocialService,
+        connectionsService: SiteSocialConnectionsService,
+        onCancel: @escaping () -> Void,
+        onFinish: @escaping (Result<SocialKeyringAccount, SocialSharingError>) -> Void
+    ) {
+        self.service = service
+        self.connectionsService = connectionsService
+        _sharedEnabled = State(initialValue: connectionsService.canMarkAsShared)
+        self.onCancel = onCancel
+        self.onFinish = onFinish
+    }
+
+    public var body: some View {
+        Form {
+            switch state {
+            case .loading:
+                loadingSection
+            case .loaded(let accounts):
+                loadedSections(accounts: accounts)
+            case .failed(let error):
+                failureSection(error: error)
+            }
+        }
+        .disabled(submitting)
+        .overlay {
+            if submitting {
+                ZStack {
+                    Color(.systemBackground).opacity(0.7)
+                    ProgressView()
+                        .controlSize(.large)
+                }
+                .ignoresSafeArea()
+            }
+        }
+        .navigationTitle(Strings.AccountConfirmation.title)
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .cancellationAction) {
+                if #available(iOS 26.0, *) {
+                    Button(role: .cancel, action: cancel)
+                } else {
+                    Button(role: .cancel, action: cancel) {
+                        Image(systemName: "xmark")
+                    }
+                }
+            }
+        }
+        .task {
+            await load()
+        }
+    }
+
+    @MainActor
+    private func load() async {
+        state = .loading
+        do {
+            let siteConnections = try await connectionsService.loadConnections()
+            connectedExternalIDs = Set(
+                siteConnections
+                    .filter { $0.serviceName == service.id }
+                    .map(\.externalID)
+            )
+            let keyrings = try await connectionsService.fetchKeyringConnections()
+            let matching = keyrings.filter { $0.service == service.id }
+            if matching.isEmpty {
+                state = .failed(.noKeyringForService(serviceLabel: service.label))
+                return
+            }
+            let accounts = SocialKeyringAccount.flatten(
+                matching,
+                includesPrimary: !service.additionalUsersOnly
+            )
+            if accounts.isEmpty {
+                // Most commonly hit by Facebook when the user has no Pages —
+                // Publicize won't post to a personal profile, so there's no
+                // usable account to pick.
+                state = .failed(emptyAccountsError(for: service))
+                return
+            }
+            state = .loaded(accounts)
+            if selectedAccountID == nil {
+                selectedAccountID =
+                    accounts.first {
+                        !connectedExternalIDs.contains($0.externalIDForMatching)
+                    }?
+                    .id
+            }
+        } catch {
+            state = .failed(error)
+        }
+    }
+
+    @MainActor
+    private func submit(account: SocialKeyringAccount) {
+        submitting = true
+        submitTask = Task {
+            let result: Result<SocialKeyringAccount, SocialSharingError>
+            do throws(SocialSharingError) {
+                _ = try await connectionsService.createConnection(
+                    keyringID: account.keyring.id,
+                    externalUserID: account.externalUserID,
+                    shared: connectionsService.canMarkAsShared ? sharedEnabled : nil
+                )
+                result = .success(account)
+            } catch {
+                result = .failure(error)
+            }
+            guard !Task.isCancelled else { return }
+            submitting = false
+            onFinish(result)
+        }
+    }
+
+    @MainActor
+    private func cancel() {
+        submitTask?.cancel()
+        onCancel()
+    }
+
+    private var loadingSection: some View {
+        Section {
+            HStack {
+                Spacer()
+                ProgressView(Strings.AccountConfirmation.loadingMessage)
+                Spacer()
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func loadedSections(accounts: [SocialKeyringAccount]) -> some View {
+        let connectable = accounts.filter { !connectedExternalIDs.contains($0.externalIDForMatching) }
+        let connected = accounts.filter { connectedExternalIDs.contains($0.externalIDForMatching) }
+
+        Section {
+            Text(
+                connectable.isEmpty
+                    ? Strings.AccountConfirmation.allConnectedDescription
+                    : Strings.AccountConfirmation.description
+            )
+            .foregroundStyle(.primary)
+            ForEach(connectable) { account in
+                Button {
+                    selectedAccountID = account.id
+                } label: {
+                    AccountSelectableRow(
+                        account: account,
+                        isSelected: selectedAccountID == account.id
+                    )
+                }
+                .buttonStyle(.plain)
+            }
+        }
+
+        if !connected.isEmpty {
+            Section(Strings.AccountConfirmation.connectedSectionTitle) {
+                ForEach(connected) { account in
+                    AccountInfoRow(account: account)
+                }
+            }
+        }
+
+        if !connectable.isEmpty {
+            if connectionsService.canMarkAsShared {
+                Section {
+                    Toggle(Strings.AccountConfirmation.markAsSharedLabel, isOn: $sharedEnabled)
+                } footer: {
+                    Text(Strings.AccountConfirmation.markAsSharedFooter)
+                }
+            }
+
+            Section {
+                Button {
+                    if let account = currentSelection {
+                        submit(account: account)
+                    }
+                } label: {
+                    Text(Strings.AccountConfirmation.confirm)
+                        .frame(maxWidth: .infinity)
+                        .foregroundStyle(.tint)
+                }
+                .disabled(currentSelection == nil || submitting)
+            }
+        } else {
+            Section {
+                Button(action: cancel) {
+                    Text(Strings.AccountConfirmation.done)
+                        .frame(maxWidth: .infinity)
+                        .foregroundStyle(.tint)
+                }
+            }
+        }
+    }
+
+    private func failureSection(error: SocialSharingError) -> some View {
+        Section {
+            VStack(alignment: .leading, spacing: 8) {
+                Text(error.errorDescription ?? "")
+                    .foregroundStyle(.red)
+                if let url = error.helpURL {
+                    Link(Strings.Errors.learnMore, destination: url)
+                }
+                Button(Strings.AccountConfirmation.retry) {
+                    Task { await load() }
+                }
+            }
+        }
+    }
+
+    private func emptyAccountsError(for service: SocialService) -> SocialSharingError {
+        if service.id == "facebook" {
+            return .noPagesForFacebook
+        }
+        return .noKeyringForService(serviceLabel: service.label)
+    }
+
+    private var currentSelection: SocialKeyringAccount? {
+        guard let id = selectedAccountID, case .loaded(let accounts) = state else {
+            return nil
+        }
+        return accounts.first { $0.id == id }
+    }
+}
+
+private enum LoadingState {
+    case loading
+    case loaded([SocialKeyringAccount])
+    case failed(SocialSharingError)
+}
+
+private struct AccountSelectableRow: View {
+    let account: SocialKeyringAccount
+    let isSelected: Bool
+
+    var body: some View {
+        HStack(spacing: 12) {
+            KeyringAvatar(url: account.profilePictureURL)
+            Text(account.name)
+                .foregroundStyle(.primary)
+            Spacer()
+            if isSelected {
+                Image(systemName: "checkmark")
+                    .foregroundStyle(.tint)
+            }
+        }
+        .contentShape(Rectangle())
+    }
+}
+
+private struct AccountInfoRow: View {
+    let account: SocialKeyringAccount
+
+    var body: some View {
+        HStack(spacing: 12) {
+            KeyringAvatar(url: account.profilePictureURL)
+            Text(account.name)
+                .foregroundStyle(.secondary)
+            Spacer()
+        }
+    }
+}
+
+private struct KeyringAvatar: View {
+    let url: URL?
+
+    var body: some View {
+        Group {
+            if let url {
+                CachedAsyncImage(url: url) { phase in
+                    switch phase {
+                    case .success(let image):
+                        image.resizable().scaledToFill()
+                    default:
+                        Color.secondary.opacity(0.15)
+                    }
+                }
+            } else {
+                Color.secondary.opacity(0.15)
+            }
+        }
+        .frame(width: 32, height: 32)
+        .clipShape(Circle())
+    }
+}

--- a/Modules/Sources/JetpackSocial/Views/AddConnectionCoordinator.swift
+++ b/Modules/Sources/JetpackSocial/Views/AddConnectionCoordinator.swift
@@ -1,0 +1,152 @@
+import Foundation
+import Logging
+import SwiftUI
+import UIKit
+
+@MainActor
+public final class AddConnectionCoordinator {
+    private let connectionsService: SiteSocialConnectionsService
+    private let authenticator: any SocialOAuthAuthenticator
+    private weak var presenter: UIViewController?
+
+    private var navController: UINavigationController?
+    private var confirmationHost: UIHostingController<AccountConfirmationView>?
+
+    private static let log = Logger(label: "org.wordpress.jetpack-social.add-connection")
+
+    public init(
+        connectionsService: SiteSocialConnectionsService,
+        authenticator: any SocialOAuthAuthenticator,
+        presenter: UIViewController
+    ) {
+        self.connectionsService = connectionsService
+        self.authenticator = authenticator
+        self.presenter = presenter
+    }
+
+    public func start() {
+        let pickerView = SocialServicePickerView(
+            connections: connectionsService,
+            onPick: { [weak self] service in
+                self?.handlePick(service)
+            },
+            onCancel: { [weak self] in
+                self?.cancelAndDismiss()
+            }
+        )
+        let host = UIHostingController(rootView: pickerView)
+        let nav = UINavigationController(rootViewController: host)
+        nav.modalPresentationStyle = .formSheet
+        navController = nav
+        presenter?.present(nav, animated: true)
+    }
+
+    // MARK: - Forward transitions
+
+    private func handlePick(_ service: SocialService) {
+        guard let nav = navController else { return }
+        guard let connectURL = service.connectURL else {
+            Self.log.error("Social picker tapped \(service.id) but the service has no connect URL")
+            return
+        }
+        let web = SocialOAuthWebViewController(
+            startURL: connectURL,
+            serviceLabel: service.label,
+            authenticator: authenticator
+        ) { [weak self] outcome in
+            Task { @MainActor in
+                self?.handleOAuth(outcome: outcome, for: service)
+            }
+        }
+        nav.pushViewController(web, animated: true)
+    }
+
+    private func handleOAuth(
+        outcome: SocialOAuthWebViewController.Outcome,
+        for service: SocialService
+    ) {
+        switch outcome {
+        case .success:
+            pushConfirmation(for: service)
+        case .cancelled:
+            cancelAndDismiss()
+        case .failure(let error):
+            dismissAndAlertFailure(.network(error))
+        }
+    }
+
+    private func pushConfirmation(for service: SocialService) {
+        guard let nav = navController else { return }
+        let view = makeConfirmationView(for: service)
+        let host = UIHostingController(rootView: view)
+        confirmationHost = host
+        // Replace the stack (picker + OAuth) with just the confirmation screen.
+        // `hidesBackButton` is unreliable when SwiftUI also sets `.toolbar`
+        // items, and backing up into OAuth would require re-running it for no
+        // gain — so there is nothing to back to, and Cancel is the only exit.
+        nav.setViewControllers([host], animated: true)
+    }
+
+    private func makeConfirmationView(for service: SocialService) -> AccountConfirmationView {
+        AccountConfirmationView(
+            service: service,
+            connectionsService: connectionsService,
+            onCancel: { [weak self] in
+                self?.cancelAndDismiss()
+            },
+            onFinish: { [weak self] result in
+                guard let self else { return }
+                switch result {
+                case .success:
+                    self.dismissNav()
+                case .failure(let error):
+                    self.dismissAndAlertFailure(error)
+                }
+            }
+        )
+    }
+
+    // MARK: - Dismissal
+
+    private func cancelAndDismiss() {
+        dismissNav()
+    }
+
+    private func dismissAndAlertFailure(_ error: SocialSharingError) {
+        dismissNav { [weak self] in
+            self?.presentFailureAlert(error: error)
+        }
+    }
+
+    private func dismissNav(_ completion: (() -> Void)? = nil) {
+        confirmationHost = nil
+        let nav = navController
+        navController = nil
+        nav?.dismiss(animated: true, completion: completion)
+    }
+
+    private func presentFailureAlert(error: SocialSharingError) {
+        guard let presenter else { return }
+        let alert = UIAlertController(
+            title: Strings.ServiceDetail.failureAlertTitle,
+            message: error.errorDescription,
+            preferredStyle: .alert
+        )
+        alert.addAction(
+            UIAlertAction(
+                title: Strings.ServiceDetail.failureAlertRetry,
+                style: .default,
+                handler: { [weak self] _ in
+                    self?.start()
+                }
+            )
+        )
+        alert.addAction(
+            UIAlertAction(
+                title: Strings.ServiceDetail.failureAlertCancel,
+                style: .cancel
+            )
+        )
+        presenter.present(alert, animated: true)
+    }
+}

--- a/Modules/Sources/JetpackSocial/Views/ManageConnectionsHostingController.swift
+++ b/Modules/Sources/JetpackSocial/Views/ManageConnectionsHostingController.swift
@@ -1,0 +1,43 @@
+import Foundation
+import SwiftUI
+import UIKit
+
+@MainActor
+public final class ManageConnectionsHostingController: UIHostingController<AnyView> {
+    private let connectionsService: SiteSocialConnectionsService
+    private let authenticator: any SocialOAuthAuthenticator
+    private var addCoordinator: AddConnectionCoordinator?
+
+    public init(
+        connectionsService: SiteSocialConnectionsService,
+        authenticator: any SocialOAuthAuthenticator
+    ) {
+        self.connectionsService = connectionsService
+        self.authenticator = authenticator
+        super.init(rootView: AnyView(EmptyView()))
+
+        rootView = AnyView(
+            ManageSocialConnectionsView(
+                connections: connectionsService,
+                onAddConnection: { [weak self] in
+                    self?.presentAdd()
+                }
+            )
+        )
+    }
+
+    @preconcurrency required dynamic init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func presentAdd() {
+        let coordinator = AddConnectionCoordinator(
+            connectionsService: connectionsService,
+            authenticator: authenticator,
+            presenter: self
+        )
+        // Strong reference keeps the coordinator alive during the OAuth flow.
+        addCoordinator = coordinator
+        coordinator.start()
+    }
+}

--- a/Modules/Sources/JetpackSocial/Views/ManageSocialConnectionsView.swift
+++ b/Modules/Sources/JetpackSocial/Views/ManageSocialConnectionsView.swift
@@ -1,0 +1,97 @@
+import SwiftUI
+
+public struct ManageSocialConnectionsView: View {
+    @ObservedObject private var connections: SiteSocialConnectionsService
+    private let onAddConnection: () -> Void
+
+    public init(
+        connections: SiteSocialConnectionsService,
+        onAddConnection: @escaping () -> Void
+    ) {
+        self.connections = connections
+        self.onAddConnection = onAddConnection
+    }
+
+    public var body: some View {
+        Form {
+            connectionsSection
+            errorSection
+        }
+        .navigationTitle(Strings.ManageConnections.navigationTitle)
+        .task {
+            _ = try? await connections.loadConnections(force: false)
+        }
+        .refreshable {
+            _ = try? await connections.loadConnections(force: true)
+        }
+    }
+
+    @ViewBuilder
+    private var connectionsSection: some View {
+        Section {
+            connectionsRows
+            connectRow
+        } header: {
+            Text(Strings.ManageConnections.connectedHeader)
+        } footer: {
+            Text(Strings.ManageConnections.connectedFooter)
+        }
+    }
+
+    @ViewBuilder
+    private var connectionsRows: some View {
+        switch connections.connections {
+        case .loading:
+            loadingRow
+        case .loaded(let list):
+            ForEach(list) { connection in
+                NavigationLink {
+                    SocialConnectionDetailView(
+                        connection: connection,
+                        connections: connections
+                    )
+                } label: {
+                    SocialConnectionRow(connection: connection)
+                }
+            }
+        case .failed:
+            EmptyView()
+        }
+    }
+
+    private var loadingRow: some View {
+        HStack {
+            Spacer()
+            ProgressView()
+            Spacer()
+        }
+    }
+
+    private var connectRow: some View {
+        Button {
+            onAddConnection()
+        } label: {
+            Text(Strings.ManageConnections.connectNewAccount)
+                .foregroundStyle(.tint)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+
+    @ViewBuilder
+    private var errorSection: some View {
+        if let error = connections.connections.error {
+            Section {
+                VStack(alignment: .leading, spacing: 8) {
+                    Text(error.errorDescription ?? "")
+                        .foregroundStyle(.red)
+                    Button(Strings.ManageConnections.retry) {
+                        Task { _ = try? await connections.loadConnections(force: true) }
+                    }
+                }
+            }
+        }
+    }
+
+}

--- a/Modules/Sources/JetpackSocial/Views/SocialConnectionDetailView.swift
+++ b/Modules/Sources/JetpackSocial/Views/SocialConnectionDetailView.swift
@@ -42,6 +42,7 @@ public struct SocialConnectionDetailView: View {
                 ZStack {
                     Color(.systemBackground).opacity(0.7)
                     ProgressView()
+                        .controlSize(.large)
                 }
                 .ignoresSafeArea()
             }

--- a/Modules/Sources/JetpackSocial/Views/SocialConnectionDetailView.swift
+++ b/Modules/Sources/JetpackSocial/Views/SocialConnectionDetailView.swift
@@ -1,0 +1,134 @@
+import SwiftUI
+
+public struct SocialConnectionDetailView: View {
+    let connection: SocialConnection
+    @ObservedObject var connections: SiteSocialConnectionsService
+
+    @Environment(\.dismiss) private var dismiss
+    @State private var pendingDeletion = false
+    @State private var isDeleting = false
+    @State private var isUpdatingShared = false
+    @State private var failureAlert: FailureAlert?
+
+    public var body: some View {
+        Form {
+            if let current {
+                if connections.canMarkAsShared {
+                    Section {
+                        Toggle(isOn: sharedBinding(for: current)) {
+                            Text(Strings.ConnectionDetail.availableToAllUsers)
+                        }
+                        .disabled(isUpdatingShared)
+                    } header: {
+                        Text(Strings.ConnectionDetail.settingsHeader)
+                    } footer: {
+                        Text(Strings.ConnectionDetail.availableToAllUsersFooter)
+                    }
+                }
+
+                Section {
+                    Button(role: .destructive) {
+                        pendingDeletion = true
+                    } label: {
+                        Text(Strings.ManageConnections.deleteButton)
+                            .frame(maxWidth: .infinity)
+                    }
+                }
+            }
+        }
+        .disabled(isDeleting)
+        .overlay {
+            if isDeleting {
+                ZStack {
+                    Color(.systemBackground).opacity(0.7)
+                    ProgressView()
+                }
+                .ignoresSafeArea()
+            }
+        }
+        .navigationTitle(handleTitle)
+        .navigationBarTitleDisplayMode(.inline)
+        .alert(
+            String.localizedStringWithFormat(
+                Strings.ManageConnections.deleteConfirmTitleFormat,
+                connection.displayName
+            ),
+            isPresented: $pendingDeletion
+        ) {
+            Button(Strings.ManageConnections.cancelButton, role: .cancel) {}
+            Button(Strings.ManageConnections.yesButton, role: .destructive) {
+                Task {
+                    isDeleting = true
+                    do throws(SocialSharingError) {
+                        try await connections.deleteConnection(id: connection.id)
+                        // Success: the service removes the connection from
+                        // its @Published list, and `.onChange(of: currentId == nil)`
+                        // auto-dismisses this view.
+                    } catch {
+                        failureAlert = FailureAlert(
+                            title: Strings.ManageConnections.deleteFailedTitle,
+                            dismissButton: Strings.ManageConnections.deleteFailedDismiss,
+                            error: error
+                        )
+                    }
+                    isDeleting = false
+                }
+            }
+        }
+        .alert(item: $failureAlert) { alert in
+            Alert(
+                title: Text(alert.title),
+                message: Text(alert.error.errorDescription ?? ""),
+                dismissButton: .cancel(Text(alert.dismissButton))
+            )
+        }
+        .onChange(of: currentId == nil) { _, missing in
+            if missing {
+                dismiss()
+            }
+        }
+    }
+
+    /// The current server-confirmed connection, looked up fresh on every render.
+    /// Nil when the connection has been deleted (triggers auto-dismiss).
+    private var current: SocialConnection? {
+        (connections.connections.value ?? []).first(where: { $0.id == connection.id })
+    }
+
+    private var currentId: String? {
+        current?.id
+    }
+
+    private var handleTitle: String {
+        current?.externalHandle ?? connection.externalHandle ?? connection.displayName
+    }
+
+    private func sharedBinding(for connection: SocialConnection) -> Binding<Bool> {
+        Binding(
+            get: { connection.isShared },
+            set: { newValue in
+                guard !isUpdatingShared else { return }
+                isUpdatingShared = true
+                Task {
+                    defer { isUpdatingShared = false }
+                    do throws(SocialSharingError) {
+                        try await connections.updateConnection(id: connection.id, shared: newValue)
+                    } catch {
+                        failureAlert = FailureAlert(
+                            title: Strings.ConnectionDetail.updateFailedTitle,
+                            dismissButton: Strings.ConnectionDetail.updateFailedDismiss,
+                            error: error
+                        )
+                    }
+                }
+            }
+        )
+    }
+}
+
+private struct FailureAlert: Identifiable {
+    let id = UUID()
+    let title: String
+    let dismissButton: String
+    let error: SocialSharingError
+}

--- a/Modules/Sources/JetpackSocial/Views/SocialConnectionRow.swift
+++ b/Modules/Sources/JetpackSocial/Views/SocialConnectionRow.swift
@@ -1,0 +1,71 @@
+import SwiftUI
+
+struct SocialConnectionRow: View {
+    let connection: SocialConnection
+
+    var body: some View {
+        HStack(spacing: 12) {
+            avatar
+            VStack(alignment: .leading, spacing: 2) {
+                Text(connection.displayName)
+                    .font(.body)
+                HStack(spacing: 6) {
+                    Text(connection.serviceLabel)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    if connection.isShared {
+                        Text(Strings.ManageConnections.sharedBadge)
+                            .font(.caption2)
+                            .padding(.horizontal, 6)
+                            .padding(.vertical, 2)
+                            .background(Color.secondary.opacity(0.15), in: Capsule())
+                    }
+                }
+            }
+            Spacer()
+            if connection.status.isBroken {
+                Text(Strings.ManageConnections.brokenStatus)
+                    .font(.caption)
+                    .foregroundStyle(.red)
+            }
+        }
+    }
+
+    private var avatar: some View {
+        profileImage
+            .frame(width: 42, height: 42)
+            .clipShape(Circle())
+            .overlay(alignment: .bottomTrailing) {
+                serviceBadge
+                    .offset(x: 4, y: 4)
+            }
+    }
+
+    @ViewBuilder
+    private var profileImage: some View {
+        if let url = connection.profilePictureURL {
+            AsyncImage(url: url) { phase in
+                switch phase {
+                case .success(let image):
+                    image.resizable().scaledToFill()
+                default:
+                    Color.secondary.opacity(0.15)
+                }
+            }
+        } else {
+            Color.secondary.opacity(0.15)
+        }
+    }
+
+    @ViewBuilder
+    private var serviceBadge: some View {
+        if let icon = SocialServiceIcon.image(forServiceID: connection.serviceName) {
+            icon
+                .resizable()
+                .scaledToFit()
+                .frame(width: 18, height: 18)
+                .padding(2)
+                .background(Circle().fill(Color(.systemBackground)))
+        }
+    }
+}

--- a/Modules/Sources/JetpackSocial/Views/SocialOAuthWebViewController.swift
+++ b/Modules/Sources/JetpackSocial/Views/SocialOAuthWebViewController.swift
@@ -1,0 +1,227 @@
+import Logging
+import UIKit
+@preconcurrency import WebKit
+import WordPressShared
+
+/// A minimal `WKWebView` host for the Publicize OAuth kick-off flow.
+///
+/// Navigation routing is delegated to
+/// `PublicizeConnectionURLMatcher.authorizeAction(for:)`, which handles
+/// every wp.com Publicize service (Mastodon, Bluesky, Facebook, LinkedIn, …).
+///
+/// Success is fired from `didFinish` after the `action=verify` URL loads,
+/// because the wp.com server needs that request to actually complete in
+/// order to persist the keyring record; cancelling the navigation earlier
+/// would leave the user staring at a "request couldn't be completed" page.
+public final class SocialOAuthWebViewController: UIViewController, WKNavigationDelegate {
+    public enum Outcome: Sendable {
+        case success
+        case cancelled
+        case failure(Error)
+    }
+
+    private let startURL: URL
+    private let serviceLabel: String
+    private let authenticator: any SocialOAuthAuthenticator
+    private let onOutcome: (Outcome) -> Void
+
+    private var loadingVerify = false
+    private var didReport = false
+
+    private let titleLabel = UILabel()
+    private let hostLabel = UILabel()
+    private let progressView = UIProgressView(progressViewStyle: .bar)
+    private var kvoObservations: [NSKeyValueObservation] = []
+
+    private static let log = Logger(label: "org.wordpress.jetpack-social.oauth-webview")
+
+    public init(
+        startURL: URL,
+        serviceLabel: String,
+        authenticator: any SocialOAuthAuthenticator,
+        onOutcome: @escaping (Outcome) -> Void
+    ) {
+        self.startURL = startURL
+        self.serviceLabel = serviceLabel
+        self.authenticator = authenticator
+        self.onOutcome = onOutcome
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    private var defaultTitle: String {
+        String.localizedStringWithFormat(Strings.OAuthWebView.connectTitleFormat, serviceLabel)
+    }
+
+    @available(*, unavailable)
+    public required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    public override func viewDidLoad() {
+        super.viewDidLoad()
+
+        view.backgroundColor = .systemBackground
+
+        // A non-persistent data store keeps OAuth cookies local to this
+        // webview instance. Persisting them across attempts leaks
+        // half-finished session state into subsequent retries, which for
+        // services like Mastodon surfaces as a 404 after Authorize.
+        let configuration = WKWebViewConfiguration()
+        configuration.websiteDataStore = .nonPersistent()
+        let web = WKWebView(frame: .zero, configuration: configuration)
+        web.translatesAutoresizingMaskIntoConstraints = false
+        web.navigationDelegate = self
+        web.customUserAgent = WPUserAgent.wordPress()
+        view.addSubview(web)
+        NSLayoutConstraint.activate([
+            web.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            web.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            web.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            web.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+        ])
+
+        configureTitleView()
+        configureProgressView(on: web)
+        observeWebView(web)
+
+        let cookieStore = web.configuration.websiteDataStore.httpCookieStore
+        Task { [weak self, weak web] in
+            guard let self else { return }
+            let request = await self.authenticator.authenticatedRequest(
+                for: self.startURL,
+                into: cookieStore
+            )
+            await MainActor.run { [weak web] in web?.load(request) }
+        }
+    }
+
+    private func report(_ outcome: Outcome) {
+        guard !didReport else { return }
+        didReport = true
+        onOutcome(outcome)
+    }
+
+    private func dismissSelf() {
+        if let navigationController {
+            navigationController.dismiss(animated: true)
+        } else {
+            dismiss(animated: true)
+        }
+    }
+
+    // MARK: - Navigation bar title + progress
+
+    private func configureTitleView() {
+        titleLabel.font = .preferredFont(forTextStyle: .headline)
+        titleLabel.textAlignment = .center
+        titleLabel.lineBreakMode = .byTruncatingTail
+        titleLabel.text = defaultTitle
+
+        hostLabel.font = .preferredFont(forTextStyle: .caption2)
+        hostLabel.textColor = .secondaryLabel
+        hostLabel.textAlignment = .center
+        hostLabel.lineBreakMode = .byTruncatingTail
+        hostLabel.text = startURL.host
+
+        let stack = UIStackView(arrangedSubviews: [titleLabel, hostLabel])
+        stack.axis = .vertical
+        stack.alignment = .center
+        stack.spacing = 0
+        navigationItem.titleView = stack
+    }
+
+    private func configureProgressView(on webView: WKWebView) {
+        progressView.translatesAutoresizingMaskIntoConstraints = false
+        progressView.isHidden = true
+        view.addSubview(progressView)
+        NSLayoutConstraint.activate([
+            progressView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            progressView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            progressView.trailingAnchor.constraint(equalTo: view.trailingAnchor)
+        ])
+    }
+
+    private func observeWebView(_ webView: WKWebView) {
+        kvoObservations.append(
+            webView.observe(\.estimatedProgress, options: [.new]) { [weak self] web, _ in
+                Task { @MainActor [weak self] in
+                    self?.updateProgress(Float(web.estimatedProgress))
+                }
+            }
+        )
+        kvoObservations.append(
+            webView.observe(\.title, options: [.new]) { [weak self] web, _ in
+                Task { @MainActor [weak self] in
+                    guard let self else { return }
+                    let pageTitle = web.title ?? ""
+                    self.titleLabel.text = pageTitle.isEmpty ? self.defaultTitle : pageTitle
+                }
+            }
+        )
+        kvoObservations.append(
+            webView.observe(\.url, options: [.new]) { [weak self] web, _ in
+                Task { @MainActor [weak self] in
+                    self?.hostLabel.text = web.url?.host ?? self?.startURL.host
+                }
+            }
+        )
+    }
+
+    private func updateProgress(_ progress: Float) {
+        progressView.progress = progress
+        progressView.isHidden = progress >= 1.0 || progress <= 0.0
+    }
+
+    // MARK: - WKNavigationDelegate
+
+    public func webView(
+        _ webView: WKWebView,
+        decidePolicyFor navigationAction: WKNavigationAction
+    ) async -> WKNavigationActionPolicy {
+        // Prevent a second verify load by someone happy-clicking.
+        guard !loadingVerify, let url = navigationAction.request.url else {
+            return .cancel
+        }
+
+        switch PublicizeConnectionURLMatcher.authorizeAction(for: url) {
+        case .none, .unknown, .request:
+            return .allow
+        case .verify:
+            loadingVerify = true
+            return .allow
+        case .deny:
+            report(.cancelled)
+            dismissSelf()
+            return .cancel
+        }
+    }
+
+    public func webView(
+        _ webView: WKWebView,
+        didFailProvisionalNavigation navigation: WKNavigation!,
+        withError error: Error
+    ) {
+        let nsError = error as NSError
+        // Some services (historically Facebook, Twitter) return a spurious
+        // `NSURLErrorCancelled` during the verify step even though the
+        // connection actually succeeded on the server. Treat that as success.
+        if loadingVerify && nsError.code == NSURLErrorCancelled {
+            report(.success)
+            return
+        }
+        Self.log.error(
+            "OAuth navigation failed: url=\(webView.url?.absoluteString ?? "nil") domain=\(nsError.domain) code=\(nsError.code) description=\(nsError.localizedDescription)"
+        )
+        report(.failure(error))
+    }
+
+    public func webViewWebContentProcessDidTerminate(_ webView: WKWebView) {
+        Self.log.error("OAuth web content process terminated: url=\(webView.url?.absoluteString ?? "nil")")
+    }
+
+    public func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+        if loadingVerify {
+            report(.success)
+        }
+    }
+}

--- a/Modules/Sources/JetpackSocial/Views/SocialServiceIcon.swift
+++ b/Modules/Sources/JetpackSocial/Views/SocialServiceIcon.swift
@@ -1,0 +1,35 @@
+import SwiftUI
+
+/// Resolves the icon for a Publicize service using assets shipped inside the
+/// JetpackSocial bundle. Returns `nil` when no icon is available — callers
+/// should gracefully omit the icon in that case.
+///
+/// Asset names use the `publicize-` prefix so they don't collide with the
+/// main app's `social-*` assets if both bundles are loaded.
+enum SocialServiceIcon {
+    static func image(forServiceID serviceID: String) -> Image? {
+        let normalized = serviceID.lowercased().replacingOccurrences(of: "_", with: "-")
+        let mapped = alias(for: normalized) ?? normalized
+        return loadImage(name: "publicize-\(mapped)")
+            ?? loadImage(name: "publicize-default")
+    }
+
+    private static func alias(for serviceID: String) -> String? {
+        switch serviceID {
+        case "google-plus-1": return "google-plus"
+        case "press-this": return "wordpress"
+        default: return nil
+        }
+    }
+
+    private static func loadImage(name: String) -> Image? {
+        // SwiftUI's `Image(_:bundle:)` returns non-optional and renders a
+        // placeholder for missing assets, so probe via UIImage to detect
+        // existence first; UIKit caches the lookup, so the discarded
+        // instance is cheap.
+        guard UIImage(named: name, in: .module, with: nil) != nil else {
+            return nil
+        }
+        return Image(name, bundle: .module)
+    }
+}

--- a/Modules/Sources/JetpackSocial/Views/SocialServicePickerView.swift
+++ b/Modules/Sources/JetpackSocial/Views/SocialServicePickerView.swift
@@ -1,0 +1,111 @@
+import SwiftUI
+
+public struct SocialServicePickerView: View {
+    @ObservedObject private var connections: SiteSocialConnectionsService
+    private let onPick: (SocialService) -> Void
+    private let onCancel: () -> Void
+
+    public init(
+        connections: SiteSocialConnectionsService,
+        onPick: @escaping (SocialService) -> Void,
+        onCancel: @escaping () -> Void
+    ) {
+        self.connections = connections
+        self.onPick = onPick
+        self.onCancel = onCancel
+    }
+
+    public var body: some View {
+        Form {
+            content
+        }
+        .navigationTitle(Strings.ServicePicker.navigationTitle)
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .cancellationAction) {
+                if #available(iOS 26.0, *) {
+                    Button(role: .cancel, action: onCancel)
+                } else {
+                    Button(role: .cancel, action: onCancel) {
+                        Image(systemName: "xmark")
+                    }
+                }
+            }
+        }
+        .task {
+            await connections.loadServices(force: false)
+        }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        switch connections.services {
+        case .loading:
+            loadingSection
+        case .loaded(let services):
+            loadedSection(services: services)
+        case .failed(let error):
+            failureSection(error: error)
+        }
+    }
+
+    private var loadingSection: some View {
+        Section {
+            HStack {
+                Spacer()
+                ProgressView()
+                Spacer()
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func loadedSection(services: [SocialService]) -> some View {
+        let visible = services.filter(\.isActive)
+        Section {
+            ForEach(visible) { service in
+                Button {
+                    onPick(service)
+                } label: {
+                    HStack(spacing: 12) {
+                        icon(for: service)
+                        Text(service.label)
+                            .foregroundStyle(.primary)
+                        Spacer()
+                    }
+                    .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+            }
+        } footer: {
+            Text(Strings.ManageConnections.footer)
+        }
+    }
+
+    private func failureSection(error: SocialSharingError) -> some View {
+        Section {
+            VStack(alignment: .leading, spacing: 8) {
+                Text(error.errorDescription ?? "")
+                    .foregroundStyle(.red)
+                Button(Strings.ManageConnections.retry) {
+                    Task { await connections.loadServices(force: true) }
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func icon(for service: SocialService) -> some View {
+        if let image = SocialServiceIcon.image(forServiceID: service.id) {
+            image
+                .resizable()
+                .scaledToFit()
+                .frame(width: 28, height: 28)
+                .clipShape(RoundedRectangle(cornerRadius: 6))
+        } else {
+            RoundedRectangle(cornerRadius: 6)
+                .fill(Color.secondary.opacity(0.15))
+                .frame(width: 28, height: 28)
+        }
+    }
+}

--- a/Modules/Tests/JetpackSocialTests/SiteSocialConnectionsServiceTests.swift
+++ b/Modules/Tests/JetpackSocialTests/SiteSocialConnectionsServiceTests.swift
@@ -1,0 +1,241 @@
+import Foundation
+import OHHTTPStubs
+import OHHTTPStubsSwift
+import Testing
+import WordPressAPI
+@testable import JetpackSocial
+
+@Suite("SiteSocialConnectionsService initial state", .serialized)
+struct SiteSocialConnectionsServiceTests {
+    @Test("currentConnectionIDs is empty before loading")
+    @MainActor
+    func emptyBeforeLoad() {
+        let client = WPComApiClient(authentication: .none)
+        let service = SiteSocialConnectionsService(
+            client: client,
+            siteId: 1,
+            canMarkAsShared: false
+        )
+        #expect(service.currentConnectionIDs().isEmpty)
+    }
+
+    @Test("connections starts in loading state")
+    @MainActor
+    func connectionsLoadingOnInit() {
+        let client = WPComApiClient(authentication: .none)
+        let service = SiteSocialConnectionsService(
+            client: client,
+            siteId: 1,
+            canMarkAsShared: false
+        )
+        if case .loading = service.connections {
+        } else {
+            Issue.record("Expected .loading, got \(service.connections)")
+        }
+    }
+
+    @Test("shared permission can be initialized and refreshed")
+    @MainActor
+    func sharedPermissionCanBeInitializedAndRefreshed() {
+        let client = WPComApiClient(authentication: .none)
+        let service = SiteSocialConnectionsService(
+            client: client,
+            siteId: 1,
+            canMarkAsShared: false
+        )
+        #expect(!service.canMarkAsShared)
+
+        service.updatePermissions(canMarkAsShared: true)
+
+        #expect(service.canMarkAsShared)
+    }
+
+    @Test("loadConnections returns the loaded site connections")
+    @MainActor
+    func loadConnectionsReturnsLoadedConnections() async throws {
+        defer { HTTPStubs.removeAllStubs() }
+        let requestRecorder = RequestRecorder()
+        stubPublicizeConnections(
+            requestRecorder: requestRecorder,
+            responseObject: [connectionResponse(shared: false)]
+        )
+        let service = makeService()
+
+        let connections = try await service.loadConnections()
+
+        #expect(requestRecorder.didReceiveRequest)
+        #expect(connections.map(\.externalID) == ["ext-42"])
+        #expect(connections.map(\.serviceName) == ["mastodon"])
+    }
+
+    @Test("loadConnections throws when the site connection list cannot load")
+    @MainActor
+    func loadConnectionsThrowsWhenConnectionsFailToLoad() async {
+        defer { HTTPStubs.removeAllStubs() }
+        let requestRecorder = RequestRecorder()
+        stubPublicizeConnections(
+            requestRecorder: requestRecorder,
+            statusCode: 500,
+            responseObject: [
+                "code": "rest_forbidden",
+                "message": "Forbidden",
+                "data": ["status": 500]
+            ]
+        )
+        let service = makeService()
+
+        do throws(SocialSharingError) {
+            _ = try await service.loadConnections()
+            Issue.record("Expected loading connections to throw")
+        } catch {
+            #expect(requestRecorder.didReceiveRequest)
+            if case .network = error {
+                return
+            }
+            Issue.record("Expected .network, got \(error)")
+        }
+    }
+
+    @Test("updateConnection keeps the server-confirmed shared state on success")
+    @MainActor
+    func updateConnectionKeepsServerConfirmedSharedStateOnSuccess() async throws {
+        defer { HTTPStubs.removeAllStubs() }
+        let updateRecorder = RequestRecorder()
+        stubPublicizeConnections(
+            requestRecorder: RequestRecorder(),
+            responseObject: [connectionResponse(shared: false)]
+        )
+        stubUpdatePublicizeConnection(
+            requestRecorder: updateRecorder,
+            responseObject: connectionResponse(shared: true)
+        )
+        let service = makeService()
+        _ = try await service.loadConnections()
+
+        let updated = try await service.updateConnection(id: "123", shared: true)
+
+        #expect(updateRecorder.didReceiveRequest)
+        #expect(updated.isShared)
+        #expect(service.connections.value?.first?.isShared == true)
+    }
+
+    @Test("updateConnection rolls back shared state and throws on failure")
+    @MainActor
+    func updateConnectionRollsBackSharedStateAndThrowsOnFailure() async throws {
+        defer { HTTPStubs.removeAllStubs() }
+        let updateRecorder = RequestRecorder()
+        stubPublicizeConnections(
+            requestRecorder: RequestRecorder(),
+            responseObject: [connectionResponse(shared: false)]
+        )
+        stubUpdatePublicizeConnection(
+            requestRecorder: updateRecorder,
+            statusCode: 500,
+            responseObject: [
+                "code": "rest_forbidden",
+                "message": "Forbidden",
+                "data": ["status": 500]
+            ]
+        )
+        let service = makeService()
+        _ = try await service.loadConnections()
+
+        do throws(SocialSharingError) {
+            _ = try await service.updateConnection(id: "123", shared: true)
+            Issue.record("Expected updating the connection to throw")
+        } catch {
+            #expect(updateRecorder.didReceiveRequest)
+            #expect(service.connections.value?.first?.isShared == false)
+            if case .network = error {
+                return
+            }
+            Issue.record("Expected .network, got \(error)")
+        }
+    }
+
+}
+
+@MainActor
+private func makeService() -> SiteSocialConnectionsService {
+    let client = WPComApiClient(authentication: .none)
+    return SiteSocialConnectionsService(
+        client: client,
+        siteId: 1,
+        canMarkAsShared: false
+    )
+}
+
+private func stubPublicizeConnections(
+    requestRecorder: RequestRecorder,
+    statusCode: Int = 200,
+    responseObject: Any
+) {
+    stub(
+        condition: isHost("public-api.wordpress.com")
+            && isMethodGET()
+            && isPath("/wpcom/v2/sites/1/publicize/connections")
+    ) { request in
+        requestRecorder.record(request)
+        return HTTPStubsResponse(
+            jsonObject: responseObject,
+            statusCode: Int32(statusCode),
+            headers: ["Content-Type": "application/json"]
+        )
+    }
+}
+
+private func stubUpdatePublicizeConnection(
+    requestRecorder: RequestRecorder,
+    statusCode: Int = 200,
+    responseObject: Any
+) {
+    stub(
+        condition: isHost("public-api.wordpress.com")
+            && isMethodPOST()
+            && isPath("/wpcom/v2/sites/1/publicize/connections/123")
+    ) { request in
+        requestRecorder.record(request)
+        return HTTPStubsResponse(
+            jsonObject: responseObject,
+            statusCode: Int32(statusCode),
+            headers: ["Content-Type": "application/json"]
+        )
+    }
+}
+
+private func connectionResponse(shared: Bool) -> [String: Any] {
+    [
+        "connection_id": "123",
+        "display_name": "Tony Li",
+        "external_handle": "@tony",
+        "external_id": "ext-42",
+        "profile_link": "https://example.com/tony",
+        "profile_picture": "https://example.com/tony.jpg",
+        "service_label": "Mastodon",
+        "service_name": "mastodon",
+        "shared": shared,
+        "status": "ok",
+        "wpcom_user_id": 67890,
+        "id": "123",
+        "username": "tony",
+        "profile_display_name": "Tony Li",
+        "global": false
+    ]
+}
+
+private final class RequestRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var request: URLRequest?
+
+    var didReceiveRequest: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return request != nil
+    }
+
+    func record(_ request: URLRequest) {
+        lock.lock()
+        self.request = request
+        lock.unlock()
+    }
+}

--- a/Modules/Tests/JetpackSocialTests/SocialKeyringAccountTests.swift
+++ b/Modules/Tests/JetpackSocialTests/SocialKeyringAccountTests.swift
@@ -66,4 +66,22 @@ struct SocialKeyringAccountTests {
         #expect(accounts[0].id == "42:primary:prim")
         #expect(accounts[1].id == "42:user:x-1")
     }
+
+    @Test("flatten with includesPrimary=false drops the primary row")
+    func flattenWithoutPrimary() {
+        let page = AdditionalExternalUser(id: "page-1", name: "My Page", description: nil, profilePictureURL: nil)
+        let keyring = makeKeyring(additional: [page])
+        let accounts = SocialKeyringAccount.flatten([keyring], includesPrimary: false)
+        #expect(accounts.count == 1)
+        let account = try! #require(accounts.first)
+        #expect(account.externalUserID == "page-1")
+        #expect(account.name == "My Page")
+    }
+
+    @Test("flatten with includesPrimary=false on a keyring with no additional users yields no rows")
+    func flattenWithoutPrimaryAndNoAdditional() {
+        let keyring = makeKeyring()
+        let accounts = SocialKeyringAccount.flatten([keyring], includesPrimary: false)
+        #expect(accounts.isEmpty)
+    }
 }

--- a/Modules/Tests/JetpackSocialTests/SocialSharingErrorTests.swift
+++ b/Modules/Tests/JetpackSocialTests/SocialSharingErrorTests.swift
@@ -12,6 +12,7 @@ struct SocialSharingErrorTests {
             .connectionNotFound(id: "42"),
             .keyringNotFound(id: 99),
             .noKeyringForService(serviceLabel: "Mastodon"),
+            .noPagesForFacebook,
             .decoding(NSError(domain: "t", code: 2)),
             .unknown(NSError(domain: "t", code: 3))
         ]
@@ -20,5 +21,19 @@ struct SocialSharingErrorTests {
             let description = error.errorDescription ?? ""
             #expect(!description.isEmpty, "\(error) produced empty description")
         }
+    }
+
+    @Test("noPagesForFacebook exposes the Pages help URL")
+    func noPagesForFacebookHasHelpURL() {
+        let url = try! #require(SocialSharingError.noPagesForFacebook.helpURL)
+        #expect(url.absoluteString.contains("publicize"))
+        #expect(url.absoluteString.contains("facebook-pages"))
+    }
+
+    @Test("errors without dedicated help docs return nil helpURL")
+    func otherErrorsHaveNoHelpURL() {
+        #expect(SocialSharingError.notAuthenticated.helpURL == nil)
+        #expect(SocialSharingError.noKeyringForService(serviceLabel: "Mastodon").helpURL == nil)
+        #expect(SocialSharingError.network(NSError(domain: "t", code: 1)).helpURL == nil)
     }
 }

--- a/Tests/KeystoneTests/Tests/Networking/JetpackSocialFactoryTests.swift
+++ b/Tests/KeystoneTests/Tests/Networking/JetpackSocialFactoryTests.swift
@@ -1,0 +1,130 @@
+import JetpackSocial
+import OHHTTPStubs
+import OHHTTPStubsSwift
+import XCTest
+
+@testable import WordPress
+@testable import WordPressData
+
+final class JetpackSocialFactoryTests: CoreDataTestCase {
+    private var previousDefaultDotComUUID: String?
+
+    override func setUp() {
+        super.setUp()
+        previousDefaultDotComUUID = UserSettings.defaultDotComUUID
+        UserSettings.defaultDotComUUID = nil
+        contextManager.useAsSharedInstance(untilTestFinished: self)
+        HTTPStubs.removeAllStubs()
+    }
+
+    override func tearDown() {
+        HTTPStubs.removeAllStubs()
+        UserSettings.defaultDotComUUID = previousDefaultDotComUUID
+        super.tearDown()
+    }
+
+    @MainActor
+    func testSelfHostedJetpackConnectedBlogUsesSiteAccountTokenInsteadOfDefaultAccountToken() async throws {
+        let defaultAccount = makeAccount(username: "default-user", token: "default-token")
+        UserSettings.defaultDotComUUID = defaultAccount.uuid
+        let siteAccount = makeAccount(username: "site-user", token: "site-token")
+        let blog = makeSelfHostedBlog(dotComID: 123)
+        blog.account = siteAccount
+
+        let service = try XCTUnwrap(JetpackSocialFactory().connectionsService(for: blog))
+        let header = try await authorizationHeader(fromLoadingConnectionsWith: service)
+
+        XCTAssertEqual(header, "Bearer site-token")
+    }
+
+    @MainActor
+    func testSelfHostedBlogWithoutWPComAccountReturnsNil() {
+        let blog = makeSelfHostedBlog(dotComID: 123)
+
+        XCTAssertNil(JetpackSocialFactory().connectionsService(for: blog))
+    }
+
+    @MainActor
+    func testBlogWithoutDotComIDReturnsNil() {
+        let blog = BlogBuilder(mainContext, dotComID: nil)
+            .withAnAccount(username: "site-user", authToken: "site-token")
+            .build()
+
+        XCTAssertNil(JetpackSocialFactory().connectionsService(for: blog))
+    }
+
+    @MainActor
+    func testDotComBlogUsesSiteAccountToken() async throws {
+        let account = makeAccount(username: "site-user", token: "site-token")
+        let blog = BlogBuilder(mainContext, dotComID: 123)
+            .with(url: "https://example.wordpress.com")
+            .isHostedAtWPcom()
+            .build()
+        blog.account = account
+
+        let service = try XCTUnwrap(JetpackSocialFactory().connectionsService(for: blog))
+        let header = try await authorizationHeader(fromLoadingConnectionsWith: service)
+
+        XCTAssertEqual(header, "Bearer site-token")
+    }
+
+    @MainActor
+    func testCachedServicesDoNotCrossWPComAccountBoundaries() throws {
+        let firstAccount = makeAccount(username: "first-user", token: "first-token")
+        let secondAccount = makeAccount(username: "second-user", token: "second-token")
+        let blog = makeSelfHostedBlog(dotComID: 123)
+        let factory = JetpackSocialFactory()
+
+        blog.account = firstAccount
+        let firstService = try XCTUnwrap(factory.connectionsService(for: blog))
+
+        blog.account = secondAccount
+        let secondService = try XCTUnwrap(factory.connectionsService(for: blog))
+
+        XCTAssertFalse(firstService === secondService)
+    }
+
+    private func makeAccount(username: String, token: String) -> WPAccount {
+        AccountBuilder(mainContext)
+            .with(username: username)
+            .with(authToken: token)
+            .build()
+    }
+
+    private func makeSelfHostedBlog(dotComID: Int) -> Blog {
+        BlogBuilder(mainContext, dotComID: NSNumber(value: dotComID))
+            .with(url: "https://self-hosted.example")
+            .with(username: "site-login")
+            .with(restApiRootURL: "https://self-hosted.example/wp-json")
+            .withApplicationPassword("app-password")
+            .build()
+    }
+
+    @MainActor
+    private func authorizationHeader(
+        fromLoadingConnectionsWith service: SiteSocialConnectionsService
+    ) async throws -> String? {
+        let requestExpectation = expectation(description: "Publicize request made")
+        let lock = NSLock()
+        var authorizationHeader: String?
+
+        stub(condition: isHost("public-api.wordpress.com")) { request in
+            lock.lock()
+            authorizationHeader = request.value(forHTTPHeaderField: "Authorization")
+            lock.unlock()
+            requestExpectation.fulfill()
+            return HTTPStubsResponse(
+                jsonObject: [],
+                statusCode: 200,
+                headers: ["Content-Type": "application/json"]
+            )
+        }
+
+        _ = try? await service.loadConnections(force: true)
+        await fulfillment(of: [requestExpectation], timeout: 5)
+
+        lock.lock()
+        defer { lock.unlock() }
+        return authorizationHeader
+    }
+}

--- a/Tests/KeystoneTests/Tests/Utility/PublicizeAuthorizationURLComponentsTests.swift
+++ b/Tests/KeystoneTests/Tests/Utility/PublicizeAuthorizationURLComponentsTests.swift
@@ -1,3 +1,4 @@
+import JetpackSocial
 import XCTest
 @testable import WordPress
 

--- a/WordPress/Classes/Networking/JetpackSocialFactory.swift
+++ b/WordPress/Classes/Networking/JetpackSocialFactory.swift
@@ -1,0 +1,91 @@
+import Foundation
+import os
+import JetpackSocial
+import WordPressAPI
+import WordPressAPIInternal
+import WordPressData
+
+public final class JetpackSocialFactory: Sendable {
+    public static let shared = JetpackSocialFactory()
+
+    private let instances = OSAllocatedUnfairLock<[ServiceConfiguration: SiteSocialConnectionsService]>(initialState: [:])
+
+    init() {}
+
+    @MainActor
+    public func connectionsService(for blog: Blog) -> SiteSocialConnectionsService? {
+        guard let configuration = serviceConfiguration(for: blog) else {
+            return nil
+        }
+        return connectionsService(
+            configuration: configuration,
+            canMarkAsShared: blog.isUserCapableOf(.editOthersPosts)
+        )
+    }
+
+    @MainActor
+    private func connectionsService(
+        configuration: ServiceConfiguration,
+        canMarkAsShared: Bool
+    ) -> SiteSocialConnectionsService? {
+        if let cached = instances.withLock({ $0[configuration] }) {
+            cached.updatePermissions(canMarkAsShared: canMarkAsShared)
+            return cached
+        }
+        let service = SiteSocialConnectionsService(
+            client: WPComApiClient(
+                urlSession: URLSession(configuration: .ephemeral),
+                authentication: configuration.authentication
+            ),
+            siteId: configuration.siteId,
+            canMarkAsShared: canMarkAsShared
+        )
+        let stored = instances.withLock { dict in
+            if let existing = dict[configuration] {
+                return existing
+            }
+            dict[configuration] = service
+            return service
+        }
+        stored.updatePermissions(canMarkAsShared: canMarkAsShared)
+        return stored
+    }
+
+    public func reset() {
+        instances.withLock { dict in
+            dict.removeAll()
+        }
+    }
+
+    private func serviceConfiguration(for blog: Blog) -> ServiceConfiguration? {
+        guard let siteId = blog.dotComID?.int64Value, siteId > 0 else {
+            return nil
+        }
+        // Jetpack Social v2 talks to WP.com Publicize APIs. This includes
+        // Jetpack-connected self-hosted blogs, but only when the blog is linked
+        // to WP.com through its own account. App-password-only self-hosted
+        // blogs are intentionally unsupported here.
+        // TODO: Revisit app-password-only support if Social v2 gets a non-WP.com account flow.
+        guard let account = blog.account else {
+            return nil
+        }
+        guard let authToken = account.authToken, !authToken.isEmpty else {
+            return nil
+        }
+        return ServiceConfiguration(
+            siteId: siteId,
+            accountID: TaggedManagedObjectID(account),
+            authToken: authToken
+        )
+    }
+}
+
+private struct ServiceConfiguration: Hashable {
+    let siteId: Int64
+    let accountID: TaggedManagedObjectID<WPAccount>
+    let authToken: String
+
+    var authentication: WpAuthentication {
+        .bearer(token: authToken)
+    }
+}

--- a/WordPress/Classes/Utility/AccountHelper.swift
+++ b/WordPress/Classes/Utility/AccountHelper.swift
@@ -98,6 +98,7 @@ import WordPressData
         deleteAccountData()
 
         WordPressClientFactory.shared.reset()
+        JetpackSocialFactory.shared.reset()
     }
 
     static func deleteAccountData() {

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -29,6 +29,7 @@ public enum FeatureFlag: Int, CaseIterable {
     case statsAds
     case customPostTypes
     case cptPostsAndPages
+    case socialSharingV2
 
     /// Returns a boolean indicating if the feature is enabled.
     ///
@@ -92,6 +93,8 @@ public enum FeatureFlag: Int, CaseIterable {
             return BuildConfiguration.current == .debug
         case .cptPostsAndPages:
             return BuildConfiguration.current == .debug
+        case .socialSharingV2:
+            return BuildConfiguration.current == .debug
         }
     }
 
@@ -137,6 +140,7 @@ extension FeatureFlag {
         case .statsAds: "Stats Ads Tab"
         case .customPostTypes: "Custom Post Types"
         case .cptPostsAndPages: "Custom Post Types: Posts and Pages"
+        case .socialSharingV2: "Social Sharing v2"
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+Swift.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+Swift.swift
@@ -1,6 +1,7 @@
 import Foundation
 import UIKit
 import SwiftUI
+import JetpackSocial
 import WordPressData
 import WordPressShared
 import WordPressAPI
@@ -338,6 +339,10 @@ extension BlogDetailsViewController {
         if !blog.supports(.publicize) {
             // if publicize is disabled, show the sharing buttons settings.
             sharingVC = SharingButtonsViewController(blog: blog)
+        } else if FeatureFlag.socialSharingV2.enabled,
+            let manage = ManageConnectionsHostingController.make(for: blog)
+        {
+            sharingVC = manage
         } else {
             sharingVC = SharingViewController(blog: blog, delegate: nil)
         }

--- a/WordPress/Classes/ViewRelated/Blog/Sharing/SharingAuthorizationWebViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Sharing/SharingAuthorizationWebViewController.swift
@@ -1,3 +1,4 @@
+import JetpackSocial
 import WebKit
 import CoreMedia
 import WordPressData

--- a/WordPress/Classes/ViewRelated/Me/App Settings/ExperimentalFeaturesDataProvider.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/ExperimentalFeaturesDataProvider.swift
@@ -11,6 +11,7 @@ class ExperimentalFeaturesDataProvider: ExperimentalFeaturesViewModel.DataProvid
         RemoteFeatureFlag.newGutenberg,
         FeatureFlag.customPostTypes,
         FeatureFlag.newSupport,
+        FeatureFlag.socialSharingV2,
     ]
 
     private let flagStore = FeatureFlagOverrideStore()

--- a/WordPress/Classes/ViewRelated/Publicize/V2/BlogSocialOAuthAuthenticator.swift
+++ b/WordPress/Classes/ViewRelated/Publicize/V2/BlogSocialOAuthAuthenticator.swift
@@ -1,0 +1,54 @@
+import Foundation
+import JetpackSocial
+import WebKit
+import WordPressData
+
+/// Adapts the app's `Blog`-backed `RequestAuthenticator` to the
+/// module-facing `SocialOAuthAuthenticator` protocol.
+///
+/// Keeps every reference to `Blog`, `WPAccount`, and `CookieJar` inside
+/// the app target so the JetpackSocial module stays free of Core Data.
+/// `WKHTTPCookieStore` already conforms to `CookieJar` via the extension
+/// in `WordPress/Classes/Utility/WebViewController/CookieJar.swift`, so
+/// we can hand it to `RequestAuthenticator.request` as-is.
+struct BlogSocialOAuthAuthenticator: SocialOAuthAuthenticator {
+    private let blogID: TaggedManagedObjectID<Blog>
+    private let coreDataStack: CoreDataStack
+
+    init(blog: Blog, coreDataStack: CoreDataStack = ContextManager.shared) {
+        self.blogID = TaggedManagedObjectID(blog)
+        self.coreDataStack = coreDataStack
+    }
+
+    func authenticatedRequest(
+        for url: URL,
+        into cookieStore: WKHTTPCookieStore
+    ) async -> URLRequest {
+        let authenticator: RequestAuthenticator?
+        do {
+            authenticator = try await coreDataStack.performQuery { [blogID] context in
+                let blog = try context.existingObject(with: blogID)
+                return RequestAuthenticator(blog: blog)
+            }
+        } catch {
+            Loggers.app.error("BlogSocialOAuthAuthenticator failed to resolve blog: \(error)")
+            return URLRequest(url: url)
+        }
+        guard let authenticator else {
+            Loggers.app.error(
+                "BlogSocialOAuthAuthenticator: RequestAuthenticator(blog:) returned nil — using unauthenticated request"
+            )
+            return URLRequest(url: url)
+        }
+        return await withCheckedContinuation { continuation in
+            // `WKHTTPCookieStore` mutation requires the main thread, and
+            // `RequestAuthenticator.request` seeds cookies synchronously
+            // into the jar before invoking the completion.
+            DispatchQueue.main.async {
+                authenticator.request(url: url, cookieJar: cookieStore) { request in
+                    continuation.resume(returning: request)
+                }
+            }
+        }
+    }
+}

--- a/WordPress/Classes/ViewRelated/Publicize/V2/ManageConnectionsHostingController+App.swift
+++ b/WordPress/Classes/ViewRelated/Publicize/V2/ManageConnectionsHostingController+App.swift
@@ -1,0 +1,17 @@
+import Foundation
+import JetpackSocial
+import WordPressData
+
+extension ManageConnectionsHostingController {
+    /// Returns `nil` gracefully when the blog is not a WP.com-connected
+    /// Jetpack Social site.
+    static func make(for blog: Blog) -> ManageConnectionsHostingController? {
+        guard let service = JetpackSocialFactory.shared.connectionsService(for: blog) else {
+            return nil
+        }
+        return ManageConnectionsHostingController(
+            connectionsService: service,
+            authenticator: BlogSocialOAuthAuthenticator(blog: blog)
+        )
+    }
+}


### PR DESCRIPTION
## Description

The existing social connection is based on rest/v1.1 endpoints, which have been deprecated. This PR re-implements the "Social" screen (under a new feature flag), using the wpcom/v2 endpoints (implemented in wprs).


https://github.com/user-attachments/assets/2da34192-bd11-437e-a513-70a960ce66f0

