### PR TITLE
Fix retain cycles in AnnouncementsDataStoreTests and GutenbergVideoUploadProcessor

### DIFF
--- a/Tests/KeystoneTests/Tests/Features/Misc/WhatsNew/AnnouncementsDataStoreTests.swift
+++ b/Tests/KeystoneTests/Tests/Features/Misc/WhatsNew/AnnouncementsDataStoreTests.swift
@@ -76,6 +76,11 @@ class AnnouncementsDataStoreTests: XCTestCase {
 
     private var subscription: Receipt?
 
+    override func tearDown() {
+        subscription = nil
+        super.tearDown()
+    }
+
     /// local cache contains valid announcements
     func testLocalAnnouncementsRetrieved() {
         // Given

--- a/WordPress/Classes/ViewRelated/Gutenberg/Processors/GutenbergVideoUploadProcessor.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Processors/GutenbergVideoUploadProcessor.swift
@@ -13,7 +13,8 @@ class GutenbergVideoUploadProcessor: Processor {
         self.remoteURLString = remoteURLString
     }
 
-    lazy var videoHtmlProcessor = HTMLProcessor(for: "video", replacer: { (video) in
+    lazy var videoHtmlProcessor = HTMLProcessor(for: "video", replacer: { [weak self] (video) in
+        guard let self else { return "" }
         var attributes = video.attributes
 
         attributes.set(.string(self.remoteURLString), forKey: "src")
@@ -30,8 +31,9 @@ class GutenbergVideoUploadProcessor: Processor {
         static var id = "id"
     }
 
-    lazy var videoBlockProcessor = GutenbergBlockProcessor(for: VideoBlockKeys.name, replacer: { videoBlock in
-        guard let mediaID = videoBlock.attributes[VideoBlockKeys.id] as? Int,
+    lazy var videoBlockProcessor = GutenbergBlockProcessor(for: VideoBlockKeys.name, replacer: { [weak self] videoBlock in
+        guard let self,
+            let mediaID = videoBlock.attributes[VideoBlockKeys.id] as? Int,
             mediaID == self.mediaUploadID else {
                 return nil
         }
@@ -53,8 +55,9 @@ class GutenbergVideoUploadProcessor: Processor {
         static var id = "mediaId"
     }
 
-    lazy var mediaTextVideoBlockProcessor = GutenbergBlockProcessor(for: MediaTextBlockKeys.name, replacer: { videoBlock in
-        guard let mediaID = videoBlock.attributes[MediaTextBlockKeys.id] as? Int,
+    lazy var mediaTextVideoBlockProcessor = GutenbergBlockProcessor(for: MediaTextBlockKeys.name, replacer: { [weak self] videoBlock in
+        guard let self,
+            let mediaID = videoBlock.attributes[MediaTextBlockKeys.id] as? Int,
             mediaID == self.mediaUploadID else {
                 return nil
         }


### PR DESCRIPTION
Closes #25547.

Report:

[wp-local-audit-Xcode26.0.zip](https://github.com/user-attachments/files/27546567/wp-local-audit-Xcode26.0.zip)

## Description

Fixes two distinct retain cycles surfaced by XCTestLeaks against the `WordPress` scheme.

### 1. `AnnouncementsDataStoreTests` (test code)

```
store → changeDispatcher → observers[token] → closure → store
```

The four tests stash `subscription = store.onChange { … store.x … }` as an instance property; the closure captures the local `store` strongly and is retained by `Dispatcher.observers`. Without a `tearDown` the `Receipt` only deinits when XCTest tears the test instance down, which is deferred when the class has multiple queued tests — long enough for the post-test leak snapshot to observe the cycle.

**Fix:** add `tearDown` that nils `subscription`. The `Receipt`'s `deinit` then calls `unsubscribe` immediately, removing the closure from `observers` and breaking the cycle.

### 2. `GutenbergVideoUploadProcessor` (production code)

```
GutenbergVideoUploadProcessor
  → videoHtmlProcessor (HTMLProcessor) [lazy strong]
    → replacer.context → captures self strongly
      → GutenbergVideoUploadProcessor (cycle)
```

Three `lazy var` properties construct child processors whose `replacer:` closures reference `self.remoteURLString` / `self.mediaUploadID` without a capture list. Each lazy property is strongly owned by `self` and retains a closure that captures `self` strongly — three independent two-node cycles.

**Fix:** `[weak self] + guard let self` in all three closures. By ownership the closure can only execute while `self` is alive, so the guard is never tripped in practice.

## Testing 

```bash
# Cycle 1
xctestleaks agent run \\
  --workspace WordPress.xcworkspace --scheme WordPress \\
  --only-testing "WordPressTest/AnnouncementsDataStoreTests"

# Cycle 2
xctestleaks agent run \\
  --workspace WordPress.xcworkspace --scheme WordPress \\
  --only-testing "WordPressTest/GutenbergVideoUploadProcessorTests/testMediaTextBlockProcessor"
```

Both reported `0 leaks` on this branch and the original leak counts on `trunk`.

## Notes for reviewers

The first leak is in test file, I'm open to revert let me know how'd you feel about it. The second one is production leak and we can get that in.