### PR TITLE
Revert adding 'socialSharingV2' as an experimental feature

### DIFF
--- a/WordPress/Classes/ViewRelated/Me/App Settings/ExperimentalFeaturesDataProvider.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/ExperimentalFeaturesDataProvider.swift
@@ -11,7 +11,6 @@ class ExperimentalFeaturesDataProvider: ExperimentalFeaturesViewModel.DataProvid
         RemoteFeatureFlag.newGutenberg,
         FeatureFlag.customPostTypes,
         FeatureFlag.newSupport,
-        FeatureFlag.socialSharingV2,
     ]
 
     private let flagStore = FeatureFlagOverrideStore()


### PR DESCRIPTION
It's added in https://github.com/wordpress-mobile/WordPress-iOS/pull/25540/changes/eac41a79ffff318068a0126be6e6e676fc20580f

@mokagio I will merge this PR after all features are completed, so that it's easier to test during PR.