### PR TITLE
Enable SwiftLint rule: collection_alignment

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -13,6 +13,9 @@ only_rules:
   # Prefer `Array(xs)` over `xs.map { $0 }`.
   - array_init
 
+  # All elements in a collection literal should be vertically aligned.
+  - collection_alignment
+
   # Colons should be next to the identifier when specifying a type.
   - colon
 

--- a/Sources/WordPressData/Swift/CoreDataHelper.swift
+++ b/Sources/WordPressData/Swift/CoreDataHelper.swift
@@ -289,7 +289,7 @@ public extension CoreDataStack {
 
         do {
             let options = [NSMigratePersistentStoresAutomaticallyOption: true,
-                                 NSInferMappingModelAutomaticallyOption: true]
+                           NSInferMappingModelAutomaticallyOption: true]
             try storeCoordinator.addPersistentStore(ofType: NSSQLiteStoreType,
                                                     configurationName: nil,
                                                     at: currentDatabaseLocation,

--- a/Tests/WordPressKitTests/WordPressKitTests/Tests/MediaServiceRemoteRESTTests.swift
+++ b/Tests/WordPressKitTests/WordPressKitTests/Tests/MediaServiceRemoteRESTTests.swift
@@ -267,18 +267,18 @@ class MediaServiceRemoteRESTTests: RemoteTestCase, RESTTestable {
         let width = 432
 
         let jsonDictionary: [String: Any] = ["ID": id,
-                                                      "URL": url,
-                                                      "guid": guid,
-                                                      "date": date,
-                                                      "post_ID": postID,
-                                                      "mime_type": mimeType,
-                                                      "file": file,
-                                                      "title": title,
-                                                      "caption": caption,
-                                                      "description": description,
-                                                      "alt": alt,
-                                                      "height": height,
-                                                      "width": width]
+                                             "URL": url,
+                                             "guid": guid,
+                                             "date": date,
+                                             "post_ID": postID,
+                                             "mime_type": mimeType,
+                                             "file": file,
+                                             "title": title,
+                                             "caption": caption,
+                                             "description": description,
+                                             "alt": alt,
+                                             "height": height,
+                                             "width": width]
 
         let remoteMedia = MediaServiceRemoteREST.remoteMedia(fromJSONDictionary: jsonDictionary)
         XCTAssertEqual(remoteMedia?.mediaID?.intValue, id)
@@ -327,18 +327,18 @@ class MediaServiceRemoteRESTTests: RemoteTestCase, RESTTestable {
                                               "width": width]
 
         let jsonDictionary2: [String: Any] = ["ID": id2,
-                                               "URL": url,
-                                               "guid": guid,
-                                               "date": date,
-                                               "post_ID": postID,
-                                               "mime_type": mimeType,
-                                               "file": file,
-                                               "title": title,
-                                               "caption": caption,
-                                               "description": description,
-                                               "alt": alt,
-                                               "height": height,
-                                               "width": width]
+                                              "URL": url,
+                                              "guid": guid,
+                                              "date": date,
+                                              "post_ID": postID,
+                                              "mime_type": mimeType,
+                                              "file": file,
+                                              "title": title,
+                                              "caption": caption,
+                                              "description": description,
+                                              "alt": alt,
+                                              "height": height,
+                                              "width": width]
         let jsonArray = [jsonDictionary1, jsonDictionary2]
 
         let remoteMediaArray: [RemoteMedia] = MediaServiceRemoteREST.remoteMedia(fromJSONArray: jsonArray) as! [RemoteMedia]

--- a/WordPress/Classes/ViewRelated/Blog/Site Management/DeleteSiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Management/DeleteSiteViewController.swift
@@ -127,8 +127,8 @@ open class DeleteSiteViewController: UITableViewController {
         paragraphStyle.alignment = .natural
 
         let attributes: [NSAttributedString.Key: Any] = [.font: WPStyleGuide.fontForTextStyle(.body, fontWeight: .regular),
-                                                        .foregroundColor: UIAppColor.neutral(.shade70),
-                                                        .paragraphStyle: paragraphStyle ]
+                                                         .foregroundColor: UIAppColor.neutral(.shade70),
+                                                         .paragraphStyle: paragraphStyle ]
         let htmlAttributes: StyledHTMLAttributes = [.BodyAttribute: attributes]
 
         let attributedText1 = NSAttributedString.attributedStringWithHTML(paragraph1, attributes: htmlAttributes)
@@ -142,7 +142,7 @@ open class DeleteSiteViewController: UITableViewController {
         sectionThreeBody.textColor = UIAppColor.neutral(.shade70)
 
         let contactButtonAttributes: [NSAttributedString.Key: Any] = [.foregroundColor: UIAppColor.primary,
-                                                                     .underlineStyle: NSUnderlineStyle.single.rawValue]
+                                                                      .underlineStyle: NSUnderlineStyle.single.rawValue]
         supportButton.setAttributedTitle(NSAttributedString(string: NSLocalizedString("Contact Support",
                                                             comment: "Button label for contacting support"),
                                                             attributes: contactButtonAttributes),

--- a/WordPress/Classes/ViewRelated/Gutenberg/Layout Picker/GutenbergLightNavigationController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Layout Picker/GutenbergLightNavigationController.swift
@@ -22,11 +22,11 @@ class GutenbergLightNavigationController: UINavigationController {
         let barButtonItemAppearance = UIBarButtonItem.appearance(whenContainedInInstancesOf: [GutenbergLightNavigationController.self])
         barButtonItemAppearance.tintColor = tintColor
         barButtonItemAppearance.setTitleTextAttributes([NSAttributedString.Key.font: WPFontManager.systemRegularFont(ofSize: 17.0),
-                                                    NSAttributedString.Key.foregroundColor: tintColor],
-                                                   for: .normal)
+                                                        NSAttributedString.Key.foregroundColor: tintColor],
+                                                       for: .normal)
         barButtonItemAppearance.setTitleTextAttributes([NSAttributedString.Key.font: WPFontManager.systemRegularFont(ofSize: 17.0),
-                                                    NSAttributedString.Key.foregroundColor: tintColor.withAlphaComponent(0.25)],
-                                                   for: .disabled)
+                                                        NSAttributedString.Key.foregroundColor: tintColor.withAlphaComponent(0.25)],
+                                                       for: .disabled)
 
         setNeedsStatusBarAppearanceUpdate()
     }

--- a/WordPress/Classes/ViewRelated/Me/App Settings/AppSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/AppSettingsViewController.swift
@@ -212,9 +212,9 @@ class AppSettingsViewController: UITableViewController {
             let title = NSLocalizedString("appSettings.media.imageQuality.title", value: "Quality", comment: "The quality of image used when uploading")
 
             let settingsSelectionConfiguration = [SettingsSelectionDefaultValueKey: currentImageQuality,
-                                                         SettingsSelectionTitleKey: title,
-                                                        SettingsSelectionTitlesKey: titles,
-                                                        SettingsSelectionValuesKey: values] as [String: Any]
+                                                  SettingsSelectionTitleKey: title,
+                                                  SettingsSelectionTitlesKey: titles,
+                                                  SettingsSelectionValuesKey: values] as [String: Any]
 
             let viewController = SettingsSelectionViewController(dictionary: settingsSelectionConfiguration)
 

--- a/WordPress/Classes/ViewRelated/Plugins/Views/PluginDetailViewHeaderCell.swift
+++ b/WordPress/Classes/ViewRelated/Plugins/Views/PluginDetailViewHeaderCell.swift
@@ -30,7 +30,7 @@ class PluginDetailViewHeaderCell: UITableViewCell, NibLoadable {
         let author = directoryEntry.author
 
         let defaultAttributes: [NSAttributedString.Key: Any] = [.font: UIFont.preferredFont(forTextStyle: .subheadline),
-                                                               .foregroundColor: UIAppColor.neutral(.shade70)]
+                                                                .foregroundColor: UIAppColor.neutral(.shade70)]
 
         let authorAttributes: [NSAttributedString.Key: Any] = [.foregroundColor: UIAppColor.primary(.shade40)]
 

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsInsightsDetailsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsInsightsDetailsViewModel.swift
@@ -858,19 +858,19 @@ private extension SiteStatsInsightsDetailsViewModel {
         }
 
         return [StatsTotalRowData(name: AnnualSiteStats.totalPosts,
-                data: annualInsights.totalPostsCount.abbreviatedString()),
-            StatsTotalRowData(name: AnnualSiteStats.totalComments,
-                    data: annualInsights.totalCommentsCount.abbreviatedString()),
-            StatsTotalRowData(name: AnnualSiteStats.commentsPerPost,
-                    data: Int(round(annualInsights.averageCommentsCount)).abbreviatedString()),
-            StatsTotalRowData(name: AnnualSiteStats.totalLikes,
-                    data: annualInsights.totalLikesCount.abbreviatedString()),
-            StatsTotalRowData(name: AnnualSiteStats.likesPerPost,
-                    data: Int(round(annualInsights.averageLikesCount)).abbreviatedString()),
-            StatsTotalRowData(name: AnnualSiteStats.totalWords,
-                    data: annualInsights.totalWordsCount.abbreviatedString()),
-            StatsTotalRowData(name: AnnualSiteStats.wordsPerPost,
-                    data: Int(round(annualInsights.averageWordsCount)).abbreviatedString())]
+                                  data: annualInsights.totalPostsCount.abbreviatedString()),
+                StatsTotalRowData(name: AnnualSiteStats.totalComments,
+                                  data: annualInsights.totalCommentsCount.abbreviatedString()),
+                StatsTotalRowData(name: AnnualSiteStats.commentsPerPost,
+                                  data: Int(round(annualInsights.averageCommentsCount)).abbreviatedString()),
+                StatsTotalRowData(name: AnnualSiteStats.totalLikes,
+                                  data: annualInsights.totalLikesCount.abbreviatedString()),
+                StatsTotalRowData(name: AnnualSiteStats.likesPerPost,
+                                  data: Int(round(annualInsights.averageLikesCount)).abbreviatedString()),
+                StatsTotalRowData(name: AnnualSiteStats.totalWords,
+                                  data: annualInsights.totalWordsCount.abbreviatedString()),
+                StatsTotalRowData(name: AnnualSiteStats.wordsPerPost,
+                                  data: Int(round(annualInsights.averageWordsCount)).abbreviatedString())]
     }
 
     // MARK: - Posts and Pages

--- a/WordPress/Classes/ViewRelated/Support/SupportTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Support/SupportTableViewController.swift
@@ -654,10 +654,10 @@ class ButtonCell: WPTableViewCellDefault {
 
         NSLayoutConstraint.activate([
             button.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: SupportTableLayoutSpacing.sidePadding),
-                                        button.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -SupportTableLayoutSpacing.sidePadding),
-                                        button.topAnchor.constraint(equalTo: contentView.topAnchor, constant: SupportTableLayoutSpacing.topBottomPadding),
-                                        button.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -SupportTableLayoutSpacing.topBottomPadding)
-                                    ])
+            button.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -SupportTableLayoutSpacing.sidePadding),
+            button.topAnchor.constraint(equalTo: contentView.topAnchor, constant: SupportTableLayoutSpacing.topBottomPadding),
+            button.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -SupportTableLayoutSpacing.topBottomPadding)
+        ])
     }
 
     enum LayoutSpacing {

--- a/WordPress/WordPressShareExtension/Sources/UI/ShareExtensionEditorViewController.swift
+++ b/WordPress/WordPressShareExtension/Sources/UI/ShareExtensionEditorViewController.swift
@@ -53,7 +53,7 @@ class ShareExtensionEditorViewController: ShareExtensionAbstractViewController {
         self.configureDefaultProperties(for: textView, accessibilityLabel: accessibilityLabel)
 
         let linkAttributes: [NSAttributedString.Key: Any] = [.underlineStyle: NSUnderlineStyle.single.rawValue,
-                                                            .foregroundColor: ShareColors.aztecLinkColor]
+                                                             .foregroundColor: ShareColors.aztecLinkColor]
 
         textView.delegate = self
         textView.formattingDelegate = self
@@ -94,8 +94,8 @@ class ShareExtensionEditorViewController: ShareExtensionAbstractViewController {
         titleParagraphStyle.alignment = .natural
 
         let attributes: [NSAttributedString.Key: Any] = [.foregroundColor: UIColor.label,
-                                                        .font: ShareFonts.title,
-                                                        .paragraphStyle: titleParagraphStyle]
+                                                         .font: ShareFonts.title,
+                                                         .paragraphStyle: titleParagraphStyle]
 
         let textView = UITextView()
 


### PR DESCRIPTION
## What and why

Enables SwiftLint's [`collection_alignment`](https://realm.github.io/SwiftLint/collection_alignment.html) rule, which requires all elements in a multi-line collection literal to be vertically aligned with the first element. Part of the Orchard SwiftLint rollout campaign (Phase 3 — formatting and consistency).

## Approach

- Added the rule to `only_rules` in `.swiftlint.yml` (alphabetical order, between `array_init` and `colon`).
- `collection_alignment` is **not** auto-correctable, so all 46 violations across 9 files were fixed by hand.
- Every change is whitespace-only — adjusting continuation-line indentation to align with the first collection element. No behaviour changes.
- No suppressions, nothing left for human review.

## How to test

- `rake lint` reports zero `collection_alignment` violations.
- The `WordPress` scheme builds clean locally (`xcodebuild -workspace WordPress.xcworkspace -scheme WordPress -destination 'platform=iOS Simulator,name=iPhone 17 Pro' build`).
