### PR TITLE
Wire JetpackSocial into Custom Post Settings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,6 +67,19 @@ To recover, delete all `*.pcm` files in the directory reported by the error and 
 - Use semantics text sizes like `.headline`
 - Use swift-log (see the `WordPress/Classes/System/Logging.swift` file) instead of CocoaLumberjack (`DDLogError`, etc)
 
+## Core Data Concurrency
+
+Don't capture an `NSManagedObject` (e.g. `Blog`, `WPAccount`) across threads — touching its properties off its context's queue violates Core Data's concurrency model.
+
+Store a `TaggedManagedObjectID<Model>` instead, inject a `CoreDataStack` (typically `ContextManager.shared`), and resolve the object inside `coreDataStack.performQuery { context in ... }` (or `performAndSave` for writes):
+
+```swift
+try await coreDataStack.performQuery { [blogID] context in
+    let blog = try context.existingObject(with: blogID)
+    return blog.someValue  // return value types, not the managed object
+}
+```
+
 ## Development Workflow
 - Branch from `trunk` (main branch)
 - PR target should be `trunk`

--- a/Modules/Sources/JetpackSocial/Models/PostMeta+Publicize.swift
+++ b/Modules/Sources/JetpackSocial/Models/PostMeta+Publicize.swift
@@ -1,0 +1,26 @@
+import Foundation
+import WordPressAPIInternal
+
+extension PostMeta {
+    /// The Jetpack publicize message stored in this meta, if any.
+    ///
+    /// The publicize plugin reads this from `_wpas_mess` post meta, registered
+    /// via `register_meta` and exposed at `meta.jetpack_publicize_message`.
+    /// Empty strings are reported as `nil` since the server treats them as
+    /// "no override".
+    public var publicizeMessage: String? {
+        guard case let .string(text)? = valueForKey(key: Self.publicizeMessageKey), !text.isEmpty else {
+            return nil
+        }
+        return text
+    }
+
+    /// Returns a new `PostMeta` with the publicize message set to the given
+    /// string. Pass an empty string to clear a previously-saved value during a
+    /// partial update.
+    public func addingPublicizeMessage(_ message: String) -> PostMeta {
+        self.withValue(key: Self.publicizeMessageKey, value: .string(message))
+    }
+
+    private static let publicizeMessageKey = "jetpack_publicize_message"
+}

--- a/Modules/Sources/JetpackSocial/Models/WpAdditionalFields+Publicize.swift
+++ b/Modules/Sources/JetpackSocial/Models/WpAdditionalFields+Publicize.swift
@@ -1,0 +1,41 @@
+import Foundation
+import WordPressAPI
+
+private enum PublicizeAdditionalFieldKeys {
+    static let connections = "jetpack_publicize_connections"
+}
+
+extension WpAdditionalFields {
+    /// Parses the post-level Publicize connection state if the REST field was present.
+    public var publicizeConnectionsByID: [String: PostSocialSharingDraft.Connection]? {
+        guard keys().contains(PublicizeAdditionalFieldKeys.connections) else {
+            return nil
+        }
+
+        var connectionsByID: [String: PostSocialSharingDraft.Connection] = [:]
+        for entry in arrayValueForKey(key: PublicizeAdditionalFieldKeys.connections) ?? [] {
+            guard case let .object(dict) = entry,
+                case let .string(id)? = dict["connection_id"],
+                case let .bool(enabled)? = dict["enabled"]
+            else {
+                continue
+            }
+            connectionsByID[id] = .init(id: id, enabled: enabled)
+        }
+        return connectionsByID
+    }
+
+    /// Returns a new `WpAdditionalFields` with the `jetpack_publicize_connections`
+    /// key populated with the draft's explicit per-post connection state.
+    public func addingPublicizeConnections(
+        _ connectionsByID: [String: PostSocialSharingDraft.Connection]
+    ) -> WpAdditionalFields {
+        let entries: [JsonValue] = connectionsByID.values.sorted { $0.id < $1.id }.map { connection in
+            .object([
+                "connection_id": .string(connection.id),
+                "enabled": .bool(connection.enabled)
+            ])
+        }
+        return self.withValue(key: PublicizeAdditionalFieldKeys.connections, value: .array(entries))
+    }
+}

--- a/Modules/Sources/JetpackSocial/Services/PostSocialSharingDraft.swift
+++ b/Modules/Sources/JetpackSocial/Services/PostSocialSharingDraft.swift
@@ -1,0 +1,75 @@
+import Foundation
+import WordPressAPI
+import WordPressAPIInternal
+
+public struct PostSocialSharingDraft: Equatable, Hashable, Sendable {
+    public struct Connection: Identifiable, Equatable, Hashable, Sendable {
+        public var id: String
+        public var enabled: Bool
+
+        public init(id: String, enabled: Bool) {
+            self.id = id
+            self.enabled = enabled
+        }
+    }
+
+    public var customMessage: String?
+    public var connectionsByID: [String: Connection]?
+
+    // TODO: per-connection customization (`_wpas_customize_per_network`) —
+    // extend to include per-connection message / attached_media / media_source
+    // once the backend paid feature lands.
+
+    public init(customMessage: String? = nil, connectionsByID: [String: Connection]? = nil) {
+        self.customMessage = customMessage
+        self.connectionsByID = connectionsByID
+    }
+}
+
+extension PostSocialSharingDraft {
+    /// Parses the relevant fields off a fetched post into a draft. Connections
+    /// come from the post's `additional_fields` blob (where Jetpack registers
+    /// `jetpack_publicize_connections` as a top-level REST field); the custom
+    /// message comes from `meta.jetpack_publicize_message`. Unknown or missing
+    /// keys collapse to defaults.
+    public init(fromPostAdditionalFields fields: WpAdditionalFields?, meta: PostMeta?) {
+        self.init(
+            customMessage: meta?.publicizeMessage,
+            connectionsByID: fields?.publicizeConnectionsByID
+        )
+    }
+
+    public func isEnabled(connectionID: String) -> Bool {
+        connectionsByID?[connectionID]?.enabled ?? true
+    }
+
+    public mutating func setEnabled(
+        _ enabled: Bool,
+        for connection: SocialConnection,
+        availableConnections: [SocialConnection]
+    ) {
+        var connections = materializedConnectionsByID(availableConnections: availableConnections)
+        connections[connection.id] = Connection(id: connection.id, enabled: enabled)
+        connectionsByID = connections
+    }
+
+    public mutating func addConnection(
+        _ connection: SocialConnection,
+        availableConnections: [SocialConnection]
+    ) {
+        var connections = materializedConnectionsByID(availableConnections: availableConnections)
+        connections[connection.id] = Connection(id: connection.id, enabled: true)
+        connectionsByID = connections
+    }
+
+    private func materializedConnectionsByID(
+        availableConnections: [SocialConnection]
+    ) -> [String: Connection] {
+        var materializedConnectionsByID: [String: Connection] = [:]
+        for connection in availableConnections {
+            materializedConnectionsByID[connection.id] =
+                connectionsByID?[connection.id] ?? Connection(id: connection.id, enabled: true)
+        }
+        return materializedConnectionsByID
+    }
+}

--- a/Modules/Sources/JetpackSocial/Services/SiteSocialConnectionsService.swift
+++ b/Modules/Sources/JetpackSocial/Services/SiteSocialConnectionsService.swift
@@ -120,12 +120,6 @@ public final class SiteSocialConnectionsService: ObservableObject {
         }
     }
 
-    /// Snapshot of the currently loaded connection IDs. Returns `[]` if
-    /// `connections` has not been loaded yet.
-    public func currentConnectionIDs() -> [String] {
-        connections.value?.map(\.id) ?? []
-    }
-
     // MARK: - Mutations
 
     @discardableResult

--- a/Modules/Sources/JetpackSocial/Strings/Strings.swift
+++ b/Modules/Sources/JetpackSocial/Strings/Strings.swift
@@ -287,4 +287,58 @@ public enum Strings {
             comment: "Navigation bar title of the service picker modal shown when adding a new social connection."
         )
     }
+
+    public enum PostSection {
+        public static let header = NSLocalizedString(
+            "jetpackSocial.postSection.header",
+            value: "Share to social media",
+            comment: "Title of the row that opens the social sharing detail screen in Post Settings."
+        )
+
+        public static let togglesFooter = NSLocalizedString(
+            "jetpackSocial.postSection.togglesFooter",
+            value: "When this post is published, it will be shared to the enabled accounts.",
+            comment: "Footer below the per-connection toggles on the social sharing detail screen."
+        )
+
+        public static let emptyCaption = NSLocalizedString(
+            "jetpackSocial.postSection.empty",
+            value: "No social accounts connected yet.",
+            comment: "Caption shown when the site has no social connections."
+        )
+
+        public static let customMessageLabel = NSLocalizedString(
+            "jetpackSocial.postSection.customMessage",
+            value: "Custom message",
+            comment: "Label above the optional custom social-sharing message field."
+        )
+
+        public static let customMessagePlaceholder = NSLocalizedString(
+            "jetpackSocial.postSection.customMessagePlaceholder",
+            value: "Write a custom message for your social audience here.",
+            comment: "Placeholder for the optional custom social-sharing message field."
+        )
+
+        public static let customMessageFooter = NSLocalizedString(
+            "jetpackSocial.postSection.customMessageFooter",
+            value: """
+                Customize the message you want to share.
+                If you don't add your own text here, we'll use the post's title as the message.
+                """,
+            comment: "Footer caption below the custom social-sharing message field."
+        )
+
+        public static let retry = NSLocalizedString(
+            "jetpackSocial.postSection.retry",
+            value: "Retry",
+            comment: "Button to retry a failed load of the connections list."
+        )
+
+        public static let summaryFormat = NSLocalizedString(
+            "jetpackSocial.postSection.summary.format",
+            value: "%1$d of %2$d",
+            comment:
+                "Trailing value on the 'Share to Social' post settings row. %1$d is the enabled count, %2$d is the total."
+        )
+    }
 }

--- a/Modules/Sources/JetpackSocial/Views/AccountConfirmationView.swift
+++ b/Modules/Sources/JetpackSocial/Views/AccountConfirmationView.swift
@@ -5,7 +5,7 @@ public struct AccountConfirmationView: View {
     private let service: SocialService
     @ObservedObject private var connectionsService: SiteSocialConnectionsService
     private let onCancel: () -> Void
-    private let onFinish: (Result<SocialKeyringAccount, SocialSharingError>) -> Void
+    private let onFinish: (Result<SocialConnection, SocialSharingError>) -> Void
 
     @State private var state: LoadingState = .loading
     @State private var connectedExternalIDs: Set<String> = []
@@ -18,7 +18,7 @@ public struct AccountConfirmationView: View {
         service: SocialService,
         connectionsService: SiteSocialConnectionsService,
         onCancel: @escaping () -> Void,
-        onFinish: @escaping (Result<SocialKeyringAccount, SocialSharingError>) -> Void
+        onFinish: @escaping (Result<SocialConnection, SocialSharingError>) -> Void
     ) {
         self.service = service
         self.connectionsService = connectionsService
@@ -111,14 +111,14 @@ public struct AccountConfirmationView: View {
     private func submit(account: SocialKeyringAccount) {
         submitting = true
         submitTask = Task {
-            let result: Result<SocialKeyringAccount, SocialSharingError>
+            let result: Result<SocialConnection, SocialSharingError>
             do throws(SocialSharingError) {
-                _ = try await connectionsService.createConnection(
+                let connection = try await connectionsService.createConnection(
                     keyringID: account.keyring.id,
                     externalUserID: account.externalUserID,
                     shared: connectionsService.canMarkAsShared ? sharedEnabled : nil
                 )
-                result = .success(account)
+                result = .success(connection)
             } catch {
                 result = .failure(error)
             }

--- a/Modules/Sources/JetpackSocial/Views/AddConnectionCoordinator.swift
+++ b/Modules/Sources/JetpackSocial/Views/AddConnectionCoordinator.swift
@@ -8,6 +8,7 @@ public final class AddConnectionCoordinator {
     private let connectionsService: SiteSocialConnectionsService
     private let authenticator: any SocialOAuthAuthenticator
     private weak var presenter: UIViewController?
+    private let onConnectionCreated: ((SocialConnection) -> Void)?
 
     private var navController: UINavigationController?
     private var confirmationHost: UIHostingController<AccountConfirmationView>?
@@ -17,11 +18,13 @@ public final class AddConnectionCoordinator {
     public init(
         connectionsService: SiteSocialConnectionsService,
         authenticator: any SocialOAuthAuthenticator,
-        presenter: UIViewController
+        presenter: UIViewController,
+        onConnectionCreated: ((SocialConnection) -> Void)? = nil
     ) {
         self.connectionsService = connectionsService
         self.authenticator = authenticator
         self.presenter = presenter
+        self.onConnectionCreated = onConnectionCreated
     }
 
     public func start() {
@@ -97,7 +100,8 @@ public final class AddConnectionCoordinator {
             onFinish: { [weak self] result in
                 guard let self else { return }
                 switch result {
-                case .success:
+                case .success(let connection):
+                    self.onConnectionCreated?(connection)
                     self.dismissNav()
                 case .failure(let error):
                     self.dismissAndAlertFailure(error)

--- a/Modules/Sources/JetpackSocial/Views/PostSocialSharingDetailView.swift
+++ b/Modules/Sources/JetpackSocial/Views/PostSocialSharingDetailView.swift
@@ -1,0 +1,135 @@
+import SwiftUI
+
+public struct PostSocialSharingDetailView: View {
+    @ObservedObject private var connections: SiteSocialConnectionsService
+    @Binding private var draft: PostSocialSharingDraft
+    private let onAddConnection: (() -> Void)?
+
+    public init(
+        connections: SiteSocialConnectionsService,
+        draft: Binding<PostSocialSharingDraft>,
+        onAddConnection: (() -> Void)? = nil
+    ) {
+        self.connections = connections
+        self._draft = draft
+        self.onAddConnection = onAddConnection
+    }
+
+    public var body: some View {
+        Form {
+            togglesSection
+            customMessageSection
+        }
+        .navigationTitle(Strings.PostSection.header)
+        .navigationBarTitleDisplayMode(.inline)
+        .task {
+            _ = try? await connections.loadConnections()
+        }
+    }
+
+    @ViewBuilder
+    private var togglesSection: some View {
+        switch connections.connections {
+        case .loading:
+            Section {
+                HStack {
+                    Spacer()
+                    ProgressView()
+                    Spacer()
+                }
+            }
+        case .loaded(let list) where list.isEmpty:
+            Section {
+                Text(Strings.PostSection.emptyCaption)
+                    .foregroundStyle(.secondary)
+                connectRow
+            }
+        case .loaded(let list):
+            Section {
+                ForEach(list) { connection in
+                    Toggle(isOn: bindingForToggle(connection: connection)) {
+                        SocialConnectionRow(connection: connection)
+                    }
+                }
+                connectRow
+            } footer: {
+                Text(Strings.PostSection.togglesFooter)
+            }
+        case .failed(let error):
+            Section {
+                VStack(alignment: .leading, spacing: 8) {
+                    Text(error.errorDescription ?? "")
+                        .foregroundStyle(.red)
+                    Button(Strings.PostSection.retry) {
+                        Task { _ = try? await connections.loadConnections(force: true) }
+                    }
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var connectRow: some View {
+        if let onAddConnection {
+            Button {
+                onAddConnection()
+            } label: {
+                Text(Strings.ManageConnections.connectNewAccount)
+                    .foregroundStyle(.tint)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+        }
+    }
+
+    private var customMessageSection: some View {
+        Section {
+            TextField(
+                Strings.PostSection.customMessagePlaceholder,
+                text: Binding(
+                    get: { draft.customMessage ?? "" },
+                    set: { draft.customMessage = $0.isEmpty ? nil : $0 }
+                ),
+                axis: .vertical
+            )
+            .lineLimit(2...5)
+        } header: {
+            Text(Strings.PostSection.customMessageLabel)
+        } footer: {
+            Text(Strings.PostSection.customMessageFooter)
+        }
+    }
+
+    private func bindingForToggle(connection: SocialConnection) -> Binding<Bool> {
+        Binding(
+            get: { draft.isEnabled(connectionID: connection.id) },
+            set: { isEnabled in
+                draft.setEnabled(
+                    isEnabled,
+                    for: connection,
+                    availableConnections: connections.connections.value ?? []
+                )
+            }
+        )
+    }
+}
+
+extension PostSocialSharingDraft {
+    /// Short summary for the "Share to Social" post settings entry row.
+    /// Returns `nil` when the row should render without a trailing value —
+    /// i.e. the list is empty (covers both "not loaded yet" and "no
+    /// connections") or all/none of the connections are enabled.
+    public func summary(for connections: [SocialConnection]) -> String? {
+        guard !connections.isEmpty else { return nil }
+        let enabledCount = connections.filter { isEnabled(connectionID: $0.id) }.count
+        if enabledCount == 0 || enabledCount == connections.count {
+            return nil
+        }
+        return String.localizedStringWithFormat(
+            Strings.PostSection.summaryFormat,
+            enabledCount,
+            connections.count
+        )
+    }
+}

--- a/Modules/Tests/JetpackSocialTests/PostSocialSharingDraftTests.swift
+++ b/Modules/Tests/JetpackSocialTests/PostSocialSharingDraftTests.swift
@@ -1,0 +1,100 @@
+import Foundation
+import Testing
+import WordPressAPI
+import WordPressAPIInternal
+@testable import JetpackSocial
+
+@Suite("PostSocialSharingDraft")
+struct PostSocialSharingDraftTests {
+    @Test("addingPublicizeConnections emits every connection with explicit enabled flag")
+    func emitsAllConnections() throws {
+        let fields = WpAdditionalFields()
+            .addingPublicizeConnections([
+                "1": .init(id: "1", enabled: true),
+                "2": .init(id: "2", enabled: false),
+                "3": .init(id: "3", enabled: true)
+            ])
+
+        #expect(Set(fields.keys()) == Set(["jetpack_publicize_connections"]))
+        #expect(
+            fields.publicizeConnectionsByID == [
+                "1": .init(id: "1", enabled: true),
+                "2": .init(id: "2", enabled: false),
+                "3": .init(id: "3", enabled: true)
+            ]
+        )
+    }
+
+    @Test("publicizeConnectionsByID distinguishes missing and empty fields")
+    func parsesMissingAndEmptyConnectionsDifferently() throws {
+        let missing = try WpAdditionalFields.fromJsonString(json: "{}")
+        #expect(missing.publicizeConnectionsByID == nil)
+
+        let empty = try WpAdditionalFields.fromJsonString(
+            json: #"{"jetpack_publicize_connections":[]}"#
+        )
+        #expect(empty.publicizeConnectionsByID == [String: PostSocialSharingDraft.Connection]())
+    }
+
+    @Test("addingPublicizeMessage round-trips through publicizeMessage")
+    func makeMetaEmitsMessage() {
+        let meta = PostMeta().addingPublicizeMessage("Howdy")
+        #expect(meta.publicizeMessage == "Howdy")
+    }
+
+    @Test("init reads message from meta and connections from additional_fields")
+    func initReadsBothSources() throws {
+        let additionalFields = WpAdditionalFields()
+            .addingPublicizeConnections([
+                "5": .init(id: "5", enabled: false),
+                "6": .init(id: "6", enabled: true)
+            ])
+        let meta = PostMeta().addingPublicizeMessage("Howdy")
+
+        let parsed = PostSocialSharingDraft(fromPostAdditionalFields: additionalFields, meta: meta)
+
+        #expect(parsed.customMessage == "Howdy")
+        #expect(
+            parsed.connectionsByID == [
+                "5": .init(id: "5", enabled: false),
+                "6": .init(id: "6", enabled: true)
+            ]
+        )
+    }
+
+    @Test("init tolerates missing fields and missing meta")
+    func initToleratesMissing() throws {
+        let empty = try WpAdditionalFields.fromJsonString(json: "{}")
+        let draft = PostSocialSharingDraft(fromPostAdditionalFields: empty, meta: PostMeta())
+        #expect(draft.customMessage == nil)
+        #expect(draft.connectionsByID == nil)
+    }
+
+    @Test("init handles nil inputs")
+    func initHandlesNil() {
+        let draft = PostSocialSharingDraft(fromPostAdditionalFields: nil, meta: nil)
+        #expect(draft.customMessage == nil)
+        #expect(draft.connectionsByID == nil)
+    }
+
+    @Test("init treats empty-string message as nil")
+    func initTreatsEmptyMessageAsNil() {
+        let meta = PostMeta().addingPublicizeMessage("")
+        let draft = PostSocialSharingDraft(fromPostAdditionalFields: nil, meta: meta)
+        #expect(draft.customMessage == nil)
+    }
+
+    @Test("connections equality is independent of dictionary literal order")
+    func connectionsEqualityIsOrderIndependent() {
+        let lhs = PostSocialSharingDraft(connectionsByID: [
+            "1": .init(id: "1", enabled: true),
+            "2": .init(id: "2", enabled: false)
+        ])
+        let rhs = PostSocialSharingDraft(connectionsByID: [
+            "2": .init(id: "2", enabled: false),
+            "1": .init(id: "1", enabled: true)
+        ])
+
+        #expect(lhs == rhs)
+    }
+}

--- a/Modules/Tests/JetpackSocialTests/SiteSocialConnectionsServiceTests.swift
+++ b/Modules/Tests/JetpackSocialTests/SiteSocialConnectionsServiceTests.swift
@@ -7,18 +7,6 @@ import WordPressAPI
 
 @Suite("SiteSocialConnectionsService initial state", .serialized)
 struct SiteSocialConnectionsServiceTests {
-    @Test("currentConnectionIDs is empty before loading")
-    @MainActor
-    func emptyBeforeLoad() {
-        let client = WPComApiClient(authentication: .none)
-        let service = SiteSocialConnectionsService(
-            client: client,
-            siteId: 1,
-            canMarkAsShared: false
-        )
-        #expect(service.currentConnectionIDs().isEmpty)
-    }
-
     @Test("connections starts in loading state")
     @MainActor
     func connectionsLoadingOnInit() {

--- a/Tests/KeystoneTests/Tests/Features/Posts/CustomPostEditorServiceTests.swift
+++ b/Tests/KeystoneTests/Tests/Features/Posts/CustomPostEditorServiceTests.swift
@@ -157,6 +157,33 @@ struct CustomPostEditorServiceTests {
         #expect(service.hasSettingsChanges == false)
     }
 
+    @Test("hasSettingsChanges stays false after applying fetched social sharing draft")
+    func hasSettingsChangesReturnsFalseAfterApplyingFetchedSocialSharingDraft() throws {
+        let context = ContextManager.forTesting().mainContext
+        let blog = BlogBuilder(context).build()
+        let fetchedDraft = PostSocialSharingDraft(
+            customMessage: "Stored message",
+            connectionsByID: [
+                "12345": .init(id: "12345", enabled: false)
+            ]
+        )
+        let post = makeRemotePost(
+            meta: PostMeta().addingPublicizeMessage("Stored message"),
+            additionalFields: WpAdditionalFields()
+                .addingPublicizeConnections(fetchedDraft.connectionsByID ?? [:])
+        )
+        let service = try makeService(blog: blog, post: post)
+
+        var settings = service.settings
+        // Mirrors the value that CustomPostSettingsViewModel receives from the
+        // fetched post. Applying it locally should not dirty the editor baseline.
+        settings.socialSharingDraft = fetchedDraft
+        service.applyLocally(settings: settings)
+
+        #expect(service.settings.socialSharingDraft == fetchedDraft)
+        #expect(service.hasSettingsChanges == false)
+    }
+
     @Test("hasSettingsChanges returns true after applying different settings to existing post")
     func hasSettingsChangesReturnsTrueAfterApplyingSettingsToExistingPost() throws {
         let context = ContextManager.forTesting().mainContext
@@ -333,7 +360,9 @@ private func makePostTypeLabels() -> PostTypeLabels {
 
 private func makeRemotePost(
     tags: [TermId]? = nil,
-    categories: [TermId]? = nil
+    categories: [TermId]? = nil,
+    meta: PostMeta? = nil,
+    additionalFields: WpAdditionalFields? = nil
 ) -> AnyPostWithEditContext {
     AnyPostWithEditContext(
         id: PostId(1),
@@ -357,13 +386,13 @@ private func makeRemotePost(
         commentStatus: .open,
         pingStatus: .open,
         format: nil,
-        meta: nil,
+        meta: meta,
         sticky: nil,
         template: "",
         categories: categories,
         tags: tags,
         parent: nil,
         menuOrder: nil,
-        additionalFields: nil
+        additionalFields: additionalFields
     )
 }

--- a/Tests/KeystoneTests/Tests/Features/Posts/CustomPostEditorServiceTests.swift
+++ b/Tests/KeystoneTests/Tests/Features/Posts/CustomPostEditorServiceTests.swift
@@ -1,5 +1,6 @@
 import Testing
 import Foundation
+import JetpackSocial
 import WordPressAPI
 import WordPressAPIInternal
 
@@ -32,6 +33,43 @@ struct CustomPostEditorServiceTests {
         #expect(service.inspectPendingSettings() == nil) // new posts don't use pendingSettings
     }
 
+    @Test("applyLocally encodes social sharing context into create params for new posts")
+    func applyLocallyEncodesSocialSharingContextIntoCreateParamsForNewPost() throws {
+        // Given
+        let context = ContextManager.forTesting().mainContext
+        let blog = BlogBuilder(context).build()
+        let service = try makeService(blog: blog, post: nil)
+        var settings = service.settings
+        settings.socialSharingDraft = PostSocialSharingDraft(
+            customMessage: "Share this",
+            connectionsByID: [
+                "1": .init(id: "1", enabled: true),
+                "2": .init(id: "2", enabled: false)
+            ]
+        )
+
+        // When
+        service.applyLocally(settings: settings)
+
+        // Then
+        let params = try #require(service.inspectCreateParams())
+        #expect(params.meta?.publicizeMessage == "Share this")
+
+        let entries = try #require(params.additionalFields?.arrayValueForKey(key: "jetpack_publicize_connections"))
+        let flagsByID = Dictionary(
+            uniqueKeysWithValues: entries.compactMap { entry -> (String, Bool)? in
+                guard case let .object(dict) = entry,
+                    case let .string(id)? = dict["connection_id"],
+                    case let .bool(enabled)? = dict["enabled"]
+                else {
+                    return nil
+                }
+                return (id, enabled)
+            }
+        )
+        #expect(flagsByID == ["1": true, "2": false])
+    }
+
     // MARK: - Existing Post Tests
 
     @Test("applyLocally stores pendingSettings for existing posts")
@@ -51,6 +89,29 @@ struct CustomPostEditorServiceTests {
         // Then
         #expect(service.inspectPendingSettings() != nil)
         #expect(service.inspectPendingSettings()?.slug == "updated-slug")
+    }
+
+    @Test("applyLocally stores social sharing draft for existing posts")
+    func applyLocallyStoresSocialSharingDraftForExistingPost() throws {
+        // Given
+        let context = ContextManager.forTesting().mainContext
+        let blog = BlogBuilder(context).build()
+        let post = makeRemotePost()
+        let service = try makeService(blog: blog, post: post)
+        var settings = service.settings
+        settings.socialSharingDraft = PostSocialSharingDraft(
+            customMessage: "Share this",
+            connectionsByID: [
+                "1": .init(id: "1", enabled: true),
+                "2": .init(id: "2", enabled: false)
+            ]
+        )
+
+        // When
+        service.applyLocally(settings: settings)
+
+        // Then
+        #expect(service.inspectPendingSettings()?.socialSharingDraft == settings.socialSharingDraft)
     }
 
     @Test("settings returns pendingSettings when set")

--- a/Tests/KeystoneTests/Tests/Features/Posts/CustomPostSettingsViewModelTests.swift
+++ b/Tests/KeystoneTests/Tests/Features/Posts/CustomPostSettingsViewModelTests.swift
@@ -1,0 +1,251 @@
+import Testing
+import Foundation
+import JetpackSocial
+import SwiftUI
+import WordPressAPI
+import WordPressAPIInternal
+
+@testable import WordPress
+@testable import WordPressCore
+@testable import WordPressData
+
+@MainActor
+struct CustomPostSettingsViewModelTests {
+
+    @Test("hasChanges stays false after settings mutation when social v2 is enabled and post has disabled connections")
+    func hasChangesIsFalseAfterUnrelatedSettingsMutation() throws {
+        // Given: a published post whose additional_fields encode a disabled connection.
+        let context = ContextManager.forTesting().mainContext
+        let blog = BlogBuilder(context).build()
+        let post = try makePostWithDisabledConnection()
+        let editorService = try makeEditorService(blog: blog, post: post)
+        let connectionsService = makeConnectionsService()
+
+        let viewModel = CustomPostSettingsViewModel(
+            editorService: editorService,
+            blog: blog,
+            socialConnectionsService: connectionsService
+        )
+
+        // Sanity: the parsed draft has the disabled connection from the post.
+        #expect(viewModel.settings.socialSharingDraft?.connectionsByID == [
+            "12345": .init(id: "12345", enabled: false)
+        ])
+
+        // When: settings is reassigned to a value-equivalent copy (simulating
+        // `resolveTermNames` writing back resolved-but-identical tags).
+        viewModel.settings = viewModel.settings
+
+        // Then: hasChanges stays false because nothing actually changed.
+        #expect(!viewModel.hasChanges)
+    }
+
+    @Test("hasChanges flips to true when the user toggles a social connection")
+    func hasChangesIsTrueAfterSocialDraftToggle() throws {
+        let context = ContextManager.forTesting().mainContext
+        let blog = BlogBuilder(context).build()
+        let post = try makePostWithDisabledConnection()
+        let editorService = try makeEditorService(blog: blog, post: post)
+        let connectionsService = makeConnectionsService()
+
+        let viewModel = CustomPostSettingsViewModel(
+            editorService: editorService,
+            blog: blog,
+            socialConnectionsService: connectionsService
+        )
+
+        // When: the user toggles the disabled connection back ON.
+        let binding = try #require(viewModel.v2SocialSharing?.draft)
+        var draft = binding.wrappedValue
+        draft.connectionsByID?["12345"] = .init(id: "12345", enabled: true)
+        binding.wrappedValue = draft
+
+        // Then: hasChanges flips to true.
+        #expect(viewModel.hasChanges)
+    }
+
+    @Test("hasChanges returns to false when the user toggles back to the original state")
+    func hasChangesReturnsFalseAfterToggleAndUntoggle() throws {
+        let context = ContextManager.forTesting().mainContext
+        let blog = BlogBuilder(context).build()
+        let post = try makePostWithDisabledConnection()
+        let editorService = try makeEditorService(blog: blog, post: post)
+        let connectionsService = makeConnectionsService()
+
+        let viewModel = CustomPostSettingsViewModel(
+            editorService: editorService,
+            blog: blog,
+            socialConnectionsService: connectionsService
+        )
+
+        // When: toggle ON, then toggle back OFF.
+        let binding = try #require(viewModel.v2SocialSharing?.draft)
+        var draft = binding.wrappedValue
+        draft.connectionsByID?["12345"] = .init(id: "12345", enabled: true)
+        binding.wrappedValue = draft
+        draft.connectionsByID?["12345"] = .init(id: "12345", enabled: false)
+        binding.wrappedValue = draft
+
+        // Then: PostSocialSharingDraft is structurally Equatable, so we're back
+        // to the initial state.
+        #expect(!viewModel.hasChanges)
+    }
+
+}
+
+// MARK: - Test Helpers
+
+private func makePostWithDisabledConnection() throws -> AnyPostWithEditContext {
+    // Mirrors the real server response observed when a published post has a
+    // connection that was already shared (server returns enabled: false).
+    let json = #"""
+        {
+            "jetpack_publicize_connections": [
+                {"connection_id": "12345", "enabled": false}
+            ]
+        }
+        """#
+    let additionalFields = try WpAdditionalFields.fromJsonString(json: json)
+    return AnyPostWithEditContext(
+        id: PostId(1),
+        date: "2025-01-01T00:00:00",
+        dateGmt: Date(timeIntervalSince1970: 0),
+        guid: PostGuidWithEditContext(raw: nil, rendered: ""),
+        link: "https://example.com",
+        modified: "2025-01-01T00:00:00",
+        modifiedGmt: Date(timeIntervalSince1970: 0),
+        slug: "test-post",
+        status: .publish,
+        postType: "post",
+        password: nil,
+        permalinkTemplate: nil,
+        generatedSlug: nil,
+        title: nil,
+        content: PostContentWithEditContext(raw: nil, rendered: "", protected: nil, blockVersion: nil),
+        author: nil,
+        excerpt: nil,
+        featuredMedia: nil,
+        commentStatus: .open,
+        pingStatus: .open,
+        format: nil,
+        meta: nil,
+        sticky: nil,
+        template: "",
+        categories: nil,
+        tags: nil,
+        parent: nil,
+        menuOrder: nil,
+        additionalFields: additionalFields
+    )
+}
+
+@MainActor
+private func makeEditorService(
+    blog: Blog,
+    post: AnyPostWithEditContext
+) throws -> CustomPostEditorService {
+    let dependencies = try makeServiceDependencies()
+    return CustomPostEditorService(
+        blog: blog,
+        post: post,
+        details: makePostTypeDetails(),
+        client: dependencies.client,
+        wpService: dependencies.wpService
+    )
+}
+
+private func makeServiceDependencies() throws -> (client: WordPressClient, wpService: WpService) {
+    let api = try WordPressAPI(
+        urlSession: .shared,
+        siteInfo: .selfHosted(
+            siteUrl: .parse(input: "https://example.com"),
+            apiRoot: .parse(input: "https://example.com/wp-json")
+        ),
+        authentication: .none
+    )
+    let client = WordPressClient(
+        api: api,
+        siteURL: URL(string: "https://example.com")!
+    )
+    let wpService = try api.createService(cache: .bootstrap())
+
+    return (client, wpService)
+}
+
+@MainActor
+private func makeConnectionsService() -> SiteSocialConnectionsService {
+    // A real instance whose `connections` stays in `.loading` for the whole
+    // test — sufficient for the regression check, which doesn't depend on
+    // any populated data.
+    let client = WPComApiClient(
+        urlSession: .shared,
+        authentication: .none
+    )
+    return SiteSocialConnectionsService(
+        client: client,
+        siteId: 1,
+        canMarkAsShared: false
+    )
+}
+
+private func makePostTypeDetails() -> PostTypeDetailsWithEditContext {
+    PostTypeDetailsWithEditContext(
+        capabilities: [:],
+        description: "",
+        hierarchical: false,
+        viewable: true,
+        labels: makePostTypeLabels(),
+        name: "Test Post Type",
+        slug: "test_post_type",
+        supports: PostTypeSupportsMap(map: [
+            .title: .bool(true),
+            .editor: .bool(true)
+        ]),
+        hasArchive: .bool(false),
+        taxonomies: [],
+        restBase: "test_post_type",
+        restNamespace: "wp/v2",
+        visibility: PostTypeVisibility(showInNavMenus: true, showUi: true),
+        icon: nil
+    )
+}
+
+private func makePostTypeLabels() -> PostTypeLabels {
+    PostTypeLabels(
+        name: "",
+        singularName: "",
+        addNew: "",
+        addNewItem: "",
+        editItem: "",
+        newItem: "",
+        viewItem: "",
+        viewItems: "",
+        searchItems: "",
+        notFound: "",
+        notFoundInTrash: "",
+        parentItemColon: nil,
+        allItems: "",
+        archives: "",
+        attributes: "",
+        insertIntoItem: "",
+        uploadedToThisItem: "",
+        featuredImage: "",
+        setFeaturedImage: "",
+        removeFeaturedImage: "",
+        useFeaturedImage: "",
+        filterItemsList: "",
+        filterByDate: "",
+        itemsListNavigation: "",
+        itemsList: "",
+        itemPublished: "",
+        itemPublishedPrivately: "",
+        itemRevertedToDraft: "",
+        itemTrashed: "",
+        itemScheduled: "",
+        itemUpdated: "",
+        itemLink: "",
+        itemLinkDescription: "",
+        menuName: "",
+        nameAdminBar: ""
+    )
+}

--- a/Tests/KeystoneTests/Tests/Features/Posts/CustomPostSettingsViewModelTests.swift
+++ b/Tests/KeystoneTests/Tests/Features/Posts/CustomPostSettingsViewModelTests.swift
@@ -122,6 +122,40 @@ struct CustomPostSettingsViewModelTests {
         #expect(viewModel.settings.socialSharingDraft == storedDraft)
     }
 
+    @Test("social v2 is hidden when the post type does not support publicize")
+    func socialV2IsHiddenWhenPostTypeDoesNotSupportPublicize() throws {
+        let context = ContextManager.forTesting().mainContext
+        let blog = BlogBuilder(context).build()
+        let storedDraft = PostSocialSharingDraft(
+            customMessage: "Stored message",
+            connectionsByID: [
+                "12345": .init(id: "12345", enabled: false)
+            ]
+        )
+        let initialParams = PostCreateParams(
+            meta: PostMeta().addingPublicizeMessage("Stored message"),
+            additionalFields: WpAdditionalFields()
+                .addingPublicizeConnections(storedDraft.connectionsByID ?? [:])
+        )
+        let editorService = try makeEditorService(
+            blog: blog,
+            post: nil,
+            initialParams: initialParams,
+            supportsPublicize: false
+        )
+        let connectionsService = makeConnectionsService()
+
+        let viewModel = CustomPostSettingsViewModel(
+            editorService: editorService,
+            blog: blog,
+            socialConnectionsService: connectionsService
+        )
+
+        #expect(viewModel.v2SocialSharing == nil)
+        #expect(viewModel.settings.socialSharingDraft == nil)
+        #expect(viewModel.getSettingsToSave(for: viewModel.settings).socialSharingDraft == nil)
+    }
+
 }
 
 // MARK: - Test Helpers
@@ -174,13 +208,14 @@ private func makePostWithDisabledConnection() throws -> AnyPostWithEditContext {
 private func makeEditorService(
     blog: Blog,
     post: AnyPostWithEditContext?,
-    initialParams: PostCreateParams? = nil
+    initialParams: PostCreateParams? = nil,
+    supportsPublicize: Bool = true
 ) throws -> CustomPostEditorService {
     let dependencies = try makeServiceDependencies()
     return CustomPostEditorService(
         blog: blog,
         post: post,
-        details: makePostTypeDetails(),
+        details: makePostTypeDetails(supportsPublicize: supportsPublicize),
         client: dependencies.client,
         wpService: dependencies.wpService,
         initialParams: initialParams
@@ -221,8 +256,16 @@ private func makeConnectionsService() -> SiteSocialConnectionsService {
     )
 }
 
-private func makePostTypeDetails() -> PostTypeDetailsWithEditContext {
-    PostTypeDetailsWithEditContext(
+private func makePostTypeDetails(supportsPublicize: Bool = true) -> PostTypeDetailsWithEditContext {
+    var supports: [PostTypeSupports: JsonValue] = [
+        .title: .bool(true),
+        .editor: .bool(true)
+    ]
+    if supportsPublicize {
+        supports[.custom("publicize")] = .bool(true)
+    }
+
+    return PostTypeDetailsWithEditContext(
         capabilities: [:],
         description: "",
         hierarchical: false,
@@ -230,10 +273,7 @@ private func makePostTypeDetails() -> PostTypeDetailsWithEditContext {
         labels: makePostTypeLabels(),
         name: "Test Post Type",
         slug: "test_post_type",
-        supports: PostTypeSupportsMap(map: [
-            .title: .bool(true),
-            .editor: .bool(true)
-        ]),
+        supports: PostTypeSupportsMap(map: supports),
         hasArchive: .bool(false),
         taxonomies: [],
         restBase: "test_post_type",

--- a/Tests/KeystoneTests/Tests/Features/Posts/CustomPostSettingsViewModelTests.swift
+++ b/Tests/KeystoneTests/Tests/Features/Posts/CustomPostSettingsViewModelTests.swift
@@ -156,11 +156,51 @@ struct CustomPostSettingsViewModelTests {
         #expect(viewModel.getSettingsToSave(for: viewModel.settings).socialSharingDraft == nil)
     }
 
+    @Test("social v2 is hidden and stripped when the post is private")
+    func socialV2IsHiddenAndStrippedWhenPostIsPrivate() throws {
+        let context = ContextManager.forTesting().mainContext
+        let blog = BlogBuilder(context).build()
+        let post = try makePostWithDisabledConnection(status: .private)
+        let editorService = try makeEditorService(blog: blog, post: post)
+        let connectionsService = makeConnectionsService()
+
+        let viewModel = CustomPostSettingsViewModel(
+            editorService: editorService,
+            blog: blog,
+            socialConnectionsService: connectionsService
+        )
+
+        #expect(viewModel.v2SocialSharing == nil)
+        #expect(viewModel.settings.socialSharingDraft == nil)
+        #expect(!viewModel.hasChanges)
+        #expect(viewModel.getSettingsToSave(for: viewModel.settings).socialSharingDraft == nil)
+    }
+
+    @Test("social sharing draft is stripped when settings are changed to private")
+    func socialSharingDraftIsStrippedWhenSettingsBecomePrivate() throws {
+        let context = ContextManager.forTesting().mainContext
+        let blog = BlogBuilder(context).build()
+        let post = try makePostWithDisabledConnection()
+        let editorService = try makeEditorService(blog: blog, post: post)
+        let connectionsService = makeConnectionsService()
+
+        let viewModel = CustomPostSettingsViewModel(
+            editorService: editorService,
+            blog: blog,
+            socialConnectionsService: connectionsService
+        )
+
+        viewModel.settings.status = .publishPrivate
+
+        #expect(viewModel.v2SocialSharing == nil)
+        #expect(viewModel.getSettingsToSave(for: viewModel.settings).socialSharingDraft == nil)
+    }
+
 }
 
 // MARK: - Test Helpers
 
-private func makePostWithDisabledConnection() throws -> AnyPostWithEditContext {
+private func makePostWithDisabledConnection(status: PostStatus = .publish) throws -> AnyPostWithEditContext {
     // Mirrors the real server response observed when a published post has a
     // connection that was already shared (server returns enabled: false).
     let json = #"""
@@ -180,7 +220,7 @@ private func makePostWithDisabledConnection() throws -> AnyPostWithEditContext {
         modified: "2025-01-01T00:00:00",
         modifiedGmt: Date(timeIntervalSince1970: 0),
         slug: "test-post",
-        status: .publish,
+        status: status,
         postType: "post",
         password: nil,
         permalinkTemplate: nil,

--- a/Tests/KeystoneTests/Tests/Features/Posts/CustomPostSettingsViewModelTests.swift
+++ b/Tests/KeystoneTests/Tests/Features/Posts/CustomPostSettingsViewModelTests.swift
@@ -91,6 +91,37 @@ struct CustomPostSettingsViewModelTests {
         #expect(!viewModel.hasChanges)
     }
 
+    @Test("new post initialization preserves locally stored social sharing draft")
+    func newPostInitializationPreservesStoredSocialSharingDraft() throws {
+        let context = ContextManager.forTesting().mainContext
+        let blog = BlogBuilder(context).build()
+        let storedDraft = PostSocialSharingDraft(
+            customMessage: "Stored message",
+            connectionsByID: [
+                "12345": .init(id: "12345", enabled: false)
+            ]
+        )
+        let initialParams = PostCreateParams(
+            meta: PostMeta().addingPublicizeMessage("Stored message"),
+            additionalFields: WpAdditionalFields()
+                .addingPublicizeConnections(storedDraft.connectionsByID ?? [:])
+        )
+        let editorService = try makeEditorService(
+            blog: blog,
+            post: nil,
+            initialParams: initialParams
+        )
+        let connectionsService = makeConnectionsService()
+
+        let viewModel = CustomPostSettingsViewModel(
+            editorService: editorService,
+            blog: blog,
+            socialConnectionsService: connectionsService
+        )
+
+        #expect(viewModel.settings.socialSharingDraft == storedDraft)
+    }
+
 }
 
 // MARK: - Test Helpers
@@ -142,7 +173,8 @@ private func makePostWithDisabledConnection() throws -> AnyPostWithEditContext {
 @MainActor
 private func makeEditorService(
     blog: Blog,
-    post: AnyPostWithEditContext
+    post: AnyPostWithEditContext?,
+    initialParams: PostCreateParams? = nil
 ) throws -> CustomPostEditorService {
     let dependencies = try makeServiceDependencies()
     return CustomPostEditorService(
@@ -150,7 +182,8 @@ private func makeEditorService(
         post: post,
         details: makePostTypeDetails(),
         client: dependencies.client,
-        wpService: dependencies.wpService
+        wpService: dependencies.wpService,
+        initialParams: initialParams
     )
 }
 

--- a/Tests/KeystoneTests/Tests/Features/Posts/PostSettingsTests.swift
+++ b/Tests/KeystoneTests/Tests/Features/Posts/PostSettingsTests.swift
@@ -995,6 +995,40 @@ struct PostSettingsTests {
         )
     }
 
+    @Test("init(from: PostCreateParams) preserves social sharing draft")
+    func testInitFromCreateParamsPreservesSocialSharingDraft() {
+        let params = PostCreateParams(
+            meta: PostMeta().addingPublicizeMessage("Stored message"),
+            additionalFields: WpAdditionalFields()
+                .addingPublicizeConnections([
+                    "1": .init(id: "1", enabled: true),
+                    "2": .init(id: "2", enabled: false)
+                ])
+        )
+
+        let settings = PostSettings(from: params)
+
+        #expect(settings.socialSharingDraft?.customMessage == "Stored message")
+        #expect(settings.socialSharingDraft?.connectionsByID == [
+            "1": .init(id: "1", enabled: true),
+            "2": .init(id: "2", enabled: false)
+        ])
+    }
+
+    @Test("makeCreateParameters clears stored publicize message from empty social draft")
+    func testMakeCreateParametersClearsStoredPublicizeMessage() {
+        let existing = PostCreateParams(
+            meta: PostMeta().addingPublicizeMessage("Stored message")
+        )
+        var settings = PostSettings(from: existing)
+        settings.socialSharingDraft = PostSocialSharingDraft(customMessage: nil)
+
+        let params = settings.makeCreateParameters(from: existing)
+
+        #expect(params.meta != nil)
+        #expect(params.meta?.publicizeMessage == nil)
+    }
+
     @Test("init(from: PostCreateParams) populates parentPageID")
     func testInitFromCreateParamsReadsParent() {
         // Given

--- a/Tests/KeystoneTests/Tests/Features/Posts/PostSettingsTests.swift
+++ b/Tests/KeystoneTests/Tests/Features/Posts/PostSettingsTests.swift
@@ -1,6 +1,7 @@
 import Testing
 import Foundation
 import CoreData
+import JetpackSocial
 import WordPressAPIInternal
 @testable import WordPress
 @testable import WordPressData
@@ -847,6 +848,81 @@ struct PostSettingsTests {
         #expect(params.format == .image)
     }
 
+    @Test("makeUpdateParameters preserves publicize message when social v2 is unavailable")
+    func testMakeRemoteUpdateParametersPreservesPublicizeMessageWhenSocialContextIsNil() {
+        // Given: the fetched post has a saved Publicize message, but Social v2
+        // is not active for this save path.
+        let post = makeRemotePost(meta: PostMeta().addingPublicizeMessage("Saved message"))
+        var settings = PostSettings(from: post)
+        settings.slug = "changed-slug"
+
+        // When
+        let params = settings.makeUpdateParameters(from: post)
+
+        // Then: an unrelated settings save must not clear the saved message.
+        #expect(params.slug == "changed-slug")
+        #expect(params.meta == nil)
+    }
+
+    @Test("makeUpdateParameters(from: AnyPostWithEditContext) clears publicize message when social v2 draft is empty")
+    func testMakeRemoteUpdateParametersClearsPublicizeMessageFromEmptySocialDraft() {
+        // Given
+        let post = makeRemotePost(meta: PostMeta().addingPublicizeMessage("Saved message"))
+        var settings = PostSettings(from: post)
+        settings.socialSharingDraft = PostSocialSharingDraft(customMessage: nil)
+
+        // When
+        let params = settings.makeUpdateParameters(from: post)
+
+        // Then: an active Social v2 draft owns the field, so nil/empty clears it.
+        #expect(params.meta != nil)
+        #expect(params.meta?.publicizeMessage == nil)
+    }
+
+    @Test("makeUpdateParameters(from: AnyPostWithEditContext) adds publicize message from social v2 draft")
+    func testMakeRemoteUpdateParametersAddsPublicizeMessageFromSocialDraft() {
+        // Given
+        let post = makeRemotePost()
+        var settings = PostSettings(from: post)
+        settings.socialSharingDraft = PostSocialSharingDraft(customMessage: "Share this")
+
+        // When
+        let params = settings.makeUpdateParameters(from: post)
+
+        // Then
+        #expect(params.meta?.publicizeMessage == "Share this")
+    }
+
+    @Test("makeUpdateParameters(from: AnyPostWithEditContext) encodes social connections")
+    func testMakeRemoteUpdateParametersAddsPublicizeConnectionsFromSocialDraft() throws {
+        // Given
+        let post = makeRemotePost()
+        var settings = PostSettings(from: post)
+        settings.socialSharingDraft = PostSocialSharingDraft(connectionsByID: [
+            "1": .init(id: "1", enabled: true),
+            "2": .init(id: "2", enabled: false),
+            "3": .init(id: "3", enabled: true)
+        ])
+
+        // When
+        let params = settings.makeUpdateParameters(from: post)
+
+        // Then
+        let entries = try #require(params.additionalFields?.arrayValueForKey(key: "jetpack_publicize_connections"))
+        let flagsByID = Dictionary(
+            uniqueKeysWithValues: entries.compactMap { entry -> (String, Bool)? in
+                guard case let .object(dict) = entry,
+                    case let .string(id)? = dict["connection_id"],
+                    case let .bool(enabled)? = dict["enabled"]
+                else {
+                    return nil
+                }
+                return (id, enabled)
+            }
+        )
+        #expect(flagsByID == ["1": true, "2": false, "3": true])
+    }
+
     @Test("Resolved terms (id > 0) are equal when ids match, regardless of name")
     func testResolvedTermEquality() {
         let term1 = PostSettings.Term(id: 5, name: "swift")
@@ -1019,7 +1095,8 @@ private func makeRemotePost(
     tags: [TermId]? = nil,
     categories: [TermId]? = nil,
     featuredMedia: MediaId? = nil,
-    format: PostFormat? = nil
+    format: PostFormat? = nil,
+    meta: PostMeta? = nil
 ) -> AnyPostWithEditContext {
     AnyPostWithEditContext(
         id: PostId(1),
@@ -1043,7 +1120,7 @@ private func makeRemotePost(
         commentStatus: .open,
         pingStatus: .open,
         format: format,
-        meta: nil,
+        meta: meta,
         sticky: nil,
         template: "",
         categories: categories,

--- a/Tests/KeystoneTests/Tests/Features/Posts/PostSettingsTests.swift
+++ b/Tests/KeystoneTests/Tests/Features/Posts/PostSettingsTests.swift
@@ -699,6 +699,26 @@ struct PostSettingsTests {
         )
     }
 
+    @Test("init(from: AnyPostWithEditContext) preserves social sharing draft")
+    func testInitFromRemotePostPreservesSocialSharingDraft() {
+        let expectedDraft = PostSocialSharingDraft(
+            customMessage: "Stored message",
+            connectionsByID: [
+                "1": .init(id: "1", enabled: true),
+                "2": .init(id: "2", enabled: false)
+            ]
+        )
+        let post = makeRemotePost(
+            meta: PostMeta().addingPublicizeMessage("Stored message"),
+            additionalFields: WpAdditionalFields()
+                .addingPublicizeConnections(expectedDraft.connectionsByID ?? [:])
+        )
+
+        let settings = PostSettings(from: post)
+
+        #expect(settings.socialSharingDraft == expectedDraft)
+    }
+
     @Test("apply(to:) converts terms back to name strings")
     func testApplyConvertsTermsToNameStrings() {
         // Given
@@ -1130,7 +1150,8 @@ private func makeRemotePost(
     categories: [TermId]? = nil,
     featuredMedia: MediaId? = nil,
     format: PostFormat? = nil,
-    meta: PostMeta? = nil
+    meta: PostMeta? = nil,
+    additionalFields: WpAdditionalFields? = nil
 ) -> AnyPostWithEditContext {
     AnyPostWithEditContext(
         id: PostId(1),
@@ -1161,6 +1182,6 @@ private func makeRemotePost(
         tags: tags,
         parent: nil,
         menuOrder: nil,
-        additionalFields: nil
+        additionalFields: additionalFields
     )
 }

--- a/Tests/KeystoneTests/Tests/Features/Posts/PostSettingsTests.swift
+++ b/Tests/KeystoneTests/Tests/Features/Posts/PostSettingsTests.swift
@@ -943,6 +943,23 @@ struct PostSettingsTests {
         #expect(flagsByID == ["1": true, "2": false, "3": true])
     }
 
+    @Test("makeUpdateParameters(from: AnyPostWithEditContext) omits unchanged social connections")
+    func testMakeRemoteUpdateParametersOmitsUnchangedPublicizeConnections() {
+        let additionalFields = WpAdditionalFields()
+            .addingPublicizeConnections([
+                "1": .init(id: "1", enabled: true),
+                "2": .init(id: "2", enabled: false)
+            ])
+        let post = makeRemotePost(additionalFields: additionalFields)
+        var settings = PostSettings(from: post)
+        settings.slug = "changed-slug"
+
+        let params = settings.makeUpdateParameters(from: post)
+
+        #expect(params.slug == "changed-slug")
+        #expect(params.additionalFields == nil)
+    }
+
     @Test("Resolved terms (id > 0) are equal when ids match, regardless of name")
     func testResolvedTermEquality() {
         let term1 = PostSettings.Term(id: 5, name: "swift")

--- a/WordPress/Classes/ViewRelated/Post/PostSettings/CustomPostSettingsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettings/CustomPostSettingsViewModel.swift
@@ -208,7 +208,9 @@ final class CustomPostSettingsViewModel: NSObject, ObservableObject, PostSetting
         self.context = context
         self.preferences = preferences
         self.client = editorService.client
-        self.capabilities = PostSettingsCapabilities(from: editorService.details)
+        let capabilities = PostSettingsCapabilities(from: editorService.details)
+        self.capabilities = capabilities
+        let socialConnectionsService = capabilities.supportsPublicize ? socialConnectionsService : nil
         self.socialConnectionsService = socialConnectionsService
 
         var initialSettings = editorService.settings
@@ -235,6 +237,8 @@ final class CustomPostSettingsViewModel: NSObject, ObservableObject, PostSetting
                 // posts can already carry a draft on editorService.settings.
                 initialSettings.socialSharingDraft = PostSocialSharingDraft()
             }
+        } else {
+            initialSettings.socialSharingDraft = nil
         }
 
         self.settings = initialSettings
@@ -284,7 +288,7 @@ final class CustomPostSettingsViewModel: NSObject, ObservableObject, PostSetting
         self.init(
             editorService: editorService,
             blog: blog,
-            socialConnectionsService: Self.resolveSocialConnectionsService(blog: blog),
+            socialConnectionsService: Self.resolveSocialConnectionsService(blog: blog, details: editorService.details),
             isStandalone: isStandalone,
             context: context,
             preferences: preferences
@@ -345,6 +349,9 @@ final class CustomPostSettingsViewModel: NSObject, ObservableObject, PostSetting
 
     func getSettingsToSave(for settings: PostSettings) -> PostSettings {
         var settings = settings
+        if !capabilities.supportsPublicize {
+            settings.socialSharingDraft = nil
+        }
         if context == .publishing {
             // We don't support saving these changes on the "Publishing" sheet
             // as it would trigger the change in status and publishing. We'll
@@ -589,8 +596,12 @@ final class CustomPostSettingsViewModel: NSObject, ObservableObject, PostSetting
         }
     }
 
-    private static func resolveSocialConnectionsService(blog: Blog) -> SiteSocialConnectionsService? {
-        guard FeatureFlag.socialSharingV2.enabled,
+    private static func resolveSocialConnectionsService(
+        blog: Blog,
+        details: PostTypeDetailsWithEditContext
+    ) -> SiteSocialConnectionsService? {
+        guard PostSettingsCapabilities(from: details).supportsPublicize,
+            FeatureFlag.socialSharingV2.enabled,
             blog.supports(.publicize),
             let service = JetpackSocialFactory.shared.connectionsService(for: blog)
         else {

--- a/WordPress/Classes/ViewRelated/Post/PostSettings/CustomPostSettingsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettings/CustomPostSettingsViewModel.swift
@@ -227,12 +227,7 @@ final class CustomPostSettingsViewModel: NSObject, ObservableObject, PostSetting
         }
 
         if socialConnectionsService != nil {
-            if let post = editorService.post {
-                initialSettings.socialSharingDraft = PostSocialSharingDraft(
-                    fromPostAdditionalFields: post.additionalFields,
-                    meta: post.meta
-                )
-            } else if initialSettings.socialSharingDraft == nil {
+            if editorService.post == nil, initialSettings.socialSharingDraft == nil {
                 // Note: After PR 25543 is merged, keep this nil guard. New
                 // posts can already carry a draft on editorService.settings.
                 initialSettings.socialSharingDraft = PostSocialSharingDraft()

--- a/WordPress/Classes/ViewRelated/Post/PostSettings/CustomPostSettingsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettings/CustomPostSettingsViewModel.swift
@@ -225,11 +225,16 @@ final class CustomPostSettingsViewModel: NSObject, ObservableObject, PostSetting
         }
 
         if socialConnectionsService != nil {
-            let initialSocialSharingDraft =
-                editorService.post.map {
-                    PostSocialSharingDraft(fromPostAdditionalFields: $0.additionalFields, meta: $0.meta)
-                } ?? PostSocialSharingDraft()
-            initialSettings.socialSharingDraft = initialSocialSharingDraft
+            if let post = editorService.post {
+                initialSettings.socialSharingDraft = PostSocialSharingDraft(
+                    fromPostAdditionalFields: post.additionalFields,
+                    meta: post.meta
+                )
+            } else if initialSettings.socialSharingDraft == nil {
+                // Note: After PR 25543 is merged, keep this nil guard. New
+                // posts can already carry a draft on editorService.settings.
+                initialSettings.socialSharingDraft = PostSocialSharingDraft()
+            }
         }
 
         self.settings = initialSettings

--- a/WordPress/Classes/ViewRelated/Post/PostSettings/CustomPostSettingsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettings/CustomPostSettingsViewModel.swift
@@ -226,7 +226,7 @@ final class CustomPostSettingsViewModel: NSObject, ObservableObject, PostSetting
             )
         }
 
-        if socialConnectionsService != nil {
+        if socialConnectionsService != nil, initialSettings.status != .publishPrivate {
             if editorService.post == nil, initialSettings.socialSharingDraft == nil {
                 // Note: After PR 25543 is merged, keep this nil guard. New
                 // posts can already carry a draft on editorService.settings.
@@ -344,7 +344,7 @@ final class CustomPostSettingsViewModel: NSObject, ObservableObject, PostSetting
 
     func getSettingsToSave(for settings: PostSettings) -> PostSettings {
         var settings = settings
-        if !capabilities.supportsPublicize {
+        if !capabilities.supportsPublicize || settings.status == .publishPrivate {
             settings.socialSharingDraft = nil
         }
         if context == .publishing {
@@ -400,7 +400,11 @@ final class CustomPostSettingsViewModel: NSObject, ObservableObject, PostSetting
     func showSocialSharingOptions() {}
 
     var v2SocialSharing: V2SocialSharingBinding? {
-        guard let service = socialConnectionsService else { return nil }
+        guard let service = socialConnectionsService,
+            settings.status != .publishPrivate
+        else {
+            return nil
+        }
         let binding = Binding<PostSocialSharingDraft>(
             get: { self.settings.socialSharingDraft ?? PostSocialSharingDraft() },
             set: { self.settings.socialSharingDraft = $0 }

--- a/WordPress/Classes/ViewRelated/Post/PostSettings/CustomPostSettingsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettings/CustomPostSettingsViewModel.swift
@@ -1,4 +1,5 @@
 import Foundation
+import JetpackSocial
 import SwiftUI
 import WordPressAPI
 import WordPressData
@@ -40,6 +41,13 @@ final class CustomPostSettingsViewModel: NSObject, ObservableObject, PostSetting
     @Published var parentPageText: String?
     @Published var socialSharingState: PostSettingsSocialSharingSectionState?
     @Published var isShowingDeletedAlert = false
+    private let socialConnectionsService: SiteSocialConnectionsService?
+
+    /// Strong reference that keeps `AddConnectionCoordinator` alive while
+    /// the OAuth flow is in progress. Cleared when the user starts a new
+    /// add flow or when this view model is deallocated. Mirrors the same
+    /// lifetime pattern in `ManageConnectionsHostingController`.
+    private var addConnectionCoordinator: AddConnectionCoordinator?
 
     private let originalSettings: PostSettings
     private let preferences: UserPersistentRepository
@@ -184,9 +192,12 @@ final class CustomPostSettingsViewModel: NSObject, ObservableObject, PostSetting
 
     // MARK: - Initializer
 
+    /// Designated init exposed to tests so they can inject a stubbed
+    /// `SiteSocialConnectionsService` without going through `JetpackSocialFactory.shared`.
     init(
         editorService: CustomPostEditorService,
         blog: Blog,
+        socialConnectionsService: SiteSocialConnectionsService?,
         isStandalone: Bool = false,
         context: PostSettingsContext = .settings,
         preferences: UserPersistentRepository = UserDefaults.standard
@@ -198,6 +209,7 @@ final class CustomPostSettingsViewModel: NSObject, ObservableObject, PostSetting
         self.preferences = preferences
         self.client = editorService.client
         self.capabilities = PostSettingsCapabilities(from: editorService.details)
+        self.socialConnectionsService = socialConnectionsService
 
         var initialSettings = editorService.settings
         // Resolve author display name from Blog's cached authors
@@ -210,6 +222,14 @@ final class CustomPostSettingsViewModel: NSObject, ObservableObject, PostSetting
                 displayName: author.displayName ?? "–",
                 avatarURL: author.avatarURL.flatMap(URL.init)
             )
+        }
+
+        if socialConnectionsService != nil {
+            let initialSocialSharingDraft =
+                editorService.post.map {
+                    PostSocialSharingDraft(fromPostAdditionalFields: $0.additionalFields, meta: $0.meta)
+                } ?? PostSocialSharingDraft()
+            initialSettings.socialSharingDraft = initialSocialSharingDraft
         }
 
         self.settings = initialSettings
@@ -247,6 +267,23 @@ final class CustomPostSettingsViewModel: NSObject, ObservableObject, PostSetting
         refreshCustomTaxonomies()
         refreshParentPageText()
         resolveTermNames()
+    }
+
+    convenience init(
+        editorService: CustomPostEditorService,
+        blog: Blog,
+        isStandalone: Bool = false,
+        context: PostSettingsContext = .settings,
+        preferences: UserPersistentRepository = UserDefaults.standard
+    ) {
+        self.init(
+            editorService: editorService,
+            blog: blog,
+            socialConnectionsService: Self.resolveSocialConnectionsService(blog: blog),
+            isStandalone: isStandalone,
+            context: context,
+            preferences: preferences
+        )
     }
 
     // MARK: - Actions
@@ -354,6 +391,46 @@ final class CustomPostSettingsViewModel: NSObject, ObservableObject, PostSetting
     }
 
     func showSocialSharingOptions() {}
+
+    var v2SocialSharing: V2SocialSharingBinding? {
+        guard let service = socialConnectionsService else { return nil }
+        let binding = Binding<PostSocialSharingDraft>(
+            get: { self.settings.socialSharingDraft ?? PostSocialSharingDraft() },
+            set: { self.settings.socialSharingDraft = $0 }
+        )
+        return V2SocialSharingBinding(
+            connections: service,
+            draft: binding,
+            isPostPublished: editorService.post?.status == .publish,
+            onAddConnection: { [weak self] in
+                self?.presentAddSocialConnection()
+            }
+        )
+    }
+
+    private func presentAddSocialConnection() {
+        guard let service = socialConnectionsService,
+            let presenter = viewController
+        else {
+            return
+        }
+        let coordinator = AddConnectionCoordinator(
+            connectionsService: service,
+            authenticator: BlogSocialOAuthAuthenticator(blog: blog),
+            presenter: presenter,
+            onConnectionCreated: { [weak self, weak service] connection in
+                guard let self else { return }
+                var draft = self.settings.socialSharingDraft ?? PostSocialSharingDraft()
+                draft.addConnection(
+                    connection,
+                    availableConnections: service?.connections.value ?? [connection]
+                )
+                self.settings.socialSharingDraft = draft
+            }
+        )
+        addConnectionCoordinator = coordinator
+        coordinator.start()
+    }
 
     // MARK: - Term Resolution
 
@@ -505,5 +582,15 @@ final class CustomPostSettingsViewModel: NSObject, ObservableObject, PostSetting
         case .settings: "post_settings"
         case .publishing: "pre_publishing"
         }
+    }
+
+    private static func resolveSocialConnectionsService(blog: Blog) -> SiteSocialConnectionsService? {
+        guard FeatureFlag.socialSharingV2.enabled,
+            blog.supports(.publicize),
+            let service = JetpackSocialFactory.shared.connectionsService(for: blog)
+        else {
+            return nil
+        }
+        return service
     }
 }

--- a/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettings.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettings.swift
@@ -465,10 +465,15 @@ struct PostSettings: Hashable {
             params.additionalFields = WpAdditionalFields.fromTermIdMap(map: customTermChanges)
         }
 
-        // Social connections
-        if let connectionsByID = socialSharingDraft?.connectionsByID, !connectionsByID.isEmpty {
-            params.additionalFields = (params.additionalFields ?? WpAdditionalFields())
-                .addingPublicizeConnections(connectionsByID)
+        // Social connections. The fetched post can already carry explicit
+        // per-post connection state, so only send it back when the user changed
+        // it during this edit session.
+        if let connectionsByID = socialSharingDraft?.connectionsByID {
+            let originalConnectionsByID = post.additionalFields?.publicizeConnectionsByID
+            if originalConnectionsByID != connectionsByID {
+                params.additionalFields = (params.additionalFields ?? WpAdditionalFields())
+                    .addingPublicizeConnections(connectionsByID)
+            }
         }
 
         // Social meta. The custom message is sent only when it differs from

--- a/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettings.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettings.swift
@@ -135,6 +135,16 @@ struct PostSettings: Hashable {
             }
         }
         self.otherTerms = otherTerms
+
+        // TODO: After PR 25543 is merged, remove this PostCreateParams
+        // restore path. New-post state will carry PostSettings directly.
+        let socialSharingDraft = PostSocialSharingDraft(
+            fromPostAdditionalFields: params.additionalFields,
+            meta: params.meta
+        )
+        if socialSharingDraft.customMessage != nil || socialSharingDraft.connectionsByID != nil {
+            self.socialSharingDraft = socialSharingDraft
+        }
     }
 
     /// Creates PostSettings from an AbstractPost instance.
@@ -515,9 +525,18 @@ struct PostSettings: Hashable {
         params.parent = parentPageID.map { PostId(Int64($0)) }
         params.additionalFields = fields
 
-        // Social meta
-        if let message = socialSharingDraft?.customMessage, !message.isEmpty {
-            params.meta = (params.meta ?? PostMeta()).addingPublicizeMessage(message)
+        // Social meta. When a local new-post draft already carries a saved
+        // message, clearing the field needs to write an empty string back into
+        // the create params rather than leaving the stale value in place.
+        // TODO: After PR 25543 is merged, move this social serialization into
+        // makeCreateParameters(taxonomies:) and remove the existing-param
+        // comparison.
+        if let socialSharingDraft {
+            let originalMessage = existing.meta?.publicizeMessage
+            let newMessage = socialSharingDraft.customMessage ?? ""
+            if originalMessage != (newMessage.isEmpty ? nil : newMessage) {
+                params.meta = (params.meta ?? PostMeta()).addingPublicizeMessage(newMessage)
+            }
         }
 
         return params

--- a/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettings.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettings.swift
@@ -1,4 +1,5 @@
 import Foundation
+import JetpackSocial
 import WordPressAPIInternal
 import WordPressData
 import WordPressKit
@@ -65,6 +66,9 @@ struct PostSettings: Hashable {
     var postFormat: String?
     var isStickyPost = false
     var sharing: PostSocialSharingSettings?
+    /// Publicize draft state used for change detection and REST parameter encoding.
+    /// When available, `connectionsByID` carries the full post-level connection state.
+    var socialSharingDraft: PostSocialSharingDraft?
     var allowComments = true
     var allowPings = true
 
@@ -443,6 +447,24 @@ struct PostSettings: Hashable {
             params.additionalFields = WpAdditionalFields.fromTermIdMap(map: customTermChanges)
         }
 
+        // Social connections
+        if let connectionsByID = socialSharingDraft?.connectionsByID, !connectionsByID.isEmpty {
+            params.additionalFields = (params.additionalFields ?? WpAdditionalFields())
+                .addingPublicizeConnections(connectionsByID)
+        }
+
+        // Social meta. The custom message is sent only when it differs from
+        // the post's saved value. An emptied field maps to an empty string so
+        // that the partial-update PATCH actually clears the previous value
+        // server-side, instead of being omitted from the meta dictionary.
+        if let socialSharingDraft {
+            let originalMessage = post.meta?.publicizeMessage
+            let newMessage = socialSharingDraft.customMessage ?? ""
+            if originalMessage != (newMessage.isEmpty ? nil : newMessage) {
+                params.meta = (params.meta ?? PostMeta()).addingPublicizeMessage(newMessage)
+            }
+        }
+
         let postParentPageID = post.parent.map { Int($0) }
         if postParentPageID != self.parentPageID {
             params.parent = self.parentPageID.map { PostId(Int64($0)) } ?? PostId(0)
@@ -465,10 +487,16 @@ struct PostSettings: Hashable {
                 customTerms[taxonomy.restBase] = termIds
             }
         }
-        let fields: WpAdditionalFields? =
+        var fields: WpAdditionalFields? =
             customTerms.isEmpty
             ? nil
             : WpAdditionalFields.fromTermIdMap(map: customTerms)
+
+        // Social connections
+        if let connectionsByID = socialSharingDraft?.connectionsByID, !connectionsByID.isEmpty {
+            fields = (fields ?? WpAdditionalFields())
+                .addingPublicizeConnections(connectionsByID)
+        }
 
         var params = existing
         params.dateGmt = publishDate
@@ -486,6 +514,12 @@ struct PostSettings: Hashable {
         params.tags = tagIds
         params.parent = parentPageID.map { PostId(Int64($0)) }
         params.additionalFields = fields
+
+        // Social meta
+        if let message = socialSharingDraft?.customMessage, !message.isEmpty {
+            params.meta = (params.meta ?? PostMeta()).addingPublicizeMessage(message)
+        }
+
         return params
     }
 }

--- a/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettings.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettings.swift
@@ -237,8 +237,16 @@ struct PostSettings: Hashable {
 
         parentPageID = post.parent.map { Int($0) }
 
-        // Social sharing (Publicize) is not available for REST API posts
+        // Legacy Publicize settings are not available for REST API posts.
         sharing = nil
+
+        let socialSharingDraft = PostSocialSharingDraft(
+            fromPostAdditionalFields: post.additionalFields,
+            meta: post.meta
+        )
+        if socialSharingDraft.customMessage != nil || socialSharingDraft.connectionsByID != nil {
+            self.socialSharingDraft = socialSharingDraft
+        }
     }
 
     // MARK: - Applying Changes

--- a/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsCapabilities.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsCapabilities.swift
@@ -12,6 +12,7 @@ struct PostSettingsCapabilities {
     var supportsPageAttributes: Bool
     var supportsSlug: Bool
     var supportsCustomFields: Bool
+    var supportsPublicize: Bool
     var customTaxonomySlugs: [String]
 }
 
@@ -32,6 +33,7 @@ extension PostSettingsCapabilities {
             supportsPageAttributes: false,
             supportsSlug: true,
             supportsCustomFields: true,
+            supportsPublicize: true,
             customTaxonomySlugs: []
         )
     }
@@ -53,6 +55,7 @@ extension PostSettingsCapabilities {
             supportsPageAttributes: true,
             supportsSlug: true,
             supportsCustomFields: true,
+            supportsPublicize: false,
             customTaxonomySlugs: []
         )
     }
@@ -70,6 +73,8 @@ extension PostSettingsCapabilities {
         supportsPageAttributes = details.supports.supports(feature: .pageAttributes)
         supportsSlug = details.supports.supports(feature: .slug)
         supportsCustomFields = false // details.supports.supports(feature: .customFields)
+        supportsPublicize = details.toPostEndpointType() == .posts
+            || details.supports.supports(feature: .custom("publicize"))
         customTaxonomySlugs = details.taxonomies.filter { $0 != "category" && $0 != "post_tag" }
     }
 }

--- a/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsView.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsView.swift
@@ -618,6 +618,7 @@ private struct JetpackBrandSectionHeader: View {
             Image("icon-jetpack")
                 .resizable()
                 .frame(width: 14, height: 14)
+                .accessibilityHidden(true)
             SectionHeader("Jetpack")
         }
     }

--- a/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsView.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsView.swift
@@ -1,6 +1,7 @@
 import UIKit
 import CoreData
 import Combine
+import JetpackSocial
 import WordPressData
 import WordPressKit
 import WordPressShared
@@ -153,7 +154,7 @@ struct PostSettingsFormContentView<ViewModel: PostSettingsViewModelProtocol>: Vi
             excerptSection
         }
         generalSection
-        socialSharingSection
+        socialSharingSectionDispatcher
         accessSection
         moreOptionsSection
     }
@@ -383,6 +384,24 @@ struct PostSettingsFormContentView<ViewModel: PostSettingsViewModelProtocol>: Vi
     // MARK: - "Social Sharing" Section
 
     @ViewBuilder
+    private var socialSharingSectionDispatcher: some View {
+        if let binding = viewModel.v2SocialSharing {
+            // The server early-returns updates to `jetpack_publicize_connections`
+            // for already-published posts, and re-share isn't supported in the
+            // app yet — so the section has nothing actionable to show.
+            if !binding.isPostPublished {
+                V2SocialSharingEntrySection(
+                    connections: binding.connections,
+                    draft: binding.draft,
+                    onAddConnection: binding.onAddConnection
+                )
+            }
+        } else {
+            socialSharingSection
+        }
+    }
+
+    @ViewBuilder
     private var socialSharingSection: some View {
         if let state = viewModel.socialSharingState {
             Section {
@@ -560,6 +579,51 @@ private struct LegacyNavigationLinkRow<Content: View>: View {
         .tint(.primary)
     }
 }
+
+/// Top-level entry for the v2 social-sharing flow. Shows a single
+/// `NavigationLink` in Post Settings; the toggles and custom message
+/// field live on the pushed detail screen.
+private struct V2SocialSharingEntrySection: View {
+    @ObservedObject var connections: SiteSocialConnectionsService
+    @Binding var draft: PostSocialSharingDraft
+    let onAddConnection: (() -> Void)?
+
+    var body: some View {
+        Section {
+            NavigationLink {
+                PostSocialSharingDetailView(
+                    connections: connections,
+                    draft: $draft,
+                    onAddConnection: onAddConnection
+                )
+            } label: {
+                SettingsRow(JetpackSocialStrings.PostSection.header) {
+                    if let summary = draft.summary(for: connections.connections.value ?? []) {
+                        Text(summary)
+                    }
+                }
+            }
+        } header: {
+            JetpackBrandSectionHeader()
+        }
+        .task {
+            _ = try? await connections.loadConnections()
+        }
+    }
+}
+
+private struct JetpackBrandSectionHeader: View {
+    var body: some View {
+        HStack(spacing: 4) {
+            Image("icon-jetpack")
+                .resizable()
+                .frame(width: 14, height: 14)
+            SectionHeader("Jetpack")
+        }
+    }
+}
+
+private typealias JetpackSocialStrings = JetpackSocial.Strings
 
 private enum Strings {
     static let generalHeader = NSLocalizedString(

--- a/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsViewModelProtocol.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsViewModelProtocol.swift
@@ -1,4 +1,5 @@
 import Foundation
+import JetpackSocial
 import SwiftUI
 import UIKit
 import WordPressAPI
@@ -69,6 +70,12 @@ protocol PostSettingsViewModelProtocol: ObservableObject {
     var customTaxonomies: [SiteTaxonomy] { get }
     var parentPageText: String? { get }
     var socialSharingState: PostSettingsSocialSharingSectionState? { get }
+
+    /// Non-nil when the host screen should render the v2 social sharing
+    /// section. Only `CustomPostSettingsViewModel` populates this; legacy
+    /// `AbstractPost` flows return `nil`.
+    var v2SocialSharing: V2SocialSharingBinding? { get }
+
     var isShowingDeletedAlert: Bool { get set }
 
     var postContent: String { get }
@@ -116,6 +123,18 @@ protocol PostSettingsViewModelProtocol: ObservableObject {
 }
 
 // MARK: - Default Implementations
+
+/// Bindings and services the v2 social sharing section needs from its host view model.
+struct V2SocialSharingBinding {
+    let connections: SiteSocialConnectionsService
+    let draft: Binding<PostSocialSharingDraft>
+    let isPostPublished: Bool
+    let onAddConnection: (() -> Void)?
+}
+
+extension PostSettingsViewModelProtocol {
+    var v2SocialSharing: V2SocialSharingBinding? { nil }
+}
 
 extension PostSettingsViewModelProtocol {
     var visibleMoreOptions: [PostSettingsMoreOption] {


### PR DESCRIPTION
Adds a new "Share to social media" section to Post Settings for custom post types when the socialSharingV2 feature flag is enabled. The section shows the site's connected social accounts with per-connection toggles, an optional custom message field, and an "Add a connection" entry point that reuses the OAuth flow from the Social screen.

On save, the post payload now includes jetpack_publicize_connections in additional fields and jetpack_publicize_message in post meta, so Jetpack Social can publish the post to the selected accounts.

https://github.com/user-attachments/assets/f52ced42-15a9-47ea-8c03-df4ebd658076

