### PR TITLE
Add WordPressMediaLibrary module with a basic media list screen

### DIFF
--- a/Modules/Package.resolved
+++ b/Modules/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "cce232941d1d80cb55c6a367fa6391b388bf73de8890b3d50efaf143f038d8b9",
+  "originHash" : "920b9a58f87b41f634e1faf8d1df637331bb83ec43992a02726e7161754e6bf8",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -343,10 +343,10 @@
     {
       "identity" : "wordpress-rs",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/Automattic/wordpress-rs",
+      "location" : "https://github.com/automattic/wordpress-rs",
       "state" : {
-        "revision" : "ace6a04026c9fcf111a695394debf8f5e7031ced",
-        "version" : "0.2.0"
+        "branch" : "pr-build/1346",
+        "revision" : "38f49a62b6aacff88933e285c7e04449383bb177"
       }
     },
     {

--- a/Modules/Package.resolved
+++ b/Modules/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "920b9a58f87b41f634e1faf8d1df637331bb83ec43992a02726e7161754e6bf8",
+  "originHash" : "84257158eee34b797c4f5c81ad33c2f508fe93818c99642c468f31136376cda1",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -345,8 +345,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/automattic/wordpress-rs",
       "state" : {
-        "branch" : "pr-build/1346",
-        "revision" : "38f49a62b6aacff88933e285c7e04449383bb177"
+        "revision" : "7065171801606268e9ad0554cf8ec3b7de8ff04d",
+        "version" : "0.3.0"
       }
     },
     {

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -63,7 +63,7 @@ let package = Package(
         .package(url: "https://github.com/wordpress-mobile/GutenbergKit", from: "0.15.0"),
         .package(
             url: "https://github.com/automattic/wordpress-rs",
-            branch: "pr-build/1346"
+            exact: "0.3.0"
         ),
         .package(
             url: "https://github.com/Automattic/color-studio",

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -25,7 +25,8 @@ let package = Package(
         .library(name: "WordPressReader", targets: ["WordPressReader"]),
         .library(name: "WordPressCore", targets: ["WordPressCore"]),
         .library(name: "WordPressCoreProtocols", targets: ["WordPressCoreProtocols"]),
-        .library(name: "WordPressKit", targets: ["WordPressKit"])
+        .library(name: "WordPressKit", targets: ["WordPressKit"]),
+        .library(name: "WordPressMediaLibrary", targets: ["WordPressMediaLibrary"])
     ],
     dependencies: [
         .package(url: "https://github.com/airbnb/lottie-ios", from: "4.4.0"),
@@ -132,6 +133,18 @@ let package = Package(
                 .product(name: "Logging", package: "swift-log")
             ],
             resources: [.process("Resources")]
+        ),
+        .target(
+            name: "WordPressMediaLibrary",
+            dependencies: [
+                "AsyncImageKit",
+                "DesignSystem",
+                "WordPressShared",
+                "WordPressUI",
+                "WordPressCore",
+                .product(name: "WordPressAPI", package: "wordpress-rs"),
+                .product(name: "Logging", package: "swift-log")
+            ]
         ),
         .target(
             name: "ShareExtensionCore",
@@ -435,6 +448,7 @@ enum XcodeSupport {
             "WordPressIntelligence",
             "WordPressShared",
             "WordPressLegacy",
+            "WordPressMediaLibrary",
             "WordPressReader",
             "WordPressUI",
             "WordPressCore",

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -61,10 +61,9 @@ let package = Package(
         ),
         .package(url: "https://github.com/zendesk/support_sdk_ios", from: "8.0.3"),
         .package(url: "https://github.com/wordpress-mobile/GutenbergKit", from: "0.15.0"),
-        // We can't use wordpress-rs branches nor commits here. Only tags work.
         .package(
-            url: "https://github.com/Automattic/wordpress-rs",
-            exact: "0.2.0"
+            url: "https://github.com/automattic/wordpress-rs",
+            branch: "pr-build/1346"
         ),
         .package(
             url: "https://github.com/Automattic/color-studio",

--- a/Modules/Sources/WordPressMediaLibrary/Analytics/MediaTracker.swift
+++ b/Modules/Sources/WordPressMediaLibrary/Analytics/MediaTracker.swift
@@ -13,7 +13,6 @@ public protocol MediaTracker {
 
 public enum MediaTrackerEvent: Sendable {
     case mediaLibraryOpened
-    // M2-M7 add more cases here.
 }
 
 /// No-op tracker for previews and module-internal default-construction.

--- a/Modules/Sources/WordPressMediaLibrary/Analytics/MediaTracker.swift
+++ b/Modules/Sources/WordPressMediaLibrary/Analytics/MediaTracker.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+/// Analytics protocol for the Media Library module.
+///
+/// `@MainActor` rather than `Sendable` because the app-target adapter stores
+/// `Blog` (an `NSManagedObject`, not Sendable) and a properties dictionary
+/// containing `Any`. The open event always fires from a MainActor context
+/// (`MediaLibraryView.task`), so MainActor isolation is the right shape.
+@MainActor
+public protocol MediaTracker {
+    func track(_ event: MediaTrackerEvent)
+}
+
+public enum MediaTrackerEvent: Sendable {
+    case mediaLibraryOpened
+    // M2-M7 add more cases here.
+}
+
+/// No-op tracker for previews and module-internal default-construction.
+@MainActor
+public struct MockMediaTracker: MediaTracker {
+    public init() {}
+
+    public func track(_ event: MediaTrackerEvent) {
+        #if DEBUG
+        debugPrint("[MediaTracker] \(event)")
+        #endif
+    }
+}

--- a/Modules/Sources/WordPressMediaLibrary/Logging/Loggers.swift
+++ b/Modules/Sources/WordPressMediaLibrary/Logging/Loggers.swift
@@ -1,0 +1,5 @@
+import Logging
+
+enum Loggers {
+    static let mediaLibrary = Logger(label: "org.wordpress.media-library")
+}

--- a/Modules/Sources/WordPressMediaLibrary/Models/MediaListItem.swift
+++ b/Modules/Sources/WordPressMediaLibrary/Models/MediaListItem.swift
@@ -1,0 +1,67 @@
+import Foundation
+import WordPressAPI
+import WordPressAPIInternal
+
+struct MediaListItem: Identifiable, Equatable {
+    let id: Int64
+    let title: String?
+    let thumbnailURL: URL?
+    let state: State
+
+    enum State: Equatable {
+        case loaded(isUpToDate: Bool)
+        case loading
+        case error(message: String)
+    }
+
+    init(item: MediaMetadataCollectionItem) {
+        self.id = item.id
+
+        switch item.state {
+        case .fresh(let entity):
+            self.title = MediaListItem.makeTitle(from: entity.data)
+            self.thumbnailURL = MediaListItem.makeThumbnailURL(from: entity.data)
+            self.state = .loaded(isUpToDate: true)
+
+        case .stale(let entity):
+            self.title = MediaListItem.makeTitle(from: entity.data)
+            self.thumbnailURL = MediaListItem.makeThumbnailURL(from: entity.data)
+            self.state = .loaded(isUpToDate: false)
+
+        case .fetchingWithData(let entity):
+            self.title = MediaListItem.makeTitle(from: entity.data)
+            self.thumbnailURL = MediaListItem.makeThumbnailURL(from: entity.data)
+            self.state = .loading
+
+        case .fetching, .missing:
+            self.title = nil
+            self.thumbnailURL = nil
+            self.state = .loading
+
+        case .failed(let error):
+            self.title = nil
+            self.thumbnailURL = nil
+            self.state = .error(message: error)
+
+        case .failedWithData(let error, let entity):
+            self.title = MediaListItem.makeTitle(from: entity.data)
+            self.thumbnailURL = MediaListItem.makeThumbnailURL(from: entity.data)
+            self.state = .error(message: error)
+        }
+    }
+
+    /// Prefer `title.raw`, fall back to `slug`, fall back to nil. The view
+    /// renders `Strings.untitled` when this is nil.
+    private static func makeTitle(from media: MediaWithEditContext) -> String? {
+        let raw = (media.title.raw ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        if !raw.isEmpty { return raw }
+        let slug = media.slug.trimmingCharacters(in: .whitespacesAndNewlines)
+        return slug.isEmpty ? nil : slug
+    }
+
+    /// M1 uses `sourceUrl` as the thumbnail. M2 picks a smaller size from
+    /// `media.mediaDetails.sizes` for grid rendering.
+    private static func makeThumbnailURL(from media: MediaWithEditContext) -> URL? {
+        URL(string: media.sourceUrl)
+    }
+}

--- a/Modules/Sources/WordPressMediaLibrary/Models/MediaListItem.swift
+++ b/Modules/Sources/WordPressMediaLibrary/Models/MediaListItem.swift
@@ -55,8 +55,7 @@ struct MediaListItem: Identifiable, Equatable {
     private static func makeTitle(from media: MediaWithEditContext) -> String? {
         let raw = (media.title.raw ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
         if !raw.isEmpty { return raw }
-        let slug = media.slug.trimmingCharacters(in: .whitespacesAndNewlines)
-        return slug.isEmpty ? nil : slug
+        return media.slug.isEmpty ? nil : media.slug
     }
 
     /// Uses `sourceUrl` as the thumbnail for now. A future change will pick a

--- a/Modules/Sources/WordPressMediaLibrary/Models/MediaListItem.swift
+++ b/Modules/Sources/WordPressMediaLibrary/Models/MediaListItem.swift
@@ -59,8 +59,8 @@ struct MediaListItem: Identifiable, Equatable {
         return slug.isEmpty ? nil : slug
     }
 
-    /// M1 uses `sourceUrl` as the thumbnail. M2 picks a smaller size from
-    /// `media.mediaDetails.sizes` for grid rendering.
+    /// Uses `sourceUrl` as the thumbnail for now. A future change will pick a
+    /// smaller size from `media.mediaDetails.sizes` for grid rendering.
     private static func makeThumbnailURL(from media: MediaWithEditContext) -> URL? {
         URL(string: media.sourceUrl)
     }

--- a/Modules/Sources/WordPressMediaLibrary/Strings/Strings.swift
+++ b/Modules/Sources/WordPressMediaLibrary/Strings/Strings.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+enum Strings {
+    static let title = NSLocalizedString(
+        "mediaLibrary.screen.title",
+        value: "Media",
+        comment: "Title for the Media Library V2 screen"
+    )
+
+    static let empty = NSLocalizedString(
+        "mediaLibrary.empty.message",
+        value: "No media yet",
+        comment: "Message shown when the Media Library has no items"
+    )
+
+    static let errorRetry = NSLocalizedString(
+        "mediaLibrary.error.retry",
+        value: "Try again",
+        comment: "Button label to retry loading after an error"
+    )
+
+    static let untitled = NSLocalizedString(
+        "mediaLibrary.row.untitled",
+        value: "(no title)",
+        comment: "Placeholder shown for media items with no title"
+    )
+}

--- a/Modules/Sources/WordPressMediaLibrary/Views/MediaLibraryHostingController.swift
+++ b/Modules/Sources/WordPressMediaLibrary/Views/MediaLibraryHostingController.swift
@@ -1,0 +1,21 @@
+import SwiftUI
+import UIKit
+import WordPressCore
+
+public enum MediaLibraryHostingController {
+    /// Module-side factory. Constructs the ViewModel from a resolved
+    /// WordPressClient and wraps it in a UIHostingController. The Blog gate
+    /// and WordPressClient construction live in the app target — see
+    /// `WordPress/Classes/ViewRelated/Media/MediaLibraryRouting.swift`.
+    @MainActor
+    public static func make(
+        client: WordPressClient,
+        tracker: any MediaTracker
+    ) -> UIViewController {
+        let viewModel = MediaLibraryViewModel(client: client, tracker: tracker)
+        let view = MediaLibraryView(viewModel: viewModel, tracker: tracker)
+        let host = UIHostingController(rootView: view)
+        host.navigationItem.largeTitleDisplayMode = .never
+        return host
+    }
+}

--- a/Modules/Sources/WordPressMediaLibrary/Views/MediaLibraryRow.swift
+++ b/Modules/Sources/WordPressMediaLibrary/Views/MediaLibraryRow.swift
@@ -1,0 +1,56 @@
+import SwiftUI
+import AsyncImageKit
+
+struct MediaLibraryRow: View {
+    let item: MediaListItem
+
+    var body: some View {
+        HStack(spacing: 12) {
+            thumbnail
+                .frame(width: 44, height: 44)
+                .clipShape(RoundedRectangle(cornerRadius: 6))
+            Text(displayTitle)
+                .font(.body)
+                .lineLimit(1)
+            Spacer()
+        }
+        .opacity(opacityForState)
+        .accessibilityLabel(displayTitle)
+    }
+
+    @ViewBuilder
+    private var thumbnail: some View {
+        switch item.state {
+        case .error:
+            Image(systemName: "exclamationmark.triangle")
+                .foregroundStyle(.secondary)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .background(Color(uiColor: .secondarySystemBackground))
+        case .loading, .loaded:
+            // Use the closure-form initializer so we can call
+            // `.resizable()` on the inner image — the default
+            // `CachedAsyncImage(url:)` returns a non-resizable Image (or a
+            // Color), which would render at the asset's natural size and
+            // ignore the .frame(width: 44, height: 44) we apply outside.
+            // Matches the existing pattern in JetpackStats/Views/AvatarView.swift.
+            CachedAsyncImage(url: item.thumbnailURL) { image in
+                image
+                    .resizable()
+                    .aspectRatio(contentMode: .fill)
+            } placeholder: {
+                Color(uiColor: .secondarySystemBackground)
+            }
+        }
+    }
+
+    private var displayTitle: String {
+        item.title ?? Strings.untitled
+    }
+
+    private var opacityForState: Double {
+        if case .loaded(let isUpToDate) = item.state, !isUpToDate {
+            return 0.7
+        }
+        return 1.0
+    }
+}

--- a/Modules/Sources/WordPressMediaLibrary/Views/MediaLibraryView.swift
+++ b/Modules/Sources/WordPressMediaLibrary/Views/MediaLibraryView.swift
@@ -1,0 +1,64 @@
+import SwiftUI
+
+struct MediaLibraryView: View {
+    @ObservedObject var viewModel: MediaLibraryViewModel
+    let tracker: any MediaTracker
+
+    var body: some View {
+        List(viewModel.items) { item in
+            MediaLibraryRow(item: item)
+                .onAppear {
+                    Task { await viewModel.loadNextPageIfNeeded(after: item) }
+                }
+        }
+        .refreshable { await viewModel.pullToRefresh() }
+        // Two .task modifiers run concurrently from view appearance. Refresh
+        // is now deterministic on its own (calls loadItems directly after
+        // network success), so the observer task is purely for subsequent
+        // updates (browser-side edits etc.).
+        .task { await viewModel.handleDataChanges() }
+        .task {
+            tracker.track(.mediaLibraryOpened)
+            // performInitialLoad() owns isRefreshing across the entire
+            // loadCachedItems + refresh sequence so the empty state can't
+            // flash between them on cold-cache first open.
+            await viewModel.performInitialLoad()
+        }
+        .navigationTitle(Strings.title)
+        // Single overlay with explicit precedence — three separate overlays
+        // could stack (e.g., empty + error both true after a failed cold-
+        // cache refresh). Error wins, then empty, then loading.
+        .overlay {
+            if let error = viewModel.errorToDisplay() {
+                errorView(error)
+            } else if viewModel.shouldDisplayEmptyView {
+                emptyView
+            } else if viewModel.shouldDisplayInitialLoading {
+                ProgressView()
+            }
+        }
+    }
+
+    private var emptyView: some View {
+        ContentUnavailableView(
+            Strings.empty,
+            systemImage: "photo.on.rectangle"
+        )
+    }
+
+    private func errorView(_ error: Error) -> some View {
+        VStack(spacing: 12) {
+            Image(systemName: "exclamationmark.triangle")
+                .font(.largeTitle)
+                .foregroundStyle(.secondary)
+            Text(error.localizedDescription)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal)
+            Button(Strings.errorRetry) {
+                Task { await viewModel.refresh() }
+            }
+            .buttonStyle(.borderedProminent)
+        }
+        .padding()
+    }
+}

--- a/Modules/Sources/WordPressMediaLibrary/Views/MediaLibraryViewModel.swift
+++ b/Modules/Sources/WordPressMediaLibrary/Views/MediaLibraryViewModel.swift
@@ -136,9 +136,8 @@ final class MediaLibraryViewModel: ObservableObject {
         }
     }
 
-    // TODO: Pagination is temporary for M1. Future milestones will switch
-    // the Media Library to a full-library sync model rather than per-page
-    // fetches.
+    // TODO: Pagination is temporary. A future change will switch the Media
+    // Library to a full-library sync model rather than per-page fetches.
     func loadNextPage() async throws {
         // Two guards:
         //   1. !isRefreshing — warm-cache first open paints cached rows
@@ -166,7 +165,7 @@ final class MediaLibraryViewModel: ObservableObject {
         await loadItems(from: collection)
     }
 
-    // TODO: Pagination is temporary for M1 — see loadNextPage().
+    // TODO: Pagination is temporary, see loadNextPage().
     func loadNextPageIfNeeded(after item: MediaListItem) async {
         // Trigger a fetch only when the row that just appeared is one of the
         // last few rows we have loaded — protects against firing for every

--- a/Modules/Sources/WordPressMediaLibrary/Views/MediaLibraryViewModel.swift
+++ b/Modules/Sources/WordPressMediaLibrary/Views/MediaLibraryViewModel.swift
@@ -116,8 +116,18 @@ final class MediaLibraryViewModel: ObservableObject {
             return
         }
 
+        // The filter closure runs synchronously on whichever thread the
+        // upstream publisher emits on — for wp-rs's `databaseUpdatesPublisher()`
+        // that's the SQLite worker thread (NotificationCenter post from the
+        // rusqlite update hook). Marking it `@Sendable` opts out of the
+        // implicit `@MainActor` isolation that Swift 6 would otherwise
+        // inherit from the enclosing class, so the cheap `isRelevantUpdate`
+        // check stays on the background thread without tripping the runtime
+        // MainActor assertion. The downstream `.collect(.byTime(DispatchQueue.main, …))`
+        // hops to main before delivering batches, so the `for await` body
+        // runs on main where it mutates `@Published` state.
         let batches = await client.cache.databaseUpdatesPublisher()
-            .filter { [weak collection] in collection?.isRelevantUpdate(hook: $0) == true }
+            .filter { @Sendable [weak collection] in collection?.isRelevantUpdate(hook: $0) == true }
             .collect(.byTime(DispatchQueue.main, .milliseconds(50)))
             .values
 

--- a/Modules/Sources/WordPressMediaLibrary/Views/MediaLibraryViewModel.swift
+++ b/Modules/Sources/WordPressMediaLibrary/Views/MediaLibraryViewModel.swift
@@ -1,0 +1,210 @@
+import Foundation
+import SwiftUI
+import WordPressAPI
+import WordPressAPIInternal
+import WordPressCore
+
+@MainActor
+final class MediaLibraryViewModel: ObservableObject {
+    private let client: WordPressClient
+    private let tracker: any MediaTracker
+    private var collectionTask: Task<MediaMetadataCollectionWithEditContext, Error>?
+    private var isLoadingNextPage = false
+
+    @Published private(set) var items: [MediaListItem] = []
+    @Published private(set) var listInfo: ListInfo?
+    @Published private(set) var error: Error?
+    /// Set to true while `refresh()` is in flight. Drives the cold-cache
+    /// initial-loading spinner explicitly, instead of inferring from the
+    /// wp-rs collection's `listInfo.isSyncing` (which only updates after
+    /// the cache observer wakes — racy).
+    @Published private(set) var isRefreshing = false
+
+    var shouldDisplayInitialLoading: Bool { items.isEmpty && isRefreshing }
+    var shouldDisplayEmptyView: Bool { items.isEmpty && !isRefreshing && error == nil }
+    func errorToDisplay() -> Error? { items.isEmpty ? error : nil }
+
+    init(client: WordPressClient, tracker: any MediaTracker) {
+        self.client = client
+        self.tracker = tracker
+    }
+
+    /// Resolves WpService and constructs the collection, exactly once.
+    /// Cached as a Task so concurrent callers (the cache observer task and
+    /// the refresh task both wake at view appearance) await the same
+    /// construction. Same pattern WordPressClient itself uses for site
+    /// info / current user.
+    private func resolveCollection() async throws -> MediaMetadataCollectionWithEditContext {
+        if let collectionTask {
+            return try await collectionTask.value
+        }
+        let task = Task<MediaMetadataCollectionWithEditContext, Error> { [client] in
+            let service = try await client.service
+            return service.media()
+                .createMediaMetadataCollectionWithEditContext(
+                    filter: MediaListFilter(),
+                    perPage: 100
+                )
+        }
+        self.collectionTask = task
+        return try await task.value
+    }
+
+    /// Loads cached items into `items` immediately so the first paint isn't
+    /// blocked on the network round-trip.
+    func loadCachedItems() async {
+        do {
+            let collection = try await resolveCollection()
+            await loadItems(from: collection)
+        } catch {
+            Loggers.mediaLibrary.error("Failed to load cached items: \(error)")
+        }
+    }
+
+    /// Single entry point for the SwiftUI .task block. Owns isRefreshing
+    /// across BOTH loadCachedItems() and refresh() so the empty state can't
+    /// flash in the microsecond window between them on cold-cache first
+    /// open. SwiftUI re-evaluates body on every @Published change, so even
+    /// a single MainActor scheduling hop where (items.isEmpty &&
+    /// !isRefreshing && error == nil) holds will paint the empty view.
+    func performInitialLoad() async {
+        isRefreshing = true
+        defer { isRefreshing = false }
+        await loadCachedItems()
+        await refresh()
+    }
+
+    func refresh() async {
+        // isRefreshing drives the cold-cache initial-loading UI deterministically,
+        // independent of the wp-rs cache observer's wake timing.
+        isRefreshing = true
+        defer { isRefreshing = false }
+
+        // Clear stale error from any previous failed attempt so a successful
+        // retry unblocks the empty/list UI even when the new fetch returns
+        // zero items. Without this, errorToDisplay() would keep showing the
+        // old error because items.isEmpty stays true.
+        self.error = nil
+
+        do {
+            let collection = try await resolveCollection()
+            _ = try await collection.refresh()
+            // Reload items directly after refresh succeeds, instead of
+            // relying on the cache observer to wake up. SwiftUI doesn't
+            // order sibling .task modifiers, so handleDataChanges() may not
+            // have subscribed before refresh wrote to the cache. This makes
+            // the cold-cache first load deterministic; handleDataChanges()
+            // handles subsequent updates only.
+            await loadItems(from: collection)
+        } catch {
+            Loggers.mediaLibrary.error("Media library refresh failed: \(error)")
+            show(error: error)
+        }
+    }
+
+    func pullToRefresh() async { await refresh() }
+
+    /// Long-running cache observer for SUBSEQUENT updates only — the initial
+    /// load is handled deterministically by `refresh()` calling
+    /// `loadItems(from:)` directly.
+    func handleDataChanges() async {
+        let collection: MediaMetadataCollectionWithEditContext
+        do {
+            collection = try await resolveCollection()
+        } catch {
+            // Collection couldn't be constructed; nothing to observe.
+            return
+        }
+
+        let batches = await client.cache.databaseUpdatesPublisher()
+            .filter { [weak collection] in collection?.isRelevantUpdate(hook: $0) == true }
+            .collect(.byTime(DispatchQueue.main, .milliseconds(50)))
+            .values
+
+        for await _ in batches {
+            await loadItems(from: collection)
+        }
+    }
+
+    // TODO: Pagination is temporary for M1. Future milestones will switch
+    // the Media Library to a full-library sync model rather than per-page
+    // fetches.
+    func loadNextPage() async throws {
+        // Two guards:
+        //   1. !isRefreshing — warm-cache first open paints cached rows
+        //      while the initial refresh is still in flight; trailing-row
+        //      .onAppear can fire loadNextPage concurrently with that
+        //      refresh. Defer pagination until the initial load completes.
+        //   2. !isLoadingNextPage — trailing-N rows can each fire .onAppear
+        //      in quick succession before the collection's listInfo
+        //      reflects the sync, producing duplicate fetches and noisy
+        //      StaleLoadMore errors. Mirrors the isLoadingMore guard in
+        //      CustomPostListView.swift:273-283.
+        guard !isRefreshing, !isLoadingNextPage else { return }
+        isLoadingNextPage = true
+        defer { isLoadingNextPage = false }
+
+        let collection = try await resolveCollection()
+        guard !collection.isSyncing,
+            collection.hasMorePages() ?? true
+        else { return }
+        if collection.listInfo()?.currentPage == nil {
+            _ = try await collection.refresh()
+        } else {
+            _ = try await collection.loadNextPage()
+        }
+        await loadItems(from: collection)
+    }
+
+    // TODO: Pagination is temporary for M1 — see loadNextPage().
+    func loadNextPageIfNeeded(after item: MediaListItem) async {
+        // Trigger a fetch only when the row that just appeared is one of the
+        // last few rows we have loaded — protects against firing for every
+        // single .onAppear above the fold.
+        let trailingThreshold = 10
+        guard items.suffix(trailingThreshold).contains(where: { $0.id == item.id }) else {
+            return
+        }
+        do {
+            try await loadNextPage()
+        } catch {
+            Loggers.mediaLibrary.error("Media library loadNextPage failed: \(error)")
+            show(error: error)
+        }
+    }
+
+    /// Reads the current snapshot from the collection and updates @Published
+    /// state. Shared by `loadCachedItems()`, `refresh()`, `loadNextPage()`,
+    /// and `handleDataChanges()` so all reload paths funnel through the
+    /// same code.
+    private func loadItems(from collection: MediaMetadataCollectionWithEditContext) async {
+        do {
+            self.listInfo = collection.listInfo()
+            let metadataItems = try await collection.loadItems()
+            withAnimation {
+                self.items = metadataItems.map(MediaListItem.init(item:))
+            }
+        } catch {
+            Loggers.mediaLibrary.error("Failed to load items: \(error)")
+        }
+    }
+
+    private func show(error: Error) {
+        if case FetchError.StaleLoadMore = error { return }
+        self.error = error
+    }
+}
+
+// Mirrors the private extension in CustomPostListViewModel.swift:726-735.
+// `isSyncing` is NOT part of the wordpress-rs ListInfo surface (which
+// exposes only state, currentPage, totalPages, totalItems, perPage at
+// wp_mobile.swift:5595-5607); this extension fills the gap.
+private extension ListInfo {
+    var isSyncing: Bool {
+        state == .fetchingFirstPage || state == .fetchingNextPage
+    }
+}
+
+private extension MediaMetadataCollectionWithEditContext {
+    var isSyncing: Bool { listInfo()?.isSyncing == true }
+}

--- a/Modules/Sources/WordPressMediaLibrary/Views/MediaLibraryViewModel.swift
+++ b/Modules/Sources/WordPressMediaLibrary/Views/MediaLibraryViewModel.swift
@@ -149,7 +149,7 @@ final class MediaLibraryViewModel: ObservableObject {
         //      in quick succession before the collection's listInfo
         //      reflects the sync, producing duplicate fetches and noisy
         //      StaleLoadMore errors. Mirrors the isLoadingMore guard in
-        //      CustomPostListView.swift:273-283.
+        //      CustomPostListView.
         guard !isRefreshing, !isLoadingNextPage else { return }
         isLoadingNextPage = true
         defer { isLoadingNextPage = false }
@@ -205,10 +205,10 @@ final class MediaLibraryViewModel: ObservableObject {
     }
 }
 
-// Mirrors the private extension in CustomPostListViewModel.swift:726-735.
+// Mirrors the private extension in CustomPostListViewModel.
 // `isSyncing` is NOT part of the wordpress-rs ListInfo surface (which
-// exposes only state, currentPage, totalPages, totalItems, perPage at
-// wp_mobile.swift:5595-5607); this extension fills the gap.
+// exposes only state, currentPage, totalPages, totalItems, and perPage);
+// this extension fills the gap.
 private extension ListInfo {
     var isSyncing: Bool {
         state == .fetchingFirstPage || state == .fetchingNextPage

--- a/WordPress/Classes/Utility/Analytics/MediaTrackerAdapter.swift
+++ b/WordPress/Classes/Utility/Analytics/MediaTrackerAdapter.swift
@@ -1,0 +1,22 @@
+import Foundation
+import WordPressData
+import WordPressMediaLibrary
+import WordPressShared
+
+/// App-target adapter that bridges the module's `MediaTracker` to
+/// `WPAppAnalytics` while preserving the V1 analytics property fidelity
+/// (tap_source, tab_source) and adding an `is_v2: "1"` discriminator.
+@MainActor
+struct MediaTrackerAdapter: MediaTracker {
+    let blog: Blog
+    let baseProperties: [String: Any]
+
+    func track(_ event: MediaTrackerEvent) {
+        let stat: WPAnalyticsStat
+        switch event {
+        case .mediaLibraryOpened:
+            stat = .openedMediaLibrary
+        }
+        WPAppAnalytics.track(stat, properties: baseProperties, blog: blog)
+    }
+}

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -30,6 +30,7 @@ public enum FeatureFlag: Int, CaseIterable {
     case customPostTypes
     case cptPostsAndPages
     case socialSharingV2
+    case mediaLibraryV2
 
     /// Returns a boolean indicating if the feature is enabled.
     ///
@@ -95,6 +96,8 @@ public enum FeatureFlag: Int, CaseIterable {
             return BuildConfiguration.current == .debug
         case .socialSharingV2:
             return BuildConfiguration.current == .debug
+        case .mediaLibraryV2:
+            return BuildConfiguration.current == .debug
         }
     }
 
@@ -141,6 +144,7 @@ extension FeatureFlag {
         case .customPostTypes: "Custom Post Types"
         case .cptPostsAndPages: "Custom Post Types: Posts and Pages"
         case .socialSharingV2: "Social Sharing v2"
+        case .mediaLibraryV2: "Media Library v2"
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Quick Actions/DashboardQuickActionsCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Quick Actions/DashboardQuickActionsCardCell.swift
@@ -108,6 +108,16 @@ final class DashboardQuickActionsCardCell: UICollectionViewCell, Reusable, UITab
                 parentViewController.show(viewController, sender: nil)
             }
         case .media:
+            if let v2 = MediaLibraryRouting.makeViewController(
+                for: blog,
+                baseAnalyticsProperties: [
+                    WPAppAnalyticsKeyTapSource: "quick_actions",
+                    WPAppAnalyticsKeyTabSource: "dashboard"
+                ]
+            ) {
+                parentViewController.show(v2, sender: nil)
+                return
+            }
             trackQuickActionsEvent(.openedMediaLibrary, blog: blog)
             let controller = SiteMediaViewController(blog: blog)
             parentViewController.show(controller, sender: nil)

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Quick Actions/DashboardQuickActionsCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Quick Actions/DashboardQuickActionsCardCell.swift
@@ -54,14 +54,16 @@ final class DashboardQuickActionsCardCell: UICollectionViewCell, Reusable, UITab
             self?.deselectCurrentCell()
         }
 
-        viewModel.$items.sink { [weak self] in
-            guard let self else { return }
-            self.items = $0
-            self.tableView.reloadData()
-            self.setNeedsLayout()
-            self.layoutIfNeeded()
-            self.parentViewController?.collectionView.collectionViewLayout.invalidateLayout()
-        }.store(in: &cancellables)
+        viewModel.$items
+            .sink { [weak self] in
+                guard let self else { return }
+                self.items = $0
+                self.tableView.reloadData()
+                self.setNeedsLayout()
+                self.layoutIfNeeded()
+                self.parentViewController?.collectionView.collectionViewLayout.invalidateLayout()
+            }
+            .store(in: &cancellables)
     }
 
     private func deselectCurrentCell() {
@@ -77,7 +79,9 @@ final class DashboardQuickActionsCardCell: UICollectionViewCell, Reusable, UITab
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let cell = tableView.dequeueReusableCell(withIdentifier: Constants.cellReuseID, for: indexPath) as! DashboardQuickActionCell
+        let cell =
+            tableView.dequeueReusableCell(withIdentifier: Constants.cellReuseID, for: indexPath)
+            as! DashboardQuickActionCell
         cell.configure(items[indexPath.row])
         cell.backgroundColor = .clear
         cell.accessoryType = .disclosureIndicator

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+Swift.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+Swift.swift
@@ -151,6 +151,18 @@ extension BlogDetailsViewController {
     }
 
     public func showMediaLibrary(from source: BlogDetailsNavigationSource, showPicker: Bool) {
+        if !showPicker,
+            let v2 = MediaLibraryRouting.makeViewController(
+                for: blog,
+                baseAnalyticsProperties: [
+                    WPAppAnalyticsKeyTapSource: source.string,
+                    WPAppAnalyticsKeyTabSource: "site_menu"
+                ]
+            )
+        {
+            presentationDelegate?.presentBlogDetailsViewController(v2)
+            return
+        }
         trackEvent(.openedMediaLibrary, from: source)
         let controller = SiteMediaViewController(blog: blog, showPicker: showPicker)
         presentationDelegate?.presentBlogDetailsViewController(controller)

--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryRouting.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryRouting.swift
@@ -1,0 +1,34 @@
+import UIKit
+import WordPressCore
+import WordPressData
+import WordPressMediaLibrary
+
+/// Single source of truth for routing into the V2 Media Library. Both V1
+/// entry points (BlogDetailsViewController.showMediaLibrary and
+/// DashboardQuickActionsCardCell .media case) call this helper. Returns nil
+/// when either the FeatureFlag is off or the site can't construct a
+/// WordPressSite, so the caller's V1 fall-through is a one-liner.
+@MainActor
+enum MediaLibraryRouting {
+    static func makeViewController(
+        for blog: Blog,
+        baseAnalyticsProperties: [String: Any]
+    ) -> UIViewController? {
+        guard FeatureFlag.mediaLibraryV2.enabled,
+            let site = try? WordPressSite(blog: blog)
+        else {
+            return nil
+        }
+        let client = WordPressClientFactory.shared.instance(for: site)
+
+        // Explicit two-step instead of `.merging(...)`. Reason:
+        // `baseAnalyticsProperties` is `[String: Any]`; a `["is_v2": "1"]`
+        // literal can infer as `[String: String]` and fail to type-check
+        // against the merging overload. Explicit form avoids the gamble.
+        var properties = baseAnalyticsProperties
+        properties["is_v2"] = "1"
+        let tracker = MediaTrackerAdapter(blog: blog, baseProperties: properties)
+
+        return MediaLibraryHostingController.make(client: client, tracker: tracker)
+    }
+}


### PR DESCRIPTION
> [!Note]
> This PR depends on the wordpress-rs https://github.com/Automattic/wordpress-rs/pull/1338.

## Description

Relates to [the Media Library V2 project](https://linear.app/a8c/project/media-library-ios-core-rest-api-re-implementation-26c8d499885c/overview).

Stands up a new SwiftUI module backed by wordpress-rs, gated behind a feature flag, with routing at the two existing entry points. After this lands, flag-on builds on a core-REST-capable site show a bare-bones SwiftUI list of media items with infinite scroll. The polished grid, filter menu, search, aspect-ratio toggle, and other controls come in the next PR.

Main changes:

1. New SPM module `WordPressMediaLibrary` under `Modules/Sources/`.
2. `MediaLibraryViewModel` consuming wordpress-rs's `MediaMetadataCollectionWithEditContext`. Structurally mirrors `CustomPostListViewModel`, with the cache observer + deterministic refresh shape adapted for media.
3. `MediaTracker` protocol in the module + `MediaTrackerAdapter` in the app target wired to `WPAppAnalytics`.
4. `FeatureFlag.mediaLibraryV2`, default-on in debug builds.
5. `MediaLibraryRouting` helper plus surgical edits at `BlogDetailsViewController.showMediaLibrary` and `DashboardQuickActionsCardCell` (Media tile): flag-on AND `(try? WordPressSite(blog:)) != nil` → V2; else V1.

## Testing instructions

Two regression paths matter:

- Flag off (Debug Menu → Feature Flags → Media Library v2): both entry points open the legacy `SiteMediaViewController`. Existing `.openedMediaLibrary` analytics fire as before.
- Flag on, but signed in to a self-hosted site without an application password: both entry points still fall through to V1 silently. No crash, no V2 attempt.

Flag-on with a core-REST-capable site (WP.com or self-hosted with app password) shows the new V2 list. Pull-to-refresh and infinite scroll both work; tap into the list isn't wired yet.
