### PR TITLE
Enable SwiftLint rule: literal_expression_end_indentation

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -64,6 +64,10 @@ only_rules:
   # Prefer `last(where:)` over `filter { }.last`.
   - last_where
 
+  # Trailing closing brackets/parens of literal expressions (arrays, dicts)
+  # should match the indentation of the line that introduced them.
+  - literal_expression_end_indentation
+
   # MARK comment should be in valid format.
   - mark
 

--- a/Modules/Sources/Support/InternalDataProvider.swift
+++ b/Modules/Sources/Support/InternalDataProvider.swift
@@ -105,7 +105,7 @@ extension SupportDataProvider {
                     userWantsToTalkToHuman: true,
                     isWrittenByUser: false
                 )
-        ])
+            ])
     }
 
     static let supportConversationSummaries: [ConversationSummary] = [

--- a/Modules/Sources/WordPressKit/PluginServiceRemote.swift
+++ b/Modules/Sources/WordPressKit/PluginServiceRemote.swift
@@ -84,28 +84,28 @@ public class PluginServiceRemote: ServiceRemoteWordPressComREST {
     public func activatePlugin(pluginID: String, siteID: Int, success: @escaping () -> Void, failure: @escaping (Error) -> Void) {
         let parameters = [
             "active": "true"
-            ] as [String: AnyObject]
+        ] as [String: AnyObject]
         modifyPlugin(parameters: parameters, pluginID: pluginID, siteID: siteID, success: success, failure: failure)
     }
 
      public func deactivatePlugin(pluginID: String, siteID: Int, success: @escaping () -> Void, failure: @escaping (Error) -> Void) {
         let parameters = [
             "active": "false"
-            ] as [String: AnyObject]
+        ] as [String: AnyObject]
         modifyPlugin(parameters: parameters, pluginID: pluginID, siteID: siteID, success: success, failure: failure)
     }
 
      public func enableAutoupdates(pluginID: String, siteID: Int, success: @escaping () -> Void, failure: @escaping (Error) -> Void) {
         let parameters = [
             "autoupdate": "true"
-            ] as [String: AnyObject]
+        ] as [String: AnyObject]
         modifyPlugin(parameters: parameters, pluginID: pluginID, siteID: siteID, success: success, failure: failure)
     }
 
      public func disableAutoupdates(pluginID: String, siteID: Int, success: @escaping () -> Void, failure: @escaping (Error) -> Void) {
         let parameters = [
             "autoupdate": "false"
-            ] as [String: AnyObject]
+        ] as [String: AnyObject]
         modifyPlugin(parameters: parameters, pluginID: pluginID, siteID: siteID, success: success, failure: failure)
     }
 
@@ -113,7 +113,7 @@ public class PluginServiceRemote: ServiceRemoteWordPressComREST {
         let parameters = [
             "active": "true",
             "autoupdate": "true"
-            ] as [String: AnyObject]
+        ] as [String: AnyObject]
         modifyPlugin(parameters: parameters, pluginID: pluginID, siteID: siteID, success: success, failure: failure)
     }
 

--- a/Modules/Sources/WordPressShared/FileManager/FileManager+FolderSize.swift
+++ b/Modules/Sources/WordPressShared/FileManager/FileManager+FolderSize.swift
@@ -21,7 +21,7 @@ public extension FileManager {
             URLResourceKey.isRegularFileKey,
             URLResourceKey.fileAllocatedSizeKey,
             URLResourceKey.totalFileAllocatedSizeKey,
-            ]
+        ]
 
         // The error handler simply signals errors to outside code.
         var errorDidOccur: Error?

--- a/Modules/Sources/WordPressUI/Extensions/UIView+Helpers.swift
+++ b/Modules/Sources/WordPressUI/Extensions/UIView+Helpers.swift
@@ -45,7 +45,7 @@ extension UIView {
             layoutMarginsGuide.trailingAnchor.constraint(equalTo: subview.trailingAnchor),
             layoutMarginsGuide.topAnchor.constraint(equalTo: subview.topAnchor),
             layoutMarginsGuide.bottomAnchor.constraint(equalTo: subview.bottomAnchor)
-            ])
+        ])
     }
 
     /// Adds constraints that pin a subview to self's safe area with padding insets.

--- a/Sources/WordPressAuthenticator/Features/SignIn/LoginEmailViewController.swift
+++ b/Sources/WordPressAuthenticator/Features/SignIn/LoginEmailViewController.swift
@@ -147,7 +147,7 @@ open class LoginEmailViewController: LoginViewController, NUXKeyboardResponder {
         stackView.addConstraints([
             button.leadingAnchor.constraint(equalTo: instructionLabel.leadingAnchor),
             button.trailingAnchor.constraint(equalTo: instructionLabel.trailingAnchor)
-            ])
+        ])
 
         googleLoginButton = button
     }
@@ -167,7 +167,7 @@ open class LoginEmailViewController: LoginViewController, NUXKeyboardResponder {
         stackView.addConstraints([
             button.leadingAnchor.constraint(equalTo: instructionLabel.leadingAnchor),
             button.trailingAnchor.constraint(equalTo: instructionLabel.trailingAnchor)
-            ])
+        ])
 
         selfHostedLoginButton = button
     }
@@ -235,7 +235,7 @@ open class LoginEmailViewController: LoginViewController, NUXKeyboardResponder {
         stackView.addConstraints([
             button.leadingAnchor.constraint(equalTo: instructionLabel.leadingAnchor),
             button.trailingAnchor.constraint(equalTo: instructionLabel.trailingAnchor)
-            ])
+        ])
 
         wpcomSignupButton = button
     }

--- a/Sources/WordPressAuthenticator/Features/SignIn/LoginSocialErrorCell.swift
+++ b/Sources/WordPressAuthenticator/Features/SignIn/LoginSocialErrorCell.swift
@@ -75,7 +75,7 @@ open class LoginSocialErrorCell: UITableViewCell {
             contentView.bottomAnchor.constraint(equalTo: labelStack.bottomAnchor, constant: Constants.labelVerticalMargin),
             contentView.layoutMarginsGuide.leadingAnchor.constraint(equalTo: labelStack.leadingAnchor),
             contentView.layoutMarginsGuide.trailingAnchor.constraint(equalTo: labelStack.trailingAnchor)
-            ])
+        ])
 
         titleLabel.text = errorTitle.localizedUppercase
         if let styledDescription = errorDescriptionStyled {

--- a/Tests/KeystoneTests/Tests/Features/SiteCreation/SiteAssemblyServiceTests.swift
+++ b/Tests/KeystoneTests/Tests/Features/SiteCreation/SiteAssemblyServiceTests.swift
@@ -31,7 +31,7 @@ class SiteAssemblyServiceTests: XCTestCase {
             "domain_name": "domainName.com" as AnyObject,
             "product_id": 42 as AnyObject,
             "supports_privacy": true as AnyObject,
-            ]
+        ]
         siteCreator.address = try DomainSuggestion(json: domainSuggestionPayload)
 
         creationRequest = siteCreator.build()

--- a/Tests/KeystoneTests/Tests/Models/BasePostTests.swift
+++ b/Tests/KeystoneTests/Tests/Models/BasePostTests.swift
@@ -46,7 +46,7 @@ class BasePostTests: CoreDataTestCase {
         [
             try! MediaFileManager.cache.directoryURL().appendingPathComponent("thumbnail-p16-1792x1792.jpeg"),
             try! MediaFileManager().directoryURL().appendingPathComponent("p16-1792x1792.jpeg")
-            ].forEach {
+        ].forEach {
                 try? "".write(to: $0, atomically: true, encoding: .utf8)
         }
     }

--- a/WordPress/Classes/Extensions/UIView+Borders.swift
+++ b/WordPress/Classes/Extensions/UIView+Borders.swift
@@ -10,7 +10,7 @@ extension UIView {
             borderView.topAnchor.constraint(equalTo: topAnchor),
             borderView.centerXAnchor.constraint(equalTo: centerXAnchor),
             borderView.widthAnchor.constraint(equalTo: widthAnchor)
-            ])
+        ])
         return borderView
     }
 
@@ -23,7 +23,7 @@ extension UIView {
             borderView.bottomAnchor.constraint(equalTo: bottomAnchor),
             borderView.centerXAnchor.constraint(equalTo: centerXAnchor),
             borderView.widthAnchor.constraint(equalTo: widthAnchor)
-            ])
+        ])
         return borderView
     }
 
@@ -36,7 +36,7 @@ extension UIView {
             borderView.bottomAnchor.constraint(equalTo: bottomAnchor),
             borderView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: leadingMargin),
             borderView.trailingAnchor.constraint(equalTo: trailingAnchor)
-            ])
+        ])
         return borderView
     }
 
@@ -49,7 +49,7 @@ extension UIView {
             borderView.bottomAnchor.constraint(equalTo: bottomAnchor),
             borderView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: leadingMargin),
             borderView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: trailingMargin)
-            ])
+        ])
         return borderView
     }
 

--- a/WordPress/Classes/Services/MediaCoordinator.swift
+++ b/WordPress/Classes/Services/MediaCoordinator.swift
@@ -366,7 +366,7 @@ class MediaCoordinator: NSObject {
                         "width": media.width ?? "",
                         "localURL": media.localURL ?? "",
                         "remoteURL": media.remoteURL ?? "",
-                ])
+                    ])
 
             self.coordinator(for: media).attach(error: nserror, toMediaID: media.uploadID)
             self.fail(nserror, media: media)

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecAttachmentViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecAttachmentViewController.swift
@@ -102,7 +102,7 @@ class AztecAttachmentViewController: UITableViewController {
                     captionRow
                 ],
                 footerText: nil)
-            ])
+        ])
     }
 
     // MARK: - Actions

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -667,7 +667,7 @@ class AztecPostViewController: UIViewController, PostEditor {
             titleTextField.trailingAnchor.constraint(equalTo: view.readableContentGuide.trailingAnchor),
             titleTopConstraint,
             titleHeightConstraint
-            ])
+        ])
 
         let insets = titleTextField.textContainerInset
 
@@ -676,35 +676,35 @@ class AztecPostViewController: UIViewController, PostEditor {
             titlePlaceholderLabel.rightAnchor.constraint(equalTo: titleTextField.rightAnchor, constant: -insets.right - titleTextField.textContainer.lineFragmentPadding),
             titlePlaceholderLabel.topAnchor.constraint(equalTo: titleTextField.topAnchor, constant: insets.top),
             titlePlaceholderLabel.heightAnchor.constraint(equalToConstant: titleTextField.font!.lineHeight)
-            ])
+        ])
 
         NSLayoutConstraint.activate([
             separatorView.leadingAnchor.constraint(equalTo: view.readableContentGuide.leadingAnchor),
             separatorView.trailingAnchor.constraint(equalTo: view.readableContentGuide.trailingAnchor),
             separatorView.topAnchor.constraint(equalTo: titleTextField.bottomAnchor),
             separatorView.heightAnchor.constraint(equalToConstant: separatorView.frame.height)
-            ])
+        ])
 
         NSLayoutConstraint.activate([
             richTextView.leadingAnchor.constraint(equalTo: view.readableContentGuide.leadingAnchor),
             richTextView.trailingAnchor.constraint(equalTo: view.readableContentGuide.trailingAnchor),
             richTextView.topAnchor.constraint(equalTo: view.topAnchor),
             richTextView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
-            ])
+        ])
 
         NSLayoutConstraint.activate([
             htmlTextView.leftAnchor.constraint(equalTo: richTextView.leftAnchor),
             htmlTextView.rightAnchor.constraint(equalTo: richTextView.rightAnchor),
             htmlTextView.topAnchor.constraint(equalTo: richTextView.topAnchor),
             htmlTextView.bottomAnchor.constraint(equalTo: richTextView.bottomAnchor)
-            ])
+        ])
 
         NSLayoutConstraint.activate([
             placeholderLabel.leftAnchor.constraint(equalTo: richTextView.leftAnchor, constant: insets.left + richTextView.textContainer.lineFragmentPadding),
             placeholderLabel.rightAnchor.constraint(equalTo: richTextView.rightAnchor, constant: -insets.right - richTextView.textContainer.lineFragmentPadding),
             textPlaceholderTopConstraint,
             placeholderLabel.bottomAnchor.constraint(lessThanOrEqualTo: richTextView.bottomAnchor, constant: Constants.placeholderPadding.bottom)
-            ])
+        ])
     }
 
     private func configureDefaultProperties(for textView: UITextView, accessibilityLabel: String) {
@@ -745,7 +745,7 @@ class AztecPostViewController: UIViewController, PostEditor {
             mediaProgressView.leadingAnchor.constraint(equalTo: navigationBar.leadingAnchor),
             mediaProgressView.widthAnchor.constraint(equalTo: navigationBar.widthAnchor),
             mediaProgressView.topAnchor.constraint(equalTo: navigationBar.bottomAnchor, constant: -mediaProgressView.frame.height)
-            ])
+        ])
     }
 
     func registerAttachmentImageProviders() {

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsSectionFooterView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsSectionFooterView.swift
@@ -35,7 +35,7 @@ public class BlogDetailsSectionFooterView: UITableViewHeaderFooterView {
             stackView.bottomAnchor.constraint(equalTo: contentView.readableContentGuide.bottomAnchor),
             // Spacer view.
             spacerView.heightAnchor.constraint(equalToConstant: 20),
-            ])
+        ])
         updateUI(title: nil, shouldShowExtraSpacing: false)
     }
 

--- a/WordPress/Classes/ViewRelated/Blog/Site Management/TableViewHeaderDetailView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Management/TableViewHeaderDetailView.swift
@@ -98,7 +98,7 @@ open class TableViewHeaderDetailView: UITableViewHeaderFooterView {
             stackView.trailingAnchor.constraint(equalTo: contentView.readableContentGuide.trailingAnchor),
             stackView.topAnchor.constraint(equalTo: contentView.readableContentGuide.topAnchor),
             stackView.bottomAnchor.constraint(equalTo: contentView.readableContentGuide.bottomAnchor),
-            ])
+        ])
     }
 
     // MARK: - View Lifecycle

--- a/WordPress/Classes/ViewRelated/Blog/Site Settings/LanguageSelectorViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Settings/LanguageSelectorViewController.swift
@@ -81,7 +81,7 @@ class LanguageSelectorViewController: UITableViewController, UISearchResultsUpda
         }
         return ImmuTable(sections: [
             ImmuTableSection(rows: filtered.map(model(language:)))
-            ])
+        ])
     }
 
     private func modelForBrowsing() -> ImmuTable {
@@ -92,7 +92,7 @@ class LanguageSelectorViewController: UITableViewController, UISearchResultsUpda
             ImmuTableSection(
                 headerText: NSLocalizedString("All languages", comment: "Section title for All Languages"),
                 rows: database.all.map(model(language:)))
-            ])
+        ])
     }
 
     private func model(language: Language) -> ImmuTableRow {

--- a/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainDetails/ViewModel/RegisterDomainDetailsViewModel+RowList.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainDetails/ViewModel/RegisterDomainDetailsViewModel+RowList.swift
@@ -137,7 +137,8 @@ extension RegisterDomainDetailsViewModel {
                 editingStyle: .multipleChoice,
                 validationRules: [nonEmptyRule,
                                   serverSideRule(with: Localized.ContactInformation.country)]
-                ))]
+                ))
+        ]
     }
 
     static var phoneNumberRows: [RowType] {

--- a/WordPress/Classes/ViewRelated/Jetpack/Install/Webview/JetpackConnectionWebViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Install/Webview/JetpackConnectionWebViewController.swift
@@ -47,7 +47,7 @@ class JetpackConnectionWebViewController: UIViewController {
         let stackView = UIStackView(arrangedSubviews: [
             progressView,
             webView
-            ])
+        ])
         stackView.axis = .vertical
         view = stackView
     }

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Settings/JetpackConnectionViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Settings/JetpackConnectionViewController.swift
@@ -76,7 +76,8 @@ open class JetpackConnectionViewController: UITableViewController {
                 rows: [disconnectRow],
                 footerText: NSLocalizedString("Your site will no longer send data to WordPress.com and Jetpack features will stop working. You will lose access to the site on the app and you will have to re-add it with the site credentials.",
                                               comment: "Explanatory text bellow the Disconnect from WordPress.com button")
-            )])
+            )
+        ])
     }
 
     // MARK: - Row Handler

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Settings/JetpackSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Settings/JetpackSettingsViewController.swift
@@ -152,7 +152,7 @@ open class JetpackSettingsViewController: UITableViewController {
                                               comment: "Jetpack Settings: WordPress.com Login settings"),
                 rows: wordPressLoginRows,
                 footerText: nil)
-            ])
+        ])
     }
 
     // MARK: Learn More footer

--- a/WordPress/Classes/ViewRelated/Me/App Settings/MediaCacheSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/MediaCacheSettingsViewController.swift
@@ -25,7 +25,7 @@ class MediaCacheSettingsViewController: UITableViewController {
         ImmuTable.registerRows([
             TextRow.self,
             BrandedNavigationRow.self
-            ], tableView: self.tableView)
+        ], tableView: self.tableView)
 
         reloadViewModel()
 

--- a/WordPress/Classes/ViewRelated/Me/App Settings/Privacy Settings/PrivacySettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/Privacy Settings/PrivacySettingsViewController.swift
@@ -128,7 +128,7 @@ class PrivacySettingsViewController: UITableViewController {
                 ccpaLink,
                 otherTracking,
                 otherTrackingLink
-                ]),
+            ]),
             ImmuTableSection(rows: [
                 reportCrashes,
                 reportCrashesInfoText

--- a/WordPress/Classes/ViewRelated/Media/CircularProgressView.swift
+++ b/WordPress/Classes/ViewRelated/Media/CircularProgressView.swift
@@ -174,7 +174,7 @@ class CircularProgressView: UIView {
         NSLayoutConstraint.activate([
             progressIndicator.centerXAnchor.constraint(equalTo: centerXAnchor),
             progressIndicator.centerYAnchor.constraint(equalTo: centerYAnchor)
-            ])
+        ])
     }
 
     private func configureErrorView() {
@@ -198,7 +198,7 @@ class CircularProgressView: UIView {
             view.bottomAnchor.constraint(equalTo: bottomAnchor),
             view.leadingAnchor.constraint(equalTo: leadingAnchor),
             view.trailingAnchor.constraint(equalTo: trailingAnchor)
-            ])
+        ])
 
         view.isHidden = true
     }
@@ -272,7 +272,7 @@ final class AccessoryView: UIView {
         NSLayoutConstraint.activate([
             container.centerXAnchor.constraint(equalTo: centerXAnchor),
             container.centerYAnchor.constraint(equalTo: centerYAnchor)
-            ])
+        ])
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Plugins/ViewModels/PluginDirectoryViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Plugins/ViewModels/PluginDirectoryViewModel.swift
@@ -226,8 +226,8 @@ class PluginDirectoryViewModel: Observable {
                 featuredRow(presenter: presenter),
                 popularRow(presenter: presenter),
                 newRow(presenter: presenter),
-                ]),
-            ])
+            ]),
+        ])
     }
 
     public func refresh() {

--- a/WordPress/Classes/ViewRelated/Plugins/ViewModels/PluginListViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Plugins/ViewModels/PluginListViewModel.swift
@@ -232,7 +232,7 @@ class PluginListViewModel: Observable {
 
             return ImmuTable(sections: [
                 ImmuTableSection(rows: rows)
-                ])
+            ])
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Plugins/ViewModels/PluginViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Plugins/ViewModels/PluginViewModel.swift
@@ -461,26 +461,26 @@ class PluginViewModel: Observable {
             ImmuTableSection(optionalRows: [
                 header,
                 versionRow
-                ]),
+            ]),
             ImmuTableSection(optionalRows: [
                 active,
                 autoupdates
-                ]),
+            ]),
             ImmuTableSection(optionalRows: [
                 settingsLink,
                 wpOrgPluginLink,
                 homeLink
-                ]),
+            ]),
             ImmuTableSection(optionalRows: [
                 description,
                 installation,
                 changelog,
                 faq
-                ]),
+            ]),
             ImmuTableSection(optionalRows: [
                 remove
-                ])
             ])
+        ])
     }
 
     private func confirmRegisterDomainAlert(for directoryEntry: PluginDirectoryEntry) -> UIAlertController {

--- a/WordPress/Classes/ViewRelated/Plugins/Views/CollectionViewContainerRow.swift
+++ b/WordPress/Classes/ViewRelated/Plugins/Views/CollectionViewContainerRow.swift
@@ -149,7 +149,7 @@ class CollectionViewContainerCell: UITableViewCell {
                 noResultsView.view.bottomAnchor.constraint(equalTo: collectionView.bottomAnchor),
                 noResultsView.view.leadingAnchor.constraint(equalTo: collectionView.leadingAnchor),
                 noResultsView.view.trailingAnchor.constraint(equalTo: collectionView.trailingAnchor)
-                ])
+            ])
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Post/Revisions/Browser/Preview/RevisionPreviewViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Revisions/Browser/Preview/RevisionPreviewViewController.swift
@@ -111,7 +111,7 @@ private extension RevisionPreviewViewController {
             textView.trailingAnchor.constraint(equalTo: guide.trailingAnchor),
             textView.topAnchor.constraint(equalTo: view.topAnchor),
             textView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
-            ])
+        ])
     }
 
     private func updateTitleHeight() {

--- a/WordPress/Classes/ViewRelated/Site Creation/Shared/TitleSubtitleTextfieldHeader.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Shared/TitleSubtitleTextfieldHeader.swift
@@ -80,7 +80,7 @@ final class SearchTextField: UITextField {
 
         NSLayoutConstraint.activate([
             heightAnchor.constraint(equalToConstant: Constants.searchHeight),
-            ])
+        ])
     }
 
     private lazy var searchIconImageView: UIImageView = {

--- a/WordPress/Classes/ViewRelated/Stats/Insights/ViewsVisitors/ViewsVisitorsLineChartCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/ViewsVisitors/ViewsVisitorsLineChartCell.swift
@@ -274,7 +274,7 @@ private extension ViewsVisitorsLineChartCell {
             chartView.trailingAnchor.constraint(equalTo: chartContainerView.trailingAnchor),
             chartView.topAnchor.constraint(equalTo: chartContainerView.topAnchor),
             chartView.bottomAnchor.constraint(equalTo: chartContainerView.bottomAnchor)
-            ])
+        ])
     }
 
     func resetChartContainerView() {

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/Overview/OverviewCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/Overview/OverviewCell.swift
@@ -258,7 +258,7 @@ private extension OverviewCell {
             chartView.trailingAnchor.constraint(equalTo: chartContainerView.trailingAnchor),
             chartView.topAnchor.constraint(equalTo: chartContainerView.topAnchor),
             chartView.bottomAnchor.constraint(equalTo: chartContainerView.bottomAnchor)
-            ])
+        ])
     }
 
     func resetChartContainerView() {

--- a/WordPress/Classes/ViewRelated/Support/SupportTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Support/SupportTableViewController.swift
@@ -657,7 +657,7 @@ class ButtonCell: WPTableViewCellDefault {
                                         button.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -SupportTableLayoutSpacing.sidePadding),
                                         button.topAnchor.constraint(equalTo: contentView.topAnchor, constant: SupportTableLayoutSpacing.topBottomPadding),
                                         button.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -SupportTableLayoutSpacing.topBottomPadding)
-                                    ])
+        ])
     }
 
     enum LayoutSpacing {

--- a/WordPress/Classes/ViewRelated/System/Notices/NoticePresenter.swift
+++ b/WordPress/Classes/ViewRelated/System/Notices/NoticePresenter.swift
@@ -405,7 +405,7 @@ class NoticeContainerView: UIView {
             stackView.trailingAnchor.constraint(equalTo: layoutMarginsGuide.trailingAnchor),
             stackView.topAnchor.constraint(equalTo: layoutMarginsGuide.topAnchor),
             stackView.bottomAnchor.constraint(equalTo: layoutMarginsGuide.bottomAnchor)
-            ])
+        ])
     }
 
     required init?(coder aDecoder: NSCoder) {

--- a/WordPress/Classes/ViewRelated/System/Notices/NoticeView.swift
+++ b/WordPress/Classes/ViewRelated/System/Notices/NoticeView.swift
@@ -186,7 +186,7 @@ class NoticeView: UIView {
         NSLayoutConstraint.activate([
             actionBackgroundView.topAnchor.constraint(equalTo: backgroundView.contentView.topAnchor),
             actionBackgroundView.bottomAnchor.constraint(equalTo: backgroundView.contentView.bottomAnchor),
-            ])
+        ])
 
         actionBackgroundView.pinSubviewToAllEdgeMargins(actionButton)
 
@@ -401,7 +401,7 @@ fileprivate extension UIView {
             borderView.topAnchor.constraint(equalTo: topAnchor),
             borderView.centerXAnchor.constraint(equalTo: centerXAnchor),
             borderView.widthAnchor.constraint(equalTo: widthAnchor)
-            ])
+        ])
     }
 
     func addTrailingBorder() {
@@ -412,7 +412,7 @@ fileprivate extension UIView {
             borderView.trailingAnchor.constraint(equalTo: trailingAnchor),
             borderView.centerYAnchor.constraint(equalTo: centerYAnchor),
             borderView.widthAnchor.constraint(equalToConstant: .hairlineBorderWidth)
-            ])
+        ])
     }
 
     func makeBorderView() -> UIView {

--- a/WordPress/WordPressShareExtension/Sources/UI/ShareExtensionEditorViewController.swift
+++ b/WordPress/WordPressShareExtension/Sources/UI/ShareExtensionEditorViewController.swift
@@ -392,7 +392,7 @@ class ShareExtensionEditorViewController: ShareExtensionAbstractViewController {
             titleTextField.trailingAnchor.constraint(equalTo: layoutGuide.trailingAnchor),
             titleTopConstraint,
             titleHeightConstraint
-            ])
+        ])
 
         let insets = titleTextField.textContainerInset
 
@@ -401,28 +401,28 @@ class ShareExtensionEditorViewController: ShareExtensionAbstractViewController {
             titlePlaceholderLabel.rightAnchor.constraint(equalTo: titleTextField.rightAnchor, constant: -insets.right - titleTextField.textContainer.lineFragmentPadding),
             titlePlaceholderLabel.topAnchor.constraint(equalTo: titleTextField.topAnchor, constant: insets.top),
             titlePlaceholderLabel.heightAnchor.constraint(equalToConstant: titleTextField.font!.lineHeight)
-            ])
+        ])
 
         NSLayoutConstraint.activate([
             separatorView.leftAnchor.constraint(equalTo: layoutGuide.leftAnchor),
             separatorView.rightAnchor.constraint(equalTo: layoutGuide.rightAnchor),
             separatorView.topAnchor.constraint(equalTo: titleTextField.bottomAnchor),
             separatorView.heightAnchor.constraint(equalToConstant: separatorView.frame.height)
-            ])
+        ])
 
         NSLayoutConstraint.activate([
             richTextView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             richTextView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             richTextView.topAnchor.constraint(equalTo: view.topAnchor),
             richTextView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
-            ])
+        ])
 
         NSLayoutConstraint.activate([
             placeholderLabel.leadingAnchor.constraint(equalTo: layoutGuide.leadingAnchor, constant: Constants.placeholderPadding.left),
             placeholderLabel.trailingAnchor.constraint(equalTo: layoutGuide.trailingAnchor, constant: -(Constants.placeholderPadding.right + richTextView.textContainer.lineFragmentPadding)),
             textPlaceholderTopConstraint,
             placeholderLabel.bottomAnchor.constraint(lessThanOrEqualTo: richTextView.bottomAnchor, constant: Constants.placeholderPadding.bottom)
-            ])
+        ])
     }
 
     private func configureDefaultProperties(for textView: UITextView, accessibilityLabel: String) {
@@ -827,7 +827,7 @@ extension ShareExtensionEditorViewController {
             .header4: .h4,
             .header5: .h5,
             .header6: .h6,
-            ]
+        ]
         for (key, value) in mapping {
             if identifiers.contains(key) {
                 return value


### PR DESCRIPTION
## What and why

Enables SwiftLint's [`literal_expression_end_indentation`](https://realm.github.io/SwiftLint/literal_expression_end_indentation.html) rule, which requires the closing bracket of a multi-line array or dictionary literal to align with the line that opened it. Part of the Orchard SwiftLint rollout campaign (Phase 3 — formatting and consistency).

## Approach

- Added the rule to `only_rules` in `.swiftlint.yml` (alphabetical order, between `last_where` and `mark`).
- `literal_expression_end_indentation` **is** auto-correctable. `rake lintfix` resolved 65 of the 67 violations on its own.
- For the remaining 2 files (`RegisterDomainDetailsViewModel+RowList.swift` and `JetpackConnectionViewController.swift`), the autocorrector miscounted the nesting and dropped closing brackets, producing code that would not compile. Those two files were reverted and the trailing brackets re-formatted by hand so the rule is satisfied without touching behaviour.
- All changes are whitespace-only. No suppressions, nothing left for human review.

## How to test

- `rake lint` reports zero `literal_expression_end_indentation` violations.
- The `WordPress` scheme builds clean locally (`xcodebuild -workspace WordPress.xcworkspace -scheme WordPress -destination 'generic/platform=iOS Simulator' build`).
