### PR TITLE
Enable SwiftLint rule: modifier_order

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -77,6 +77,9 @@ only_rules:
   # MARK comment should be in valid format.
   - mark
 
+  # Modifier order should be consistent.
+  - modifier_order
+
   # Opening braces should be preceded by a single space and on the same line as
   # the declaration.
   - opening_brace

--- a/Modules/Sources/AsyncImageKit/Helpers/FaviconService.swift
+++ b/Modules/Sources/AsyncImageKit/Helpers/FaviconService.swift
@@ -4,7 +4,7 @@ import UIKit
 public actor FaviconService {
     public static let shared = FaviconService()
 
-    private nonisolated let cache = FaviconCache()
+    nonisolated private let cache = FaviconCache()
 
     private let session = URLSession(configuration: {
         let configuration = URLSessionConfiguration.default

--- a/Modules/Sources/AsyncImageKit/Helpers/ImageSaliencyService.swift
+++ b/Modules/Sources/AsyncImageKit/Helpers/ImageSaliencyService.swift
@@ -5,10 +5,10 @@ import Vision
 /// Detects the most salient (visually interesting) region in images using Vision framework.
 /// Results are cached by image URL.
 public actor ImageSaliencyService {
-    public nonisolated static let shared = ImageSaliencyService()
+    nonisolated public static let shared = ImageSaliencyService()
 
-    private nonisolated let cache = SaliencyCache()
-    private nonisolated let detector = SaliencyDetector()
+    nonisolated private let cache = SaliencyCache()
+    nonisolated private let detector = SaliencyDetector()
     private var inflightTasks: [URL: Task<CGRect?, Never>] = [:]
 
     init() {
@@ -18,7 +18,7 @@ public actor ImageSaliencyService {
     }
 
     /// Returns a cached rect synchronously without starting a task, or `nil` if not yet cached.
-    public nonisolated func cachedSaliencyRect(for url: URL) -> CGRect? {
+    nonisolated public func cachedSaliencyRect(for url: URL) -> CGRect? {
         cache.cachedRect(for: url)
     }
 
@@ -46,7 +46,7 @@ public actor ImageSaliencyService {
     /// Returns the frame for the image view within a container such that `saliencyRect`
     /// appears at `topInset` points from the top. Returns `nil` when no adjustment is needed
     /// (i.e. the image is not portrait relative to the container).
-    public nonisolated func adjustedFrame(
+    nonisolated public func adjustedFrame(
         saliencyRect: CGRect,
         imageSize: CGSize,
         in containerSize: CGSize,

--- a/Modules/Sources/AsyncImageKit/ImageDownloader.swift
+++ b/Modules/Sources/AsyncImageKit/ImageDownloader.swift
@@ -5,9 +5,9 @@ import AVFoundation
 /// The system that downloads and caches images, and prepares them for display.
 @ImageDownloaderActor
 public final class ImageDownloader {
-    public nonisolated static let shared = ImageDownloader()
+    nonisolated public static let shared = ImageDownloader()
 
-    private nonisolated let cache: MemoryCacheProtocol
+    nonisolated private let cache: MemoryCacheProtocol
 
     private let urlSession = URLSession {
         $0.urlCache = nil
@@ -23,7 +23,7 @@ public final class ImageDownloader {
 
     private var tasks: [String: ImageDataTask] = [:]
 
-    public nonisolated init(
+    nonisolated public init(
         cache: MemoryCacheProtocol = MemoryCache.shared
     ) {
         self.cache = cache
@@ -112,7 +112,7 @@ public final class ImageDownloader {
         cache[makeKey(for: imageURL, size: size)] = image
     }
 
-    private nonisolated func makeKey(for imageURL: URL?, size: ImageSize?) -> String {
+    nonisolated private func makeKey(for imageURL: URL?, size: ImageSize?) -> String {
         guard let imageURL else {
             assertionFailure("The request.url was nil") // This should never happen
             return ""
@@ -150,7 +150,7 @@ public final class ImageDownloader {
         return try await task.getData(subscriptionID: subscriptionID)
     }
 
-    fileprivate nonisolated func unsubscribe(_ subscriptionID: UUID, key: String) {
+    nonisolated fileprivate func unsubscribe(_ subscriptionID: UUID, key: String) {
         Task {
             await _unsubscribe(subscriptionID, key: key)
         }

--- a/Modules/Sources/AsyncImageKit/ImagePrefetcher.swift
+++ b/Modules/Sources/AsyncImageKit/ImagePrefetcher.swift
@@ -15,7 +15,7 @@ public final class ImagePrefetcher {
         }
     }
 
-    public nonisolated init(
+    nonisolated public init(
         downloader: ImageDownloader = .shared,
         maxConcurrentTasks: Int = 2
     ) {
@@ -23,7 +23,7 @@ public final class ImagePrefetcher {
         self.maxConcurrentTasks = maxConcurrentTasks
     }
 
-    public nonisolated func startPrefetching(for requests: [ImageRequest]) {
+    nonisolated public func startPrefetching(for requests: [ImageRequest]) {
         Task { @ImageDownloaderActor in
             for request in requests {
                 startPrefetching(for: request)
@@ -67,7 +67,7 @@ public final class ImagePrefetcher {
         performPendingTasks()
     }
 
-    public nonisolated func stopPrefetching(for requests: [ImageRequest]) {
+    nonisolated public func stopPrefetching(for requests: [ImageRequest]) {
         Task { @ImageDownloaderActor in
             for request in requests {
                 stopPrefetching(for: request)
@@ -83,7 +83,7 @@ public final class ImagePrefetcher {
         }
     }
 
-    public nonisolated func stopAll() {
+    nonisolated public func stopAll() {
         Task { @ImageDownloaderActor in
             for (_, value) in queue {
                 value.task?.cancel()

--- a/Modules/Sources/AsyncImageKit/Views/AsyncImageView.swift
+++ b/Modules/Sources/AsyncImageKit/Views/AsyncImageView.swift
@@ -68,7 +68,7 @@ public final class AsyncImageView: UIView {
         }
     }
 
-    public override init(frame: CGRect) {
+    override public init(frame: CGRect) {
         super.init(frame: frame)
 
         setupView()
@@ -94,7 +94,7 @@ public final class AsyncImageView: UIView {
         backgroundColor = .secondarySystemBackground
     }
 
-    public override func layoutSubviews() {
+    override public func layoutSubviews() {
         super.layoutSubviews()
 
         imageView.frame = {

--- a/Modules/Sources/FormattableContentKit/Actions/DefaultFormattableContentAction.swift
+++ b/Modules/Sources/FormattableContentKit/Actions/DefaultFormattableContentAction.swift
@@ -13,7 +13,7 @@ public class DefaultFormattableContentAction: FormattableContentAction {
         }
     }
 
-    private(set) public var command: FormattableContentActionCommand?
+    public private(set) var command: FormattableContentActionCommand?
 
     public var identifier: Identifier {
         return type(of: self).actionIdentifier()

--- a/Modules/Sources/FormattableContentKit/Actions/FormattableCommentContent.swift
+++ b/Modules/Sources/FormattableContentKit/Actions/FormattableCommentContent.swift
@@ -11,7 +11,7 @@ public class FormattableCommentContent: NotificationTextContent {
         return isActionOn(id: identifier) || !isActionEnabled(id: identifier)
     }
 
-    public override var kind: FormattableContentKind {
+    override public var kind: FormattableContentKind {
         return .comment
     }
 

--- a/Modules/Sources/FormattableContentKit/FormattableContent/FooterTextContent.swift
+++ b/Modules/Sources/FormattableContentKit/FormattableContent/FooterTextContent.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 public class FooterTextContent: FormattableTextContent {
-    public override init(text: String, ranges: [FormattableContentRange], actions: [FormattableContentAction]?) {
+    override public init(text: String, ranges: [FormattableContentRange], actions: [FormattableContentAction]?) {
         if text == "You replied to this comment." {
             let localizedText = NSLocalizedString("You replied to this comment.", comment: "Notification text - below a comment notification detail")
 

--- a/Modules/Sources/FormattableContentKit/FormattableContent/FormattableUserContent.swift
+++ b/Modules/Sources/FormattableContentKit/FormattableContent/FormattableUserContent.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 public class FormattableUserContent: NotificationTextContent {
-    public override var kind: FormattableContentKind {
+    override public var kind: FormattableContentKind {
         return .user
     }
 

--- a/Modules/Sources/FormattableContentKit/NotificationTextContent.swift
+++ b/Modules/Sources/FormattableContentKit/NotificationTextContent.swift
@@ -55,11 +55,11 @@ public class NotificationTextContent: FormattableTextContent, FormattableMediaCo
     public let parent: Notifiable
     public let meta: [String: AnyObject]?
 
-    public override var text: String? {
+    override public var text: String? {
         return textOverride ?? super.text
     }
 
-    public override var kind: FormattableContentKind {
+    override public var kind: FormattableContentKind {
         if let firstMedia = media.first, firstMedia.kind == .image || firstMedia.kind == .badge {
             return .image
         }

--- a/Modules/Sources/JetpackSocial/Views/ManageConnectionsHostingController.swift
+++ b/Modules/Sources/JetpackSocial/Views/ManageConnectionsHostingController.swift
@@ -26,7 +26,7 @@ public final class ManageConnectionsHostingController: UIHostingController<AnyVi
         )
     }
 
-    @preconcurrency required dynamic init?(coder: NSCoder) {
+    @preconcurrency dynamic required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
 

--- a/Modules/Sources/JetpackSocial/Views/SocialOAuthWebViewController.swift
+++ b/Modules/Sources/JetpackSocial/Views/SocialOAuthWebViewController.swift
@@ -57,7 +57,7 @@ public final class SocialOAuthWebViewController: UIViewController, WKNavigationD
         fatalError("init(coder:) has not been implemented")
     }
 
-    public override func viewDidLoad() {
+    override public func viewDidLoad() {
         super.viewDidLoad()
 
         view.backgroundColor = .systemBackground

--- a/Modules/Sources/ShareExtensionCore/Data/SharedCoreDataStack.swift
+++ b/Modules/Sources/ShareExtensionCore/Data/SharedCoreDataStack.swift
@@ -7,7 +7,7 @@ import WordPressKit
 /// NSPersistentContainer subclass that defaults to the shared container directory
 ///
 final class SharedPersistentContainer: NSPersistentContainer {
-    internal override class func defaultDirectoryURL() -> URL {
+    override internal class func defaultDirectoryURL() -> URL {
         var url = super.defaultDirectoryURL()
         if let newURL = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: BuildSettings.current.appGroupName) {
             url = newURL

--- a/Modules/Sources/WordPressCore/Types/LockingHashMap.swift
+++ b/Modules/Sources/WordPressCore/Types/LockingHashMap.swift
@@ -45,7 +45,7 @@ public class LockingHashMap<Value>: @unchecked Sendable {
 public class LockingTaskHashMap<T, E>: LockingHashMap<Task<T, E>>, @unchecked Sendable where T: Sendable, E: Error {
 
     @discardableResult
-    public override func removeValue(forKey key: AnyHashable) -> Task<T, E>? {
+    override public func removeValue(forKey key: AnyHashable) -> Task<T, E>? {
         lock.withLock {
             let task = self.list.removeValue(forKey: key)
             task?.cancel()
@@ -53,7 +53,7 @@ public class LockingTaskHashMap<T, E>: LockingHashMap<Task<T, E>>, @unchecked Se
         }
     }
 
-    public override func removeAll() {
+    override public func removeAll() {
         lock.withLock {
             for key in self.list.keys {
                 let task = self.list.removeValue(forKey: key)

--- a/Modules/Sources/WordPressIntelligence/IntelligenceService.swift
+++ b/Modules/Sources/WordPressIntelligence/IntelligenceService.swift
@@ -14,7 +14,7 @@ public enum IntelligenceService {
     public static let contextSizeLimit = 4096
 
     /// Checks if intelligence features are supported on the current device.
-    public nonisolated static var isSupported: Bool {
+    nonisolated public static var isSupported: Bool {
         guard #available(iOS 26, *) else {
             return false
         }

--- a/Modules/Sources/WordPressKit/AccountServiceRemoteREST+SocialService.swift
+++ b/Modules/Sources/WordPressKit/AccountServiceRemoteREST+SocialService.swift
@@ -50,7 +50,7 @@ extension AccountServiceRemoteREST {
     ///     - email Email from Apple account.
     ///     - fullName User's full name from Apple account.
     /// - Returns: Dictionary with endpoint parameters, to be used when connecting to social service.
-    static public func appleSignInParameters(email: String, fullName: String) -> [String: AnyObject] {
+    public static func appleSignInParameters(email: String, fullName: String) -> [String: AnyObject] {
         return [
             "user_email": email as AnyObject,
             "user_name": fullName as AnyObject

--- a/Modules/Sources/WordPressKit/HTTPAuthenticationAlertController.swift
+++ b/Modules/Sources/WordPressKit/HTTPAuthenticationAlertController.swift
@@ -9,7 +9,7 @@ open class HTTPAuthenticationAlertController {
 
     private static var onGoingChallenges = [URLProtectionSpace: [AuthenticationHandler]]()
 
-    static public func controller(for challenge: URLAuthenticationChallenge, handler: @escaping AuthenticationHandler) -> UIAlertController? {
+    public static func controller(for challenge: URLAuthenticationChallenge, handler: @escaping AuthenticationHandler) -> UIAlertController? {
         if var handlers = onGoingChallenges[challenge.protectionSpace] {
             handlers.append(handler)
             onGoingChallenges[challenge.protectionSpace] = handlers

--- a/Modules/Sources/WordPressKit/NSMutableParagraphStyle+extensions.swift
+++ b/Modules/Sources/WordPressKit/NSMutableParagraphStyle+extensions.swift
@@ -1,14 +1,14 @@
 import Foundation
 
 extension NSMutableParagraphStyle {
-    @objc convenience public init(minLineHeight: CGFloat, lineBreakMode: NSLineBreakMode, alignment: NSTextAlignment) {
+    @objc public convenience init(minLineHeight: CGFloat, lineBreakMode: NSLineBreakMode, alignment: NSTextAlignment) {
         self.init()
         self.minimumLineHeight = minLineHeight
         self.lineBreakMode = lineBreakMode
         self.alignment = alignment
     }
 
-    @objc convenience public init(minLineHeight: CGFloat, maxLineHeight: CGFloat, lineBreakMode: NSLineBreakMode, alignment: NSTextAlignment) {
+    @objc public convenience init(minLineHeight: CGFloat, maxLineHeight: CGFloat, lineBreakMode: NSLineBreakMode, alignment: NSTextAlignment) {
         self.init(minLineHeight: minLineHeight, lineBreakMode: lineBreakMode, alignment: alignment)
         self.maximumLineHeight = maxLineHeight
     }

--- a/Modules/Sources/WordPressKit/RemoteBlockEditorSettings.swift
+++ b/Modules/Sources/WordPressKit/RemoteBlockEditorSettings.swift
@@ -37,7 +37,7 @@ public class RemoteBlockEditorSettings: Codable {
         return String(data: data, encoding: .utf8)
     }
 
-    required public init(from decoder: Decoder) throws {
+    public required init(from decoder: Decoder) throws {
         let map = try decoder.container(keyedBy: CodingKeys.self)
         self.isFSETheme = (try? map.decode(Bool.self, forKey: .isFSETheme)) ?? false
         self.galleryWithImageBlocks = (try? map.decode(Bool.self, forKey: .galleryWithImageBlocks)) ?? false

--- a/Modules/Sources/WordPressKit/WordPressComRestApi.swift
+++ b/Modules/Sources/WordPressKit/WordPressComRestApi.swift
@@ -113,11 +113,11 @@ open class WordPressComRestApi: NSObject {
 
     // MARK: WordPressComRestApi
 
-    @objc convenience public init(oAuthToken: String? = nil, userAgent: String? = nil) {
+    @objc public convenience init(oAuthToken: String? = nil, userAgent: String? = nil) {
         self.init(oAuthToken: oAuthToken, userAgent: userAgent, backgroundUploads: false, backgroundSessionIdentifier: WordPressComRestApi.defaultBackgroundSessionIdentifier)
     }
 
-    @objc convenience public init(oAuthToken: String? = nil, userAgent: String? = nil, baseURL: URL = WordPressComRestApi.apiBaseURL) {
+    @objc public convenience init(oAuthToken: String? = nil, userAgent: String? = nil, baseURL: URL = WordPressComRestApi.apiBaseURL) {
         self.init(oAuthToken: oAuthToken, userAgent: userAgent, backgroundUploads: false, backgroundSessionIdentifier: WordPressComRestApi.defaultBackgroundSessionIdentifier, baseURL: baseURL)
     }
 
@@ -586,13 +586,13 @@ extension WordPressComRestApi {
 
     /// Returns an API object without an OAuth token defined & with the userAgent set for the WordPress App user agent
     ///
-    @objc class public func anonymousApi(userAgent: String) -> WordPressComRestApi {
+    @objc public class func anonymousApi(userAgent: String) -> WordPressComRestApi {
         return WordPressComRestApi(oAuthToken: nil, userAgent: userAgent)
     }
 
     /// Returns an API object without an OAuth token defined & with both the userAgent & localeKey set for the WordPress App user agent
     ///
-    @objc class public func anonymousApi(userAgent: String, localeKey: String) -> WordPressComRestApi {
+    @objc public class func anonymousApi(userAgent: String, localeKey: String) -> WordPressComRestApi {
         return WordPressComRestApi(oAuthToken: nil, userAgent: userAgent, localeKey: localeKey)
     }
 }

--- a/Modules/Sources/WordPressKit/WordPressOrgXMLRPCApi.swift
+++ b/Modules/Sources/WordPressKit/WordPressOrgXMLRPCApi.swift
@@ -79,7 +79,7 @@ open class WordPressOrgXMLRPCApi: NSObject, WordPressOrgXMLRPCApiInterfacing {
     /// - Parameters:
     ///   - endpoint:  the endpoint to connect to the xmlrpc api interface.
     ///   - userAgent: the user agent to use on the connection.
-    @objc convenience public init(endpoint: URL, userAgent: String? = nil) {
+    @objc public convenience init(endpoint: URL, userAgent: String? = nil) {
         self.init(endpoint: endpoint, userAgent: userAgent, backgroundUploads: false, backgroundSessionIdentifier: WordPressOrgXMLRPCApi.defaultBackgroundSessionIdentifier + "." + endpoint.absoluteString)
     }
 

--- a/Modules/Sources/WordPressKitModels/RemoteReaderSiteInfoSubscription.swift
+++ b/Modules/Sources/WordPressKitModels/RemoteReaderSiteInfoSubscription.swift
@@ -11,7 +11,7 @@ private struct CodingKeys {
 @objc public class RemoteReaderSiteInfoSubscriptionPost: NSObject {
     @objc public var sendPosts: Bool
 
-    @objc required public init(dictionary: [String: Any]) {
+    @objc public required init(dictionary: [String: Any]) {
         self.sendPosts = (dictionary[CodingKeys.sendPost] as? Bool) ?? false
         super.init()
     }
@@ -22,7 +22,7 @@ private struct CodingKeys {
     @objc public var sendComments: Bool
     @objc public var postDeliveryFrequency: String
 
-    @objc required public init(dictionary: [String: Any]) {
+    @objc public required init(dictionary: [String: Any]) {
         sendComments = (dictionary[CodingKeys.sendComments] as? Bool) ?? false
         postDeliveryFrequency = (dictionary[CodingKeys.postDeliveryFrequency] as? String) ?? ""
         super.init(dictionary: dictionary)

--- a/Modules/Sources/WordPressReader/Comments/Views/WebCommentContentRenderer.swift
+++ b/Modules/Sources/WordPressReader/Comments/Views/WebCommentContentRenderer.swift
@@ -38,7 +38,7 @@ public final class WebCommentContentRenderer: NSObject, CommentContentRenderer {
     private var isReloadNeeded = false
 
     // MARK: Methods
-    public override init() {
+    override public init() {
         super.init()
 
         webView.isInspectable = true

--- a/Modules/Sources/WordPressShared/AsyncOperation/AsyncBlockOperation.swift
+++ b/Modules/Sources/WordPressShared/AsyncOperation/AsyncBlockOperation.swift
@@ -6,7 +6,7 @@ public class AsyncBlockOperation: AsyncOperation, @unchecked Sendable {
         self.block = block
     }
 
-    public override func main() {
+    override public func main() {
         self.block { [weak self] in
             self?.state = .isFinished
         }

--- a/Modules/Sources/WordPressShared/AsyncOperation/AsyncOperation.swift
+++ b/Modules/Sources/WordPressShared/AsyncOperation/AsyncOperation.swift
@@ -3,7 +3,7 @@ open class AsyncOperation: Operation, @unchecked Sendable {
         case isReady, isExecuting, isFinished
     }
 
-    public override var isAsynchronous: Bool {
+    override public var isAsynchronous: Bool {
         return true
     }
 
@@ -18,15 +18,15 @@ open class AsyncOperation: Operation, @unchecked Sendable {
         }
     }
 
-    public override var isExecuting: Bool {
+    override public var isExecuting: Bool {
         return state == .isExecuting
     }
 
-    public override var isFinished: Bool {
+    override public var isFinished: Bool {
         return state == .isFinished
     }
 
-    public override func start() {
+    override public func start() {
         if isCancelled {
             state = .isFinished
             return

--- a/Modules/Sources/WordPressShared/Utility/ManagedObjectsObserver.swift
+++ b/Modules/Sources/WordPressShared/Utility/ManagedObjectsObserver.swift
@@ -3,7 +3,7 @@ import CoreData
 import Combine
 
 public final class ManagedObjectsObserver<T: NSManagedObject>: NSObject, NSFetchedResultsControllerDelegate {
-    @Published private(set) public var objects: [T] = []
+    @Published public private(set) var objects: [T] = []
 
     private let controller: NSFetchedResultsController<T>
 

--- a/Modules/Sources/WordPressUI/Deprecated/NoResultsViewController.swift
+++ b/Modules/Sources/WordPressUI/Deprecated/NoResultsViewController.swift
@@ -62,22 +62,22 @@ import WordPressShared
 
     // MARK: - View
 
-    public override func viewDidLoad() {
+    override public func viewDidLoad() {
         super.viewDidLoad()
         WPStyleGuide.configureColors(view: view, tableView: nil)
     }
 
-    public override func viewWillAppear(_ animated: Bool) {
+    override public func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         configureView()
     }
 
-    public override func didMove(toParent parent: UIViewController?) {
+    override public func didMove(toParent parent: UIViewController?) {
         super.didMove(toParent: parent)
         configureView()
     }
 
-    public override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
+    override public func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
         super.viewWillTransition(to: size, with: coordinator)
         setAccessoryViewsVisibility()
         // `traitCollectionDidChange` is not fired for iOS 16.0 + Media adding flow. The reason why the constraints update call was moved to here.
@@ -87,7 +87,7 @@ import WordPressShared
         }
     }
 
-    public override func viewDidLayoutSubviews() {
+    override public func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
         adjustTitleOnlyLabelHeight()
     }

--- a/Modules/Sources/WordPressUI/FancyAlert/FancyButton.swift
+++ b/Modules/Sources/WordPressUI/FancyAlert/FancyButton.swift
@@ -109,17 +109,17 @@ open class FancyButton: UIButton {
 
     // MARK: - LifeCycle Methods
 
-    open override func didMoveToWindow() {
+    override open func didMoveToWindow() {
         super.didMoveToWindow()
         configureAppearance()
     }
 
-    open override func awakeFromNib() {
+    override open func awakeFromNib() {
         super.awakeFromNib()
         configureAppearance()
     }
 
-    open override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+    override open func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
         configureBackgrounds()
     }
@@ -127,7 +127,7 @@ open class FancyButton: UIButton {
     // This implementation is required to allow the text of a button to
     // wrap appropriately including insets above and below.
     //
-    open override var intrinsicContentSize: CGSize {
+    override open var intrinsicContentSize: CGSize {
         guard let titleLabel else {
             return super.intrinsicContentSize
         }
@@ -143,7 +143,7 @@ open class FancyButton: UIButton {
         return size
     }
 
-    open override func layoutSubviews() {
+    override open func layoutSubviews() {
         titleLabel?.preferredMaxLayoutWidth = bounds.width
 
         super.layoutSubviews()

--- a/Modules/Sources/WordPressUI/Tools/GradientView.swift
+++ b/Modules/Sources/WordPressUI/Tools/GradientView.swift
@@ -13,7 +13,7 @@ public class GradientView: UIView {
         commonInit()
     }
 
-    required public init?(coder aDecoder: NSCoder) {
+    public required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
         commonInit()
     }

--- a/Modules/Sources/WordPressUI/Views/AdaptiveTabBar.swift
+++ b/Modules/Sources/WordPressUI/Views/AdaptiveTabBar.swift
@@ -105,7 +105,7 @@ public class AdaptiveTabBar: UIControl {
         if #available(iOS 26, *) { 1 } else { 0.33 }
     }
 
-    public override func layoutSubviews() {
+    override public func layoutSubviews() {
         super.layoutSubviews()
 
         if previousWidth != bounds.width {

--- a/Modules/Sources/WordPressUI/Views/AdaptiveTabBarController.swift
+++ b/Modules/Sources/WordPressUI/Views/AdaptiveTabBarController.swift
@@ -2,7 +2,7 @@ import UIKit
 
 @MainActor
 public final class AdaptiveTabBarController<Item: AdaptiveTabBarItem> {
-    private(set) public var items: [Item] = []
+    public private(set) var items: [Item] = []
 
     public var selection: Item? {
         didSet {

--- a/Modules/Sources/WordPressUI/Views/InfiniteScrollerView.swift
+++ b/Modules/Sources/WordPressUI/Views/InfiniteScrollerView.swift
@@ -47,7 +47,7 @@ public final class InfiniteScrollView: UIScrollView {
         return stackView.arrangedSubviews[0].frame.size.height
     }
 
-    public override init(frame: CGRect) {
+    override public init(frame: CGRect) {
         guard viewBuilder != nil else {
             fatalError("this class must be initialized using init(frame:viewBuilder:)")
         }

--- a/Modules/Sources/WordPressUI/Views/SeparatorView.swift
+++ b/Modules/Sources/WordPressUI/Views/SeparatorView.swift
@@ -13,7 +13,7 @@ public final class SeparatorView: UIView {
         return view
     }
 
-    public override init(frame: CGRect) {
+    override public init(frame: CGRect) {
         super.init(frame: frame)
 
         backgroundColor = .separator

--- a/Modules/Sources/WordPressUI/Views/SiteIconView.swift
+++ b/Modules/Sources/WordPressUI/Views/SiteIconView.swift
@@ -120,7 +120,7 @@ public struct SiteIconViewModel {
 public final class SiteIconHostingView: UIView {
     private let viewModel = SiteIconHostingViewModel()
 
-    public override init(frame: CGRect) {
+    override public init(frame: CGRect) {
         super.init(frame: frame)
 
         let host = UIHostingController(rootView: _SiteIconHostingView(viewModel: viewModel))

--- a/Modules/Sources/WordPressUI/Views/SpacerView.swift
+++ b/Modules/Sources/WordPressUI/Views/SpacerView.swift
@@ -25,7 +25,7 @@ public final class SpacerView: UIView {
         heightAnchor.constraint(equalToConstant: height).isActive = true
     }
 
-    public override init(frame: CGRect) {
+    override public init(frame: CGRect) {
         super.init(frame: .zero)
 
         // Make sure it compresses or expands before any other views if needed.
@@ -35,7 +35,7 @@ public final class SpacerView: UIView {
         setContentHuggingPriority(.init(10), for: .vertical)
     }
 
-    public override var intrinsicContentSize: CGSize {
+    override public var intrinsicContentSize: CGSize {
         CGSizeMake(0, 0) // Avoid ambiguous layout
     }
 

--- a/Modules/Sources/WordPressUI/Views/WPReusableTableViewCells.swift
+++ b/Modules/Sources/WordPressUI/Views/WPReusableTableViewCells.swift
@@ -3,7 +3,7 @@ import WordPressShared
 import WordPressLegacy
 
 open class WPReusableTableViewCell: WPTableViewCell {
-    open override func prepareForReuse() {
+    override open func prepareForReuse() {
         super.prepareForReuse()
 
         textLabel?.text = nil
@@ -18,7 +18,7 @@ open class WPReusableTableViewCell: WPTableViewCell {
         accessibilityLabel = nil
     }
 
-    public override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+    override public init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         commonInit()
     }
@@ -40,7 +40,7 @@ open class WPReusableTableViewCell: WPTableViewCell {
 }
 
 open class WPTableViewCellDefault: WPReusableTableViewCell {
-    public override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+    override public init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: .default, reuseIdentifier: reuseIdentifier)
     }
 
@@ -50,7 +50,7 @@ open class WPTableViewCellDefault: WPReusableTableViewCell {
 }
 
 open class WPTableViewCellSubtitle: WPReusableTableViewCell {
-    public override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+    override public init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: .subtitle, reuseIdentifier: reuseIdentifier)
     }
 
@@ -60,7 +60,7 @@ open class WPTableViewCellSubtitle: WPReusableTableViewCell {
 }
 
 open class WPTableViewCellValue1: WPReusableTableViewCell {
-    public override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+    override public init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: .value1, reuseIdentifier: reuseIdentifier)
     }
 
@@ -68,14 +68,14 @@ open class WPTableViewCellValue1: WPReusableTableViewCell {
         super.init(coder: aDecoder)
     }
 
-    public override func commonInit() {
+    override public func commonInit() {
         super.commonInit()
         detailTextLabel?.numberOfLines = 1
     }
 }
 
 open class WPTableViewCellValue2: WPReusableTableViewCell {
-    public override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+    override public init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: .value2, reuseIdentifier: reuseIdentifier)
     }
 

--- a/Modules/Tests/WordPressSharedTests/KeychainUtilsTests.swift
+++ b/Modules/Tests/WordPressSharedTests/KeychainUtilsTests.swift
@@ -27,7 +27,7 @@ class KeychainUtilsTests: XCTestCase {
 
 // MARK: - SFHFKeychainUtilsMock
 
-final private class SFHFKeychainUtilsMock: SFHFKeychainUtils {
+private final class SFHFKeychainUtilsMock: SFHFKeychainUtils {
     typealias MockKeychain = [String: [String: [String: String]]]
 
     static var keychain: MockKeychain = [:]

--- a/Sources/WordPressAuthenticator/Features/NUX/Button/NUXButton.swift
+++ b/Sources/WordPressAuthenticator/Features/NUX/Button/NUXButton.swift
@@ -52,7 +52,7 @@ public struct NUXButtonStyle {
 
     var buttonStyle: NUXButtonStyle?
 
-    open override var isEnabled: Bool {
+    override open var isEnabled: Bool {
         didSet {
             activityIndicator.color = activityIndicatorColor(isEnabled: isEnabled)
         }
@@ -79,7 +79,7 @@ public struct NUXButtonStyle {
         }
     }
 
-    open override func tintColorDidChange() {
+    override open func tintColorDidChange() {
         // Update colors when toggling light/dark mode.
         super.tintColorDidChange()
         configureBackgrounds()
@@ -127,12 +127,12 @@ public struct NUXButtonStyle {
 
     // MARK: - LifeCycle Methods
 
-    open override func didMoveToWindow() {
+    override open func didMoveToWindow() {
         super.didMoveToWindow()
         configureAppearance()
     }
 
-    open override func awakeFromNib() {
+    override open func awakeFromNib() {
         super.awakeFromNib()
         configureAppearance()
     }

--- a/Sources/WordPressAuthenticator/Features/SignIn/LoginNavigationController.swift
+++ b/Sources/WordPressAuthenticator/Features/SignIn/LoginNavigationController.swift
@@ -3,11 +3,11 @@ import WordPressShared
 
 public class LoginNavigationController: RotationAwareNavigationViewController {
 
-    public override var preferredStatusBarStyle: UIStatusBarStyle {
+    override public var preferredStatusBarStyle: UIStatusBarStyle {
         return topViewController?.preferredStatusBarStyle ?? WordPressAuthenticator.shared.style.statusBarStyle
     }
 
-    public override func pushViewController(_ viewController: UIViewController, animated: Bool) {
+    override public func pushViewController(_ viewController: UIViewController, animated: Bool) {
         // By default, the back button label uses the previous view's title.
         // To override that, reset the label when pushing a new view controller.
         self.viewControllers.last?.navigationItem.backButtonDisplayMode = .minimal

--- a/Sources/WordPressAuthenticator/Features/SignIn/LoginSocialErrorCell.swift
+++ b/Sources/WordPressAuthenticator/Features/SignIn/LoginSocialErrorCell.swift
@@ -42,7 +42,7 @@ open class LoginSocialErrorCell: UITableViewCell {
         layoutLabels()
     }
 
-    required public init?(coder aDecoder: NSCoder) {
+    public required init?(coder aDecoder: NSCoder) {
         errorTitle = aDecoder.value(forKey: "errorTitle") as? String ?? ""
         errorDescription = aDecoder.value(forKey: "errorDescription") as? String ?? ""
         titleLabel = UILabel()

--- a/Sources/WordPressAuthenticator/Features/SignIn/LoginViewController.swift
+++ b/Sources/WordPressAuthenticator/Features/SignIn/LoginViewController.swift
@@ -39,7 +39,7 @@ open class LoginViewController: NUXViewController, LoginFacadeDelegate {
         return delegate
     }
 
-    open override var preferredStatusBarStyle: UIStatusBarStyle {
+    override open var preferredStatusBarStyle: UIStatusBarStyle {
         // Set to the old style as the default.
         // Each VC in the unified flows needs to override this to use the unified style.
         return WordPressAuthenticator.shared.style.statusBarStyle
@@ -172,7 +172,7 @@ open class LoginViewController: NUXViewController, LoginFacadeDelegate {
     }
 
     // MARK: SigninWPComSyncHandler methods
-    dynamic open func finishedLogin(withAuthToken authToken: String, requiredMultifactorCode: Bool) {
+    open dynamic func finishedLogin(withAuthToken authToken: String, requiredMultifactorCode: Bool) {
         let wpcom = WordPressComCredentials(authToken: authToken, isJetpackLogin: isJetpackLogin, multifactor: requiredMultifactorCode, siteURL: loginFields.siteAddress)
         let credentials = AuthenticatorCredentials(wpcom: wpcom)
 
@@ -186,7 +186,7 @@ open class LoginViewController: NUXViewController, LoginFacadeDelegate {
     }
 
     /// Overridden here to direct these errors to the login screen's error label
-    dynamic open func displayRemoteError(_ error: Error) {
+    open dynamic func displayRemoteError(_ error: Error) {
         configureViewLoading(false)
         let err = error as NSError
         guard err.code != 403 else {
@@ -350,7 +350,7 @@ extension LoginViewController {
 //
 extension LoginViewController {
 
-    open override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+    override open func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
 
         // Update Dynamic Type
@@ -362,7 +362,7 @@ extension LoginViewController {
         setTableViewMargins(forWidth: view.frame.width)
     }
 
-    open override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
+    override open func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
         super.viewWillTransition(to: size, with: coordinator)
         setTableViewMargins(forWidth: size.width)
     }

--- a/Sources/WordPressAuthenticator/Helpers/Analytics/AuthenticatorAnalyticsTracker.swift
+++ b/Sources/WordPressAuthenticator/Helpers/Analytics/AuthenticatorAnalyticsTracker.swift
@@ -284,9 +284,9 @@ public class AuthenticatorAnalyticsTracker {
     /// State for the analytics tracker.
     ///
     public class State {
-        internal(set) public var lastFlow: Flow
-        internal(set) public var lastSource: Source
-        internal(set) public var lastStep: Step
+        public internal(set) var lastFlow: Flow
+        public internal(set) var lastSource: Source
+        public internal(set) var lastStep: Step
 
         init(lastFlow: Flow = AuthenticatorAnalyticsTracker.defaultFlow, lastSource: Source = AuthenticatorAnalyticsTracker.defaultSource, lastStep: Step = AuthenticatorAnalyticsTracker.defaultStep) {
             self.lastFlow = lastFlow

--- a/Sources/WordPressAuthenticator/Helpers/UnifiedAuth/ViewRelated/ReusableViews/TextLabelTableViewCell.swift
+++ b/Sources/WordPressAuthenticator/Helpers/UnifiedAuth/ViewRelated/ReusableViews/TextLabelTableViewCell.swift
@@ -27,7 +27,7 @@ public final class TextLabelTableViewCell: UITableViewCell {
 
     /// Override methods
     ///
-    public override func prepareForReuse() {
+    override public func prepareForReuse() {
         super.prepareForReuse()
         label.text = nil
     }

--- a/Sources/WordPressAuthenticator/Helpers/WordPressComOAuthClientFacade.swift
+++ b/Sources/WordPressAuthenticator/Helpers/WordPressComOAuthClientFacade.swift
@@ -5,7 +5,7 @@ import WordPressKit
 
     private let client: WordPressComOAuthClient
 
-    @objc required public init(client: String, secret: String) {
+    @objc public required init(client: String, secret: String) {
         self.client = WordPressComOAuthClient(
             clientID: client,
             secret: secret,

--- a/Sources/WordPressAuthenticator/Views/LoginTextField.swift
+++ b/Sources/WordPressAuthenticator/Views/LoginTextField.swift
@@ -6,7 +6,7 @@ open class LoginTextField: WPWalkthroughTextField {
     /// Make a Swift-only property communicate a color to the
     /// Objective-C only class, WPWalkthroughTextField.
     ///
-    open override var secureTextEntryImageColor: UIColor! {
+    override open var secureTextEntryImageColor: UIColor! {
         set {
             // no-op. Usually set in Interface Builder.
         }
@@ -15,7 +15,7 @@ open class LoginTextField: WPWalkthroughTextField {
         }
     }
 
-    open override func awakeFromNib() {
+    override open func awakeFromNib() {
         super.awakeFromNib()
         backgroundColor = WordPressAuthenticator.shared.style.textFieldBackgroundColor
     }

--- a/Sources/WordPressData/Swift/AppEnvironment.swift
+++ b/Sources/WordPressData/Swift/AppEnvironment.swift
@@ -23,7 +23,7 @@ public struct AppEnvironment {
 
     /// The current environment. Use this to access the app globals.
     ///
-    public static private(set) var current = AppEnvironment()
+    public private(set) static var current = AppEnvironment()
 
     // MARK: - Initialization
 

--- a/Sources/WordPressData/Swift/Blog+Swift.swift
+++ b/Sources/WordPressData/Swift/Blog+Swift.swift
@@ -4,7 +4,7 @@ import ObjectiveC
 import NSURL_IDN
 import WordPressShared
 
-private nonisolated(unsafe) var blogKeychainKey: UInt8 = 0
+nonisolated(unsafe) private var blogKeychainKey: UInt8 = 0
 
 extension Blog {
 

--- a/Sources/WordPressData/Swift/Blog.swift
+++ b/Sources/WordPressData/Swift/Blog.swift
@@ -91,7 +91,7 @@ public class Blog: NSManagedObject {
 
     // MARK: - NSManagedObject Lifecycle
 
-    public override func willSave() {
+    override public func willSave() {
         super.willSave()
 
         // The `dotComID` getter has special code to _update_ `blogID` value.
@@ -102,7 +102,7 @@ public class Blog: NSManagedObject {
         _ = dotComID
     }
 
-    public override func prepareForDeletion() {
+    override public func prepareForDeletion() {
         super.prepareForDeletion()
 
         // Delete stored password in the keychain for self-hosted sites.
@@ -126,7 +126,7 @@ public class Blog: NSManagedObject {
         }
     }
 
-    public override func didTurnIntoFault() {
+    override public func didTurnIntoFault() {
         super.didTurnIntoFault()
 
         xmlrpcApi = nil

--- a/Sources/WordPressData/Swift/BloggingPrompt+CoreDataClass.swift
+++ b/Sources/WordPressData/Swift/BloggingPrompt+CoreDataClass.swift
@@ -12,7 +12,7 @@ public class BloggingPrompt: NSManagedObject {
         return NSEntityDescription.insertNewObject(forEntityName: Self.entityName(), into: context) as? BloggingPrompt
     }
 
-    public override func awakeFromInsert() {
+    override public func awakeFromInsert() {
         self.date = .init(timeIntervalSince1970: 0)
         self.displayAvatarURLs = []
     }

--- a/Sources/WordPressData/Swift/ContextManager.swift
+++ b/Sources/WordPressData/Swift/ContextManager.swift
@@ -30,7 +30,7 @@ public class ContextManager: NSObject, CoreDataStack, CoreDataStackSwift {
         persistentContainer.viewContext
     }
 
-    convenience override init() {
+    override convenience init() {
         self.init(modelName: ContextManagerModelNameCurrent, store: Self.localDatabasePath)
     }
 

--- a/Sources/WordPressData/Swift/Domain.swift
+++ b/Sources/WordPressData/Swift/Domain.swift
@@ -22,7 +22,7 @@ public class ManagedDomain: NSManagedObject {
 
     // MARK: - NSManagedObject
 
-    public override class func entityName() -> String {
+    override public class func entityName() -> String {
         return "Domain"
     }
 

--- a/Sources/WordPressData/Swift/JetpackState.swift
+++ b/Sources/WordPressData/Swift/JetpackState.swift
@@ -45,7 +45,7 @@ import Foundation
         return version.compare(JetpackState.minimumVersionRequired, options: .numeric) != .orderedAscending
     }
 
-    public override var description: String {
+    override public var description: String {
         if isConnected {
             let connectedAs = connectedUsername?.nonEmptyString()
                 ?? connectedEmail?.nonEmptyString()

--- a/Sources/WordPressData/Swift/ManagedAccountSettings.swift
+++ b/Sources/WordPressData/Swift/ManagedAccountSettings.swift
@@ -9,7 +9,7 @@ public class ManagedAccountSettings: NSManagedObject {
 
     // MARK: - NSManagedObject
 
-    public override class func entityName() -> String {
+    override public class func entityName() -> String {
         return "AccountSettings"
     }
 

--- a/Sources/WordPressData/Swift/Media.swift
+++ b/Sources/WordPressData/Swift/Media.swift
@@ -124,7 +124,7 @@ public class Media: NSManagedObject {
 
     // MARK: - Core Data Lifecycle
 
-    public override func prepareForDeletion() {
+    override public func prepareForDeletion() {
         let fileManager = FileManager.default
         if let path = absoluteLocalURL?.path, fileManager.fileExists(atPath: path) {
             do {

--- a/Sources/WordPressData/Swift/Notification.swift
+++ b/Sources/WordPressData/Swift/Notification.swift
@@ -89,7 +89,7 @@ public class Notification: NSManagedObject {
     ///
     fileprivate static let cachedAttributes = Set(arrayLiteral: "body", "header", "subject", "timestamp")
 
-    public override func awakeFromFetch() {
+    override public func awakeFromFetch() {
         super.awakeFromFetch()
 
         if cachedAttributesObserver == nil {

--- a/Sources/WordPressData/Swift/Post.swift
+++ b/Sources/WordPressData/Swift/Post.swift
@@ -34,7 +34,7 @@ public class Post: AbstractPost {
 
     // MARK: - NSManagedObject
 
-    public override class func entityName() -> String {
+    override public class func entityName() -> String {
         return "Post"
     }
 

--- a/Sources/WordPressData/Swift/PostCategory+CoreDataClass.swift
+++ b/Sources/WordPressData/Swift/PostCategory+CoreDataClass.swift
@@ -4,7 +4,7 @@ import CoreData
 @objc(PostCategory)
 public class PostCategory: NSManagedObject {
 
-    @objc public override class func entityName() -> String {
+    @objc override public class func entityName() -> String {
         return "Category"
     }
 

--- a/Sources/WordPressData/Swift/ReaderPost.swift
+++ b/Sources/WordPressData/Swift/ReaderPost.swift
@@ -13,7 +13,7 @@ public class ReaderPost: BasePost {
     /// Used for tracking when a post is rendered (displayed), and bumping the train tracks rendered event.
     public var rendered: Bool = false
 
-    public override func didSave() {
+    override public func didSave() {
         super.didSave()
 
         // A ReaderCard can have either a post, or a list of topics, but not both.
@@ -57,7 +57,7 @@ extension ReaderPost {
         return URL(string: blogURL ?? "")?.host
     }
 
-    public override func titleForDisplay() -> String {
+    override public func titleForDisplay() -> String {
         let title = postTitle?.trimmingCharacters(in: .whitespaces).stringByDecodingXMLCharacters()
         guard let title, !title.isEmpty else {
             return ""

--- a/Sources/WordPressData/Swift/ReaderTagTopic.swift
+++ b/Sources/WordPressData/Swift/ReaderTagTopic.swift
@@ -22,7 +22,7 @@ open class ReaderTagTopic: ReaderAbstractTopic {
     }
 
     /// Creates a new ReaderTagTopic object from a RemoteReaderInterest
-    convenience public init(remoteInterest: RemoteReaderInterest, context: NSManagedObjectContext, isFollowing: Bool = false) {
+    public convenience init(remoteInterest: RemoteReaderInterest, context: NSManagedObjectContext, isFollowing: Bool = false) {
         self.init(context: context)
 
         title = remoteInterest.title

--- a/Sources/WordPressData/Swift/SiteSuggestion+CoreDataClass.swift
+++ b/Sources/WordPressData/Swift/SiteSuggestion+CoreDataClass.swift
@@ -18,7 +18,7 @@ public class SiteSuggestion: NSManagedObject, Decodable {
         case blavatarURL = "blavatar"
     }
 
-    required convenience public init(from decoder: Decoder) throws {
+    public required convenience init(from decoder: Decoder) throws {
         guard let managedObjectContext = decoder.userInfo[CodingUserInfoKey.managedObjectContext] as? NSManagedObjectContext else {
             throw DecoderError.missingManagedObjectContext
         }

--- a/Sources/WordPressData/Swift/WPAccount.swift
+++ b/Sources/WordPressData/Swift/WPAccount.swift
@@ -85,13 +85,13 @@ public class WPAccount: NSManagedObject {
 
     // MARK: - Entity Name
 
-    @objc public override class func entityName() -> String {
+    @objc override public class func entityName() -> String {
         return "Account"
     }
 
     // MARK: - Lifecycle
 
-    public override func prepareForDeletion() {
+    override public func prepareForDeletion() {
         super.prepareForDeletion()
 
         // Only do these deletions in the primary context (no parent)
@@ -102,7 +102,7 @@ public class WPAccount: NSManagedObject {
         }
     }
 
-    public override func didTurnIntoFault() {
+    override public func didTurnIntoFault() {
         super.didTurnIntoFault()
         _private_wordPressComRestApi = nil
         cachedToken = nil

--- a/Tests/KeystoneTests/Helpers/ContextManager+Helpers.swift
+++ b/Tests/KeystoneTests/Helpers/ContextManager+Helpers.swift
@@ -54,7 +54,7 @@ private class AutomaticTeardownTestObserver: NSObject, XCTestObservation {
 
     static let instance = AutomaticTeardownTestObserver()
 
-    private override init() {
+    override private init() {
         super.init()
         XCTestObservationCenter.shared.addTestObserver(self)
     }

--- a/Tests/KeystoneTests/Tests/Features/Dashboard/DashboardPostsSyncManagerTests.swift
+++ b/Tests/KeystoneTests/Tests/Features/Dashboard/DashboardPostsSyncManagerTests.swift
@@ -188,7 +188,7 @@ class DashboardPostsSyncManagerTests: CoreDataTestCase {
 
 private class SyncManagerListenerMock: NSObject, DashboardPostsSyncManagerListener {
 
-    @objc dynamic private(set) var postsSyncedCalled = false
+    @objc private(set) dynamic var postsSyncedCalled = false
     private(set) var postsSyncSuccess: Bool?
     private(set) var postsSyncBlog: Blog?
     private(set) var postsSyncType: DashboardPostsSyncManager.PostType?

--- a/Tests/KeystoneTests/Tests/Features/Domains/AllDomainsListItemViewModelTests.swift
+++ b/Tests/KeystoneTests/Tests/Features/Domains/AllDomainsListItemViewModelTests.swift
@@ -91,7 +91,7 @@ fileprivate extension AllDomainsListItemViewModel.Row {
 
 extension AllDomainsListItemViewModel.Row: Equatable {
 
-    static public func ==(left: Self, right: Self) -> Bool {
+    public static func ==(left: Self, right: Self) -> Bool {
         return left.name == right.name
         && left.description == right.description
         && left.expiryDate == right.expiryDate

--- a/Tests/KeystoneTests/Tests/Services/BlogJetpackTests.swift
+++ b/Tests/KeystoneTests/Tests/Services/BlogJetpackTests.swift
@@ -11,15 +11,15 @@ class BlogJetpackTests: CoreDataTestCase {
 
     private let timeout: TimeInterval = 2.0
 
-    lazy private var blog: Blog = {
+    private lazy var blog: Blog = {
         makeBlog()
     }()
 
-    lazy private var accountService: AccountService = {
+    private lazy var accountService: AccountService = {
         .init(coreDataStack: contextManager)
     }()
 
-    lazy private var blogService: BlogService = {
+    private lazy var blogService: BlogService = {
         .init(coreDataStack: contextManager)
     }()
 

--- a/Tests/KeystoneTests/Tests/Services/PluginJetpackProxyServiceTests.swift
+++ b/Tests/KeystoneTests/Tests/Services/PluginJetpackProxyServiceTests.swift
@@ -10,7 +10,7 @@ class PluginJetpackProxyServiceTests: XCTestCase {
         .init(wordPressComRestApi: api)
     }
 
-    lazy private var service: PluginJetpackProxyService = {
+    private lazy var service: PluginJetpackProxyService = {
         .init(remote: remote)
     }()
 

--- a/Tests/KeystoneTests/Tests/Utility/RemoteFeatureFlagTests.swift
+++ b/Tests/KeystoneTests/Tests/Utility/RemoteFeatureFlagTests.swift
@@ -80,7 +80,7 @@ class MockFeatureFlagRemote: FeatureFlagRemote {
         super.init()
     }
 
-    public override func getRemoteFeatureFlags(forDeviceId deviceId: String, callback: @escaping FeatureFlagResponseCallback) {
+    override public func getRemoteFeatureFlags(forDeviceId deviceId: String, callback: @escaping FeatureFlagResponseCallback) {
         deviceIdCallback?(deviceId)
         callback(.success(flags))
     }

--- a/Tests/WordPressDataTests/Helpers/ContextManager+Testing.swift
+++ b/Tests/WordPressDataTests/Helpers/ContextManager+Testing.swift
@@ -53,7 +53,7 @@ private class AutomaticTeardownTestObserver: NSObject, XCTestObservation {
 
     static let instance = AutomaticTeardownTestObserver()
 
-    private override init() {
+    override private init() {
         super.init()
         XCTestObservationCenter.shared.addTestObserver(self)
     }

--- a/WordPress/Classes/Extensions/StoreKit+Debug.swift
+++ b/WordPress/Classes/Extensions/StoreKit+Debug.swift
@@ -1,7 +1,7 @@
 import StoreKit
 
 extension SKProduct {
-    open override var description: String {
+    override open var description: String {
         return "<SKProduct: \(productIdentifier), title: \(localizedTitle)>"
     }
 }
@@ -26,7 +26,7 @@ extension SKPaymentTransactionState: @retroactive CustomStringConvertible {
 }
 
 extension SKPaymentTransaction {
-    open override var description: String {
+    override open var description: String {
         let idString = transactionIdentifier.map({ " #\($0)" }) ?? ""
         let dateString = transactionDate.map({ " \($0)"}) ?? ""
         let errorString = error.map({ ". Error: \($0)" }) ?? ""

--- a/WordPress/Classes/Jetpack/JetpackMigration/SuccessCard/TableView/MigrationSuccessCell.swift
+++ b/WordPress/Classes/Jetpack/JetpackMigration/SuccessCard/TableView/MigrationSuccessCell.swift
@@ -6,7 +6,7 @@ public class MigrationSuccessCell: UITableViewCell {
     var onTap: (() -> Void)?
     var cardView: MigrationSuccessCardView?
 
-    public override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+    override public init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         setup()
     }

--- a/WordPress/Classes/Plugins/Views/PluginDetailsView.swift
+++ b/WordPress/Classes/Plugins/Views/PluginDetailsView.swift
@@ -449,7 +449,7 @@ final class WordPressPluginDetailViewModel: ObservableObject {
     @Published var newVersion: UpdateCheckPluginInfo?
     @Published private(set) var error: String?
 
-    @Published private(set) fileprivate var operation: PluginOperationStatus?
+    @Published fileprivate private(set) var operation: PluginOperationStatus?
 
     var previouslyLoadedSlug: PluginWpOrgDirectorySlug?
 

--- a/WordPress/Classes/Services/JetpackCapabilitiesService.swift
+++ b/WordPress/Classes/Services/JetpackCapabilitiesService.swift
@@ -17,7 +17,7 @@ import WordPressKit
         }
     }
 
-    public override convenience init() {
+    override public convenience init() {
         self.init(coreDataStack: ContextManager.shared, capabilitiesServiceRemote: nil)
     }
 

--- a/WordPress/Classes/Services/MediaSettings.swift
+++ b/WordPress/Classes/Services/MediaSettings.swift
@@ -114,7 +114,7 @@ class MediaSettings: NSObject {
         super.init()
     }
 
-    convenience override init() {
+    override convenience init() {
         self.init(database: UserPersistentStoreFactory.instance() as KeyValueDatabase)
     }
 

--- a/WordPress/Classes/Services/RecentSitesService.swift
+++ b/WordPress/Classes/Services/RecentSitesService.swift
@@ -36,7 +36,7 @@ class RecentSitesService: NSObject {
 
     /// Initialize the service using the standard UserDefaults as the database.
     ///
-    convenience override init() {
+    override convenience init() {
         self.init(database: UserDefaults.standard as KeyValueDatabase)
     }
 

--- a/WordPress/Classes/System/3D Touch/WP3DTouchShortcutCreator.swift
+++ b/WordPress/Classes/System/3D Touch/WP3DTouchShortcutCreator.swift
@@ -28,7 +28,7 @@ open class WP3DTouchShortcutCreator: NSObject {
         registerForNotifications()
     }
 
-    public convenience override init() {
+    override public convenience init() {
         self.init(shortcutsProvider: UIApplication.shared)
     }
 

--- a/WordPress/Classes/System/Root View/ReaderPresenter.swift
+++ b/WordPress/Classes/System/Root View/ReaderPresenter.swift
@@ -23,7 +23,7 @@ public final class ReaderPresenter: NSObject, SplitViewDisplayable {
 
     private var selectionObserver: AnyCancellable?
 
-    public convenience override init() {
+    override public convenience init() {
         self.init(viewModel: ReaderSidebarViewModel())
     }
 

--- a/WordPress/Classes/Utility/Analytics/AnalyticsTrackerAutomatticTracks.swift
+++ b/WordPress/Classes/Utility/Analytics/AnalyticsTrackerAutomatticTracks.swift
@@ -12,7 +12,7 @@ import BuildSettingsKit
     private var cachedAnonymousUserID: String?
     private var cachedCurrentUserID: String?
 
-    @objc convenience public override init() {
+    @objc override public convenience init() {
         let settings = BuildSettings.current
         self.init(
             eventNamePrefix: WPAnalyticsTesting.eventNamePrefix ?? settings.eventNamePrefix,

--- a/WordPress/Classes/Utility/AppIcon.swift
+++ b/WordPress/Classes/Utility/AppIcon.swift
@@ -32,7 +32,7 @@ struct AppIcon {
     }
 
     /// An `AppIcon` instance representing the current icon used by the app, whether custom or default.
-    static private var currentOrDefaultIcon: AppIcon {
+    private static var currentOrDefaultIcon: AppIcon {
         if let name = UIApplication.shared.alternateIconName {
             return allIcons.first(where: { $0.name == name }) ?? defaultIcon
         } else {

--- a/WordPress/Classes/Utility/BackgroundTasks/WeeklyRoundupBackgroundTask.swift
+++ b/WordPress/Classes/Utility/BackgroundTasks/WeeklyRoundupBackgroundTask.swift
@@ -200,7 +200,7 @@ private class WeeklyRoundupDataProvider {
         }
     }
 
-    static private func weeklyRoundupEnabledSites(
+    private static func weeklyRoundupEnabledSites(
         settings: [NotificationSettings],
         sites: [Site]
     ) -> [Site] {
@@ -250,7 +250,7 @@ private class WeeklyRoundupDataProvider {
     /// - Throws: `DataRequestError.authTokenNotFound` if the account associated with the site has no auth token.
     /// - Throws: `DataRequestError.dotComSiteWithoutDotComID(site)` if the dotComID of the site is not available.
     /// - Returns: An instance of `StatsServiceRemoteV2` for the site.
-    static private func makeRemoteStatsService(for site: Site) throws -> StatsServiceRemoteV2 {
+    private static func makeRemoteStatsService(for site: Site) throws -> StatsServiceRemoteV2 {
         guard let authToken = site.authToken else {
             throw DataRequestError.authTokenNotFound
         }
@@ -314,7 +314,7 @@ class WeeklyRoundupBackgroundTask: BackgroundTask {
     // MARK: - Misc Properties
 
     static let identifier = Constants.taskIdentifierProcessing
-    static private let secondsPerDay = 24 * 60 * 60
+    private static let secondsPerDay = 24 * 60 * 60
 
     private let store: Store
 

--- a/WordPress/Classes/Utility/ImmuTable/ImmuTable.swift
+++ b/WordPress/Classes/Utility/ImmuTable/ImmuTable.swift
@@ -526,7 +526,7 @@ class ImmuTableDiffableViewHandler: ImmuTableViewHandler {
         return diffableDataSource.itemIdentifier(for: indexPath)?.immuTableRow
     }
 
-    open override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+    override open func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         if target.responds(to: #selector(UITableViewDelegate.tableView(_:didSelectRowAt:))) {
             target.tableView?(tableView, didSelectRowAt: indexPath)
         } else if let item = item(for: indexPath) {
@@ -537,7 +537,7 @@ class ImmuTableDiffableViewHandler: ImmuTableViewHandler {
         }
     }
 
-    open override func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+    override open func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
         if let item = item(for: indexPath), let customHeight = type(of: item).customHeight {
             return CGFloat(customHeight)
         }

--- a/WordPress/Classes/Utility/KeychainTools.swift
+++ b/WordPress/Classes/Utility/KeychainTools.swift
@@ -40,7 +40,7 @@ final class KeychainTools: NSObject {
         }
     }
 
-    static fileprivate func serviceForItem(_ item: String) -> String? {
+    fileprivate static func serviceForItem(_ item: String) -> String? {
         switch item {
         case "wordpress.com":
             return BuildSettings.current.authKeychainServiceName
@@ -51,7 +51,7 @@ final class KeychainTools: NSObject {
         }
     }
 
-    static fileprivate func removeKeychainItem(forService service: String) {
+    fileprivate static func removeKeychainItem(forService service: String) {
         let query: [NSString: AnyObject] = [
             kSecClass: kSecClassGenericPassword,
             kSecAttrService: service as AnyObject
@@ -67,7 +67,7 @@ final class KeychainTools: NSObject {
         }
     }
 
-    static fileprivate func removeAllKeychainItems() {
+    fileprivate static func removeAllKeychainItems() {
         let query: [NSString: AnyObject] = [
             kSecClass: kSecClassGenericPassword
         ]

--- a/WordPress/Classes/Utility/Media/MediaVideoExporter.swift
+++ b/WordPress/Classes/Utility/Media/MediaVideoExporter.swift
@@ -73,11 +73,11 @@ class MediaVideoExporter: MediaExporter {
         self.filename = filename
     }
 
-    convenience public init(url: URL) {
+    public convenience init(url: URL) {
         self.init(url: url, session: nil, filename: url.lastPathComponent)
     }
 
-    convenience public init(session: AVAssetExportSession, filename: String? = nil) {
+    public convenience init(session: AVAssetExportSession, filename: String? = nil) {
         self.init(url: nil, session: session, filename: filename)
     }
 

--- a/WordPress/Classes/Utility/Spotlight/SearchManager.swift
+++ b/WordPress/Classes/Utility/Spotlight/SearchManager.swift
@@ -10,7 +10,7 @@ import WordPressData
     // MARK: - Singleton
 
     @objc static let shared = SearchManager()
-    private override init() {}
+    override private init() {}
 
     // MARK: - Indexing
 

--- a/WordPress/Classes/Utility/WebViewController/WebNavigationDelegate.swift
+++ b/WordPress/Classes/Utility/WebViewController/WebNavigationDelegate.swift
@@ -14,7 +14,7 @@ class WebNavigationPolicy: NSObject {
     @objc private(set) var redirectRequest: URLRequest?
     @objc private(set) var action: WKNavigationActionPolicy = .cancel
 
-    private override init() {}
+    override private init() {}
 
     @objc static let allow: WebNavigationPolicy = {
         let policy = WebNavigationPolicy()

--- a/WordPress/Classes/ViewRelated/Activity/List/ActivityLogsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/List/ActivityLogsViewController.swift
@@ -13,7 +13,7 @@ final class ActivityLogsViewController: UIHostingController<ActivityLogsView> {
         self.title = Strings.title
     }
 
-    required dynamic init?(coder aDecoder: NSCoder) {
+    dynamic required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
 }

--- a/WordPress/Classes/ViewRelated/Activity/List/BackupsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/List/BackupsViewController.swift
@@ -12,7 +12,7 @@ final class BackupsViewController: UIHostingController<ActivityLogsView> {
         self.title = Strings.title
     }
 
-    required dynamic init?(coder aDecoder: NSCoder) {
+    dynamic required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
 }

--- a/WordPress/Classes/ViewRelated/AppUpdate/BlockingUpdateView.swift
+++ b/WordPress/Classes/ViewRelated/AppUpdate/BlockingUpdateView.swift
@@ -9,7 +9,7 @@ final class BlockingUpdateViewController: UIHostingController<BlockingUpdateView
         super.init(rootView: .init(viewModel: viewModel, onButtonTapped: onButtonTapped))
     }
 
-    @MainActor required dynamic init?(coder aDecoder: NSCoder) {
+    @MainActor dynamic required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
 }

--- a/WordPress/Classes/ViewRelated/Aztec/Media/MediaProgressCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Media/MediaProgressCoordinator.swift
@@ -262,7 +262,7 @@ public class MediaProgressCoordinator: NSObject {
 
     // MARK: - KeyPath observer method for the global progress property
 
-    public override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey: Any]?, context: UnsafeMutableRawPointer?) {
+    override public func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey: Any]?, context: UnsafeMutableRawPointer?) {
         guard
             context == &Self.mediaProgressObserverContext,
             keyPath == #keyPath(Progress.fractionCompleted)

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsSectionFooterView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsSectionFooterView.swift
@@ -12,7 +12,7 @@ public class BlogDetailsSectionFooterView: UITableViewHeaderFooterView {
     }()
     private let spacerView = UIView(frame: .zero)
 
-    public override init(reuseIdentifier: String?) {
+    override public init(reuseIdentifier: String?) {
         super.init(reuseIdentifier: reuseIdentifier)
         setupSubviews()
     }

--- a/WordPress/Classes/ViewRelated/Blog/Sharing/PublicizeServiceCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Sharing/PublicizeServiceCell.swift
@@ -10,7 +10,7 @@ public final class PublicizeServiceCell: UITableViewCell {
 
     @objc public class var cellId: String { "PublicizeServiceCell" }
 
-    public override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+    override public init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
 
         detailsLabel.font = .preferredFont(forTextStyle: .footnote)
@@ -38,7 +38,7 @@ public final class PublicizeServiceCell: UITableViewCell {
         fatalError("init(coder:) has not been implemented")
     }
 
-    public override func prepareForReuse() {
+    override public func prepareForReuse() {
         super.prepareForReuse()
 
         accessoryView = .none

--- a/WordPress/Classes/ViewRelated/Blog/Sharing/SharingAccountViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Sharing/SharingAccountViewController.swift
@@ -36,12 +36,12 @@ import WordPressUI
         navigationItem.title = publicizeService.label
     }
 
-    required public init?(coder aDecoder: NSCoder) {
+    public required init?(coder aDecoder: NSCoder) {
         // TODO:
         fatalError("init(coder:) has not been implemented")
     }
 
-    open override func viewDidLoad() {
+    override open func viewDidLoad() {
         super.viewDidLoad()
 
         configureNavbar()

--- a/WordPress/Classes/ViewRelated/Blog/Sharing/TwitterDeprecationTableFooterView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Sharing/TwitterDeprecationTableFooterView.swift
@@ -43,7 +43,7 @@ import WordPressUI
 
     // MARK: Methods
 
-    public override init(reuseIdentifier: String?) {
+    override public init(reuseIdentifier: String?) {
         super.init(reuseIdentifier: reuseIdentifier)
         setupSubviews()
     }

--- a/WordPress/Classes/ViewRelated/Blog/Site Management/DeleteSiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Management/DeleteSiteViewController.swift
@@ -58,7 +58,7 @@ open class DeleteSiteViewController: UITableViewController {
         setupDeleteButton()
     }
 
-    open override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
+    override open func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
         super.viewWillTransition(to: size, with: coordinator)
 
         coordinator.animate(alongsideTransition: { _ in

--- a/WordPress/Classes/ViewRelated/Blog/Site Management/TableViewHeaderDetailView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Management/TableViewHeaderDetailView.swift
@@ -69,7 +69,7 @@ open class TableViewHeaderDetailView: UITableViewHeaderFooterView {
     ///     - title: String displayed in standard section header style
     ///     - detail: String displayed in standard section footer style
     ///
-    @objc convenience public init(title: String?, detail: String?) {
+    @objc public convenience init(title: String?, detail: String?) {
         self.init(reuseIdentifier: nil)
         defer {
             self.title = title ?? ""
@@ -82,7 +82,7 @@ open class TableViewHeaderDetailView: UITableViewHeaderFooterView {
         stackSubviews()
     }
 
-    required public init?(coder aDecoder: NSCoder) {
+    public required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
         stackSubviews()
     }

--- a/WordPress/Classes/ViewRelated/Blog/Site Monitoring/SiteMonitoringView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Monitoring/SiteMonitoringView.swift
@@ -67,7 +67,7 @@ final class SiteMonitoringViewController: UIHostingController<SiteMonitoringView
         super.init(rootView: .init(viewModel: SiteMonitoringViewModel(blog: blog, selectedTab: selectedTab)))
     }
 
-    @MainActor required dynamic init?(coder aDecoder: NSCoder) {
+    @MainActor dynamic required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/Site Settings/DateAndTimeFormatSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Settings/DateAndTimeFormatSettingsViewController.swift
@@ -42,7 +42,7 @@ open class DateAndTimeFormatSettingsViewController: UITableViewController {
 
     // MARK: - View Lifecycle
 
-    open override func viewDidLoad() {
+    override open func viewDidLoad() {
         super.viewDidLoad()
         title = NSLocalizedString("Date and Time Format", comment: "Title for the Date and Time Format Settings Screen")
         ImmuTable.registerRows([NavigationItemRow.self], tableView: tableView)
@@ -51,7 +51,7 @@ open class DateAndTimeFormatSettingsViewController: UITableViewController {
         reloadViewModel()
     }
 
-    open override func viewWillAppear(_ animated: Bool) {
+    override open func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         reloadViewModel()
     }
@@ -89,11 +89,11 @@ open class DateAndTimeFormatSettingsViewController: UITableViewController {
 
     // MARK: Learn More footer
 
-    open override func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
+    override open func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
         return DateAndTimeFormatSettingsViewController.footerHeight
     }
 
-    open override func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
+    override open func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
         let footer = UITableViewHeaderFooterView(frame: CGRect(x: 0.0,
                                                                y: 0.0,
                                                                width: tableView.frame.width,

--- a/WordPress/Classes/ViewRelated/Blog/Site Settings/DiscussionSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Settings/DiscussionSettingsViewController.swift
@@ -19,14 +19,14 @@ open class DiscussionSettingsViewController: UITableViewController {
     }
 
     // MARK: - View Lifecycle
-    open override func viewDidLoad() {
+    override open func viewDidLoad() {
         super.viewDidLoad()
 
         setupNavBar()
         setupTableView()
     }
 
-    open override func viewWillAppear(_ animated: Bool) {
+    override open func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
 
         tableView.reloadSelectedRow()
@@ -97,15 +97,15 @@ open class DiscussionSettingsViewController: UITableViewController {
     }
 
     // MARK: - UITableViewDataSoutce Methods
-    open override func numberOfSections(in tableView: UITableView) -> Int {
+    override open func numberOfSections(in tableView: UITableView) -> Int {
         return sections.count
     }
 
-    open override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+    override open func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return sections[section].rows.count
     }
 
-    open override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+    override open func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let row = rowAtIndexPath(indexPath)
         let cell = cellForRow(row, tableView: tableView)
 
@@ -119,20 +119,20 @@ open class DiscussionSettingsViewController: UITableViewController {
         return cell
     }
 
-    open override func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
+    override open func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
         return sections[section].headerText
     }
 
-    open override func tableView(_ tableView: UITableView, titleForFooterInSection section: Int) -> String? {
+    override open func tableView(_ tableView: UITableView, titleForFooterInSection section: Int) -> String? {
         return sections[section].footerText
     }
 
-    open override func tableView(_ tableView: UITableView, willDisplayFooterView view: UIView, forSection section: Int) {
+    override open func tableView(_ tableView: UITableView, willDisplayFooterView view: UIView, forSection section: Int) {
         WPStyleGuide.configureTableViewSectionFooter(view)
     }
 
     // MARK: - UITableViewDelegate Methods
-    open override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+    override open func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         rowAtIndexPath(indexPath).handler?(tableView)
     }
 

--- a/WordPress/Classes/ViewRelated/Blog/Site Settings/HomepageSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Settings/HomepageSettingsViewController.swift
@@ -56,7 +56,7 @@ import WordPressShared
         fatalError("init(coder:) has not been implemented")
     }
 
-    open override func viewDidLoad() {
+    override open func viewDidLoad() {
         super.viewDidLoad()
 
         title = Strings.title
@@ -73,12 +73,12 @@ import WordPressShared
         fetchAllPagesTask = postRepository.fetchAllPages(statuses: [], in: TaggedManagedObjectID(blog))
     }
 
-    open override func viewWillAppear(_ animated: Bool) {
+    override open func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         animateDeselectionInteractively()
     }
 
-    open override func viewDidDisappear(_ animated: Bool) {
+    override open func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
 
         if self.navigationController == nil {

--- a/WordPress/Classes/ViewRelated/Blog/Site Settings/LanguageViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Settings/LanguageViewController.swift
@@ -20,7 +20,7 @@ open class LanguageViewController: UITableViewController, LanguageSelectorDelega
         self.blog = blog
     }
 
-    open override func viewDidLoad() {
+    override open func viewDidLoad() {
         super.viewDidLoad()
 
         // Setup tableViewController
@@ -33,7 +33,7 @@ open class LanguageViewController: UITableViewController, LanguageSelectorDelega
         tableView.cellLayoutMarginsFollowReadableWidth = true
     }
 
-    open override func viewWillAppear(_ animated: Bool) {
+    override open func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
 
         tableView.reloadDataPreservingSelection()
@@ -41,15 +41,15 @@ open class LanguageViewController: UITableViewController, LanguageSelectorDelega
     }
 
     // MARK: - UITableViewDataSource Methods
-    open override func numberOfSections(in tableView: UITableView) -> Int {
+    override open func numberOfSections(in tableView: UITableView) -> Int {
         return 1
     }
 
-    open override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+    override open func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return 1
     }
 
-    open override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+    override open func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         var cell = tableView.dequeueReusableCell(withIdentifier: reuseIdentifier)
         if cell == nil {
             cell = WPTableViewCell(style: .value1, reuseIdentifier: reuseIdentifier)
@@ -62,16 +62,16 @@ open class LanguageViewController: UITableViewController, LanguageSelectorDelega
         return cell!
     }
 
-    open override func tableView(_ tableView: UITableView, titleForFooterInSection section: Int) -> String? {
+    override open func tableView(_ tableView: UITableView, titleForFooterInSection section: Int) -> String? {
         return footerText
     }
 
-    open override func tableView(_ tableView: UITableView, willDisplayFooterView view: UIView, forSection section: Int) {
+    override open func tableView(_ tableView: UITableView, willDisplayFooterView view: UIView, forSection section: Int) {
         WPStyleGuide.configureTableViewSectionFooter(view)
     }
 
     // MARK: - UITableViewDelegate Methods
-    open override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+    override open func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         pressedLanguageRow()
     }
 

--- a/WordPress/Classes/ViewRelated/Blog/Subscribers/List/SubscribersView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Subscribers/List/SubscribersView.swift
@@ -12,7 +12,7 @@ final class SubscribersViewController: UIHostingController<AnyView> {
         self.title = Strings.title
     }
 
-    required dynamic init?(coder aDecoder: NSCoder) {
+    dynamic required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
 }

--- a/WordPress/Classes/ViewRelated/Cells/CheckmarkTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Cells/CheckmarkTableViewCell.swift
@@ -25,7 +25,7 @@ import WordPressUI
         setupSubviews()
     }
 
-    public required override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+    override public required init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         setupSubviews()
     }

--- a/WordPress/Classes/ViewRelated/Cells/ExpandableCell.swift
+++ b/WordPress/Classes/ViewRelated/Cells/ExpandableCell.swift
@@ -13,7 +13,7 @@ class ExpandableCell: WPReusableTableViewCell, NibLoadable {
         setupSubviews()
     }
 
-    public required override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+    override public required init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         setupSubviews()
     }

--- a/WordPress/Classes/ViewRelated/Cells/MediaQuotaCell.swift
+++ b/WordPress/Classes/ViewRelated/Cells/MediaQuotaCell.swift
@@ -59,7 +59,7 @@ import WordPressUI
     }
 
     // MARK: - UIKit bindings
-    public override func awakeFromNib() {
+    override public func awakeFromNib() {
         super.awakeFromNib()
         customizeAppearance()
     }

--- a/WordPress/Classes/ViewRelated/Cells/PickerTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Cells/PickerTableViewCell.swift
@@ -51,7 +51,7 @@ open class PickerTableViewCell: WPTableViewCell, UIPickerViewDelegate, UIPickerV
         setupSubviews()
     }
 
-    public required override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+    override public required init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         setupSubviews()
     }

--- a/WordPress/Classes/ViewRelated/Cells/SwitchTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Cells/SwitchTableViewCell.swift
@@ -32,7 +32,7 @@ open class SwitchTableViewCell: WPTableViewCell {
         setupSubviews()
     }
 
-    public required override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+    override public required init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         setupSubviews()
     }

--- a/WordPress/Classes/ViewRelated/Cells/TextWithAccessoryButtonCell.swift
+++ b/WordPress/Classes/ViewRelated/Cells/TextWithAccessoryButtonCell.swift
@@ -38,7 +38,7 @@ class TextWithAccessoryButtonCell: WPReusableTableViewCell, NibLoadable {
         }
     }
 
-    public override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+    override public init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         initialSetup()
     }

--- a/WordPress/Classes/ViewRelated/Comments/Controllers/CommentDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Comments/Controllers/CommentDetailViewController.swift
@@ -244,7 +244,7 @@ public class CommentDetailViewController: UIViewController, NoResultsViewHost {
 
     // MARK: View lifecycle
 
-    public override func viewDidLoad() {
+    override public func viewDidLoad() {
         super.viewDidLoad()
 
         configureNavigationBar()
@@ -253,7 +253,7 @@ public class CommentDetailViewController: UIViewController, NoResultsViewHost {
         refreshCommentReplyIfNeeded()
     }
 
-    public override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
+    override public func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
         super.viewWillTransition(to: size, with: coordinator)
 
         // when an orientation change is triggered, recalculate the content cell's height.

--- a/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainDetails/ViewController/RegisterDomainDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainDetails/ViewController/RegisterDomainDetailsViewController.swift
@@ -365,7 +365,7 @@ extension RegisterDomainDetailsViewController {
 
     // MARK: Section Header Footer
 
-    open override func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
+    override open func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
         guard let sectionType = SectionIndex(rawValue: section) else {
             return nil
         }
@@ -377,7 +377,7 @@ extension RegisterDomainDetailsViewController {
         }
     }
 
-    open override func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+    override open func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
         guard let sectionType = SectionIndex(rawValue: section) else {
             return nil
         }
@@ -392,7 +392,7 @@ extension RegisterDomainDetailsViewController {
         return nil
     }
 
-    open override func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
+    override open func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
         guard let sectionType = SectionIndex(rawValue: section) else {
             return nil
         }

--- a/WordPress/Classes/ViewRelated/Domains/Domain registration/SiteCreationPurchasingWebFlowController.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Domain registration/SiteCreationPurchasingWebFlowController.swift
@@ -21,7 +21,7 @@ final class SiteCreationPurchasingWebFlowController {
     // MARK: - Dependencies
 
     /// The view controller that presents the domain checkout web page.
-    weak private var presentingViewController: UIViewController?
+    private weak var presentingViewController: UIViewController?
 
     /// The service that interacts with the Backend API.
     private let shoppingCartService: ShoppingCartServiceProtocol

--- a/WordPress/Classes/ViewRelated/Domains/Views/SiteDomainsView.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Views/SiteDomainsView.swift
@@ -262,7 +262,7 @@ final class SiteDomainsViewController: UIHostingController<SiteDomainsView> {
         context.viewController = self
     }
 
-    @MainActor required dynamic init?(coder aDecoder: NSCoder) {
+    @MainActor dynamic required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
 

--- a/WordPress/Classes/ViewRelated/EEUUSCompliance/CompliancePopoverViewController.swift
+++ b/WordPress/Classes/ViewRelated/EEUUSCompliance/CompliancePopoverViewController.swift
@@ -10,7 +10,7 @@ final class CompliancePopoverViewController: UIHostingController<CompliancePopov
         super.init(rootView: CompliancePopover(viewModel: viewModel))
     }
 
-    required dynamic init?(coder aDecoder: NSCoder) {
+    dynamic required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
 

--- a/WordPress/Classes/ViewRelated/Feature Introduction/Blogging Prompts/BloggingPromptsFeatureDescriptionView.swift
+++ b/WordPress/Classes/ViewRelated/Feature Introduction/Blogging Prompts/BloggingPromptsFeatureDescriptionView.swift
@@ -12,7 +12,7 @@ class BloggingPromptsFeatureDescriptionView: UIView, NibLoadable {
 
     // MARK: - Init
 
-    open override func awakeFromNib() {
+    override open func awakeFromNib() {
         super.awakeFromNib()
         configureView()
     }

--- a/WordPress/Classes/ViewRelated/Gutenberg/Layout Picker/GutenbergLayoutPickerViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Layout Picker/GutenbergLayoutPickerViewController.swift
@@ -33,7 +33,7 @@ class GutenbergLayoutSection: CategorySection {
 
 class GutenbergLayoutPickerViewController: FilterableCategoriesViewController {
     private var sections: [GutenbergLayoutSection] = []
-    internal override var categorySections: [CategorySection] { get { sections }}
+    override internal var categorySections: [CategorySection] { get { sections }}
     lazy var resultsController: NSFetchedResultsController<PageTemplateCategory> = {
         let resultsController = PageLayoutService.resultsController(forBlog: blog, delegate: self)
         sections = makeSectionData(with: resultsController)

--- a/WordPress/Classes/ViewRelated/Gutenberg/Views/GutenGhostView.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Views/GutenGhostView.swift
@@ -36,7 +36,7 @@ class GutenGhostView: UIView {
         }
     }
 
-    @IBOutlet weak private var inserterView: UIView! {
+    @IBOutlet private weak var inserterView: UIView! {
         didSet {
             inserterView.layer.cornerRadius = inserterView.frame.height / 2
             inserterView.clipsToBounds = true

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Menu Card/JetpackBrandingMenuCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Menu Card/JetpackBrandingMenuCardCell.swift
@@ -135,7 +135,7 @@ public class JetpackBrandingMenuCardCell: UITableViewCell {
 
     // MARK: Initializers
 
-    public override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+    override public init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         commonInit()
     }
@@ -151,7 +151,7 @@ public class JetpackBrandingMenuCardCell: UITableViewCell {
 
     // MARK: Cell Lifecycle
 
-    public override func prepareForReuse() {
+    override public func prepareForReuse() {
         super.prepareForReuse()
 
         containerStackView.removeAllSubviews()

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Moved To Jetpack/MovedToJetpackViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Moved To Jetpack/MovedToJetpackViewController.swift
@@ -160,26 +160,26 @@ public final class MovedToJetpackViewController: UIViewController {
 
     // MARK: - Lifecycle
 
-    public override func viewDidLoad() {
+    override public func viewDidLoad() {
         super.viewDidLoad()
         navigationController?.delegate = self
         setupView()
         animationView.play()
     }
 
-    public override func viewDidAppear(_ animated: Bool) {
+    override public func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         tracker.trackScreenDisplayed()
     }
 
-    public override func viewDidDisappear(_ animated: Bool) {
+    override public func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
         animationView.currentProgress = 1.0
     }
 
     // MARK: - Navigation overrides
 
-    public override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
+    override public var supportedInterfaceOrientations: UIInterfaceOrientationMask {
         return .portrait
     }
 

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Settings/JetpackConnectionViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Settings/JetpackConnectionViewController.swift
@@ -43,7 +43,7 @@ open class JetpackConnectionViewController: UITableViewController {
 
     // MARK: - View Lifecycle
 
-    open override func viewDidLoad() {
+    override open func viewDidLoad() {
         super.viewDidLoad()
         title = NSLocalizedString("Manage Connection", comment: "Title for the Jetpack Manage Connection Screen")
         ImmuTable.registerRows([DestructiveButtonRow.self], tableView: tableView)
@@ -51,11 +51,11 @@ open class JetpackConnectionViewController: UITableViewController {
         reloadViewModel()
     }
 
-    open override func viewWillAppear(_ animated: Bool) {
+    override open func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
     }
 
-    open override func viewWillDisappear(_ animated: Bool) {
+    override open func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
     }
 

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Settings/JetpackSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Settings/JetpackSettingsViewController.swift
@@ -36,7 +36,7 @@ open class JetpackSettingsViewController: UITableViewController {
 
     // MARK: - View Lifecycle
 
-    open override func viewDidLoad() {
+    override open func viewDidLoad() {
         super.viewDidLoad()
         WPAnalytics.trackEvent(.jetpackSettingsViewed)
         title = NSLocalizedString("Settings", comment: "Title for the Jetpack Security Settings Screen")
@@ -46,14 +46,14 @@ open class JetpackSettingsViewController: UITableViewController {
         reloadViewModel()
     }
 
-    open override func viewWillAppear(_ animated: Bool) {
+    override open func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         tableView.reloadSelectedRow()
         tableView.deselectSelectedRowWithAnimation(true)
         refreshSettings()
     }
 
-    open override func viewWillDisappear(_ animated: Bool) {
+    override open func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
     }
 
@@ -157,14 +157,14 @@ open class JetpackSettingsViewController: UITableViewController {
 
     // MARK: Learn More footer
 
-    open override func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
+    override open func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
         if section == JetpackSettingsViewController.wordPressLoginSection {
             return JetpackSettingsViewController.footerHeight
         }
         return 0.0
     }
 
-    open override func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
+    override open func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
         if section == JetpackSettingsViewController.wordPressLoginSection {
             let footer = UITableViewHeaderFooterView(frame: CGRect(x: 0.0,
                                                                    y: 0.0,

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Settings/JetpackSpeedUpSiteSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Settings/JetpackSpeedUpSiteSettingsViewController.swift
@@ -32,7 +32,7 @@ open class JetpackSpeedUpSiteSettingsViewController: UITableViewController {
 
     // MARK: - View Lifecycle
 
-    open override func viewDidLoad() {
+    override open func viewDidLoad() {
         super.viewDidLoad()
 
         title = NSLocalizedString("Speed up your site", comment: "Title for the Speed up your site Settings Screen")
@@ -41,7 +41,7 @@ open class JetpackSpeedUpSiteSettingsViewController: UITableViewController {
         reloadViewModel()
     }
 
-    open override func viewWillAppear(_ animated: Bool) {
+    override open func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
 
         reloadViewModel()

--- a/WordPress/Classes/ViewRelated/Jetpack/Login/JetpackLoginViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Login/JetpackLoginViewController.swift
@@ -85,13 +85,13 @@ public class JetpackLoginViewController: UIViewController {
 
     // MARK: - LifeCycle Methods
 
-    public override func viewDidLoad() {
+    override public func viewDidLoad() {
         super.viewDidLoad()
         WPStyleGuide.configureColors(view: view, tableView: nil)
         setupControls()
     }
 
-    public override func willTransition(to newCollection: UITraitCollection, with coordinator: UIViewControllerTransitionCoordinator) {
+    override public func willTransition(to newCollection: UITraitCollection, with coordinator: UIViewControllerTransitionCoordinator) {
         super.willTransition(to: newCollection, with: coordinator)
         toggleHidingImageView(for: newCollection)
     }

--- a/WordPress/Classes/ViewRelated/Me/App Settings/App Icons/AppIconViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/App Icons/AppIconViewController.swift
@@ -17,13 +17,13 @@ open class AppIconViewController: UITableViewController {
         super.init(style: .insetGrouped)
     }
 
-    required public init?(coder: NSCoder) {
+    public required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
 
     // MARK: - View Lifecycle
 
-    open override func viewDidLoad() {
+    override open func viewDidLoad() {
         super.viewDidLoad()
 
         title = NSLocalizedString("App Icon", comment: "Title of screen to change the app's icon")
@@ -44,19 +44,19 @@ open class AppIconViewController: UITableViewController {
 
     // MARK: - UITableview Data Source
 
-    open override func numberOfSections(in tableView: UITableView) -> Int {
+    override open func numberOfSections(in tableView: UITableView) -> Int {
         return icons.count
     }
 
-    open override func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
+    override open func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
         return icons[section].title
     }
 
-    open override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+    override open func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return icons[section].items.count
     }
 
-    open override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+    override open func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let icon = icons[indexPath.section][indexPath.row]
 
         let cell = tableView.dequeueReusableCell(withIdentifier: Constants.cellIdentifier, for: indexPath)
@@ -90,7 +90,7 @@ open class AppIconViewController: UITableViewController {
         return currentIconName == icon.name
     }
 
-    open override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+    override open func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         guard !iconIsSelected(for: indexPath) else {
             tableView.deselectRow(at: indexPath, animated: true)
             return

--- a/WordPress/Classes/ViewRelated/Me/App Settings/DebugMenuViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/DebugMenuViewController.swift
@@ -246,7 +246,7 @@ final class DebugMenuViewController: UIHostingController<DebugMenuView> {
         navigation.parentViewController = self
     }
 
-    @MainActor required dynamic init?(coder aDecoder: NSCoder) {
+    @MainActor dynamic required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
 

--- a/WordPress/Classes/ViewRelated/Me/Me Main/MeViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/Me Main/MeViewController.swift
@@ -15,7 +15,7 @@ public class MeViewController: UITableViewController {
 
     // MARK: - Table View Controller
 
-    public override init(style: UITableView.Style) {
+    override public init(style: UITableView.Style) {
         super.init(style: style)
         navigationItem.title = NSLocalizedString("Me", comment: "Me page title")
         clearsSelectionOnViewWillAppear = false
@@ -32,7 +32,7 @@ public class MeViewController: UITableViewController {
         fatalError("init(coder:) has not been implemented")
     }
 
-    public override func viewDidLoad() {
+    override public func viewDidLoad() {
         super.viewDidLoad()
 
         if isSidebarModeEnabled {
@@ -62,26 +62,26 @@ public class MeViewController: UITableViewController {
         reloadViewModel()
     }
 
-    public override func viewDidLayoutSubviews() {
+    override public func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
 
         tableView.layoutHeaderView()
     }
 
-    public override func viewWillAppear(_ animated: Bool) {
+    override public func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
 
         refreshAccountDetailsAndSettings()
         animateDeselectionInteractively()
     }
 
-    public override func viewDidAppear(_ animated: Bool) {
+    override public func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
 
         registerUserActivity()
     }
 
-    public override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+    override public func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
 
         // Required to update the tableview cell disclosure indicators
@@ -240,7 +240,7 @@ public class MeViewController: UITableViewController {
 
     // MARK: - UITableViewDelegate
 
-    public override func tableView(_ tableView: UITableView, willSelectRowAt indexPath: IndexPath) -> IndexPath? {
+    override public func tableView(_ tableView: UITableView, willSelectRowAt indexPath: IndexPath) -> IndexPath? {
         let isNewSelection = (indexPath != tableView.indexPathForSelectedRow)
 
         if isNewSelection {
@@ -626,7 +626,7 @@ extension MeViewController: ShareAppContentPresenterDelegate {
 // MARK: - Jetpack powered badge
 extension MeViewController {
 
-    public override func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
+    override public func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
         guard section == handler.viewModel.sections.count - 1,
               JetpackBrandingVisibility.all.enabled else {
             return nil

--- a/WordPress/Classes/ViewRelated/NUX/Controllers/UnifiedPrologue/UnifiedProloguePages.swift
+++ b/WordPress/Classes/ViewRelated/NUX/Controllers/UnifiedPrologue/UnifiedProloguePages.swift
@@ -31,7 +31,7 @@ class UnifiedProloguePageViewController: UIViewController {
 
     private let titleLabel = UILabel()
 
-    lazy private var contentView: UIView = {
+    private lazy var contentView: UIView = {
         makeContentView()
     }()
 

--- a/WordPress/Classes/ViewRelated/NewSupport/RootSupportView.swift
+++ b/WordPress/Classes/ViewRelated/NewSupport/RootSupportView.swift
@@ -205,7 +205,7 @@ class RootSupportViewController: UIHostingController<AnyView> {
         super.init(rootView: AnyView(erasing: type))
     }
 
-    @MainActor @preconcurrency required dynamic init?(coder aDecoder: NSCoder) {
+    @MainActor @preconcurrency dynamic required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
 }

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingsViewController.swift
@@ -62,7 +62,7 @@ class NotificationSettingsViewController: UIViewController {
 
     // MARK: - View Lifecycle
 
-    open override func viewDidLoad() {
+    override open func viewDidLoad() {
         super.viewDidLoad()
 
         // Initialize Interface
@@ -73,7 +73,7 @@ class NotificationSettingsViewController: UIViewController {
         reloadSettings()
     }
 
-    open override func viewWillAppear(_ animated: Bool) {
+    override open func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
 
         WPAnalytics.track(.openedNotificationSettingsList)
@@ -82,7 +82,7 @@ class NotificationSettingsViewController: UIViewController {
         tableView.deselectSelectedRowWithAnimation(true)
     }
 
-    open override func viewDidAppear(_ animated: Bool) {
+    override open func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
 
         registerUserActivity()

--- a/WordPress/Classes/ViewRelated/Notifications/Tools/IntrinsicTableView.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Tools/IntrinsicTableView.swift
@@ -8,13 +8,13 @@ import UIKit
 ///     -   http://stackoverflow.com/questions/17334478/uitableview-within-uiscrollview-using-autolayout
 ///
 @objc public class IntrinsicTableView: UITableView {
-    public override var contentSize: CGSize {
+    override public var contentSize: CGSize {
         didSet {
             self.invalidateIntrinsicContentSize()
         }
     }
 
-    public override var intrinsicContentSize: CGSize {
+    override public var intrinsicContentSize: CGSize {
         layoutIfNeeded()
         return CGSize(width: UIView.noIntrinsicMetric, height: contentSize.height)
     }

--- a/WordPress/Classes/ViewRelated/Post/Categories/PostCategoriesViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Categories/PostCategoriesViewController.swift
@@ -41,13 +41,13 @@ import WordPressUI
         fatalError("init(coder:) has not been implemented")
     }
 
-    public override func viewDidLoad() {
+    override public func viewDidLoad() {
         super.viewDidLoad()
         configureTableView()
         configureView()
     }
 
-    public override func viewWillAppear(_ animated: Bool) {
+    override public func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         reloadCategories()
         if !hasSyncedCategories {
@@ -55,7 +55,7 @@ import WordPressUI
         }
     }
 
-    public override func viewWillDisappear(_ animated: Bool) {
+    override public func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         onCategoriesChanged?()
     }
@@ -192,11 +192,11 @@ import WordPressUI
 
     //tableView
 
-    public override func numberOfSections(in tableView: UITableView) -> Int {
+    override public func numberOfSections(in tableView: UITableView) -> Int {
         return 1
     }
 
-    public override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+    override public func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         var result = categories.count
         if selectionMode == .parent {
             result = result + 1
@@ -204,7 +204,7 @@ import WordPressUI
         return result
     }
 
-    public override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+    override public func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         guard let cell = tableView.dequeueReusableCell(withIdentifier: Constants.categoryCellIdentifier, for: indexPath) as? WPTableViewCell else {
             return UITableViewCell()
         }
@@ -227,7 +227,7 @@ import WordPressUI
         return cell
     }
 
-    public override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+    override public func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         if let currentSelectedIndexPath = tableView.indexPathForSelectedRow {
             tableView.deselectRow(at: currentSelectedIndexPath, animated: true)
         }

--- a/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsView.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsView.swift
@@ -31,7 +31,7 @@ final class PostSettingsViewController<ViewModel: PostSettingsViewModelProtocol>
         viewModel.viewController = self
     }
 
-    @preconcurrency required dynamic init?(coder aDecoder: NSCoder) {
+    @preconcurrency dynamic required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
 }

--- a/WordPress/Classes/ViewRelated/Post/Publishing/PublishPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Publishing/PublishPostViewController.swift
@@ -90,7 +90,7 @@ final class PublishPostViewController<ViewModel: PostSettingsViewModelProtocol>:
         presentingViewController.present(navigationVC, animated: true)
     }
 
-    required dynamic init?(coder aDecoder: NSCoder) {
+    dynamic required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
 

--- a/WordPress/Classes/ViewRelated/Post/Views/PostMediaUploadsView.swift
+++ b/WordPress/Classes/ViewRelated/Post/Views/PostMediaUploadsView.swift
@@ -11,7 +11,7 @@ final class PostMediaUploadsViewController: UIHostingController<PostMediaUploads
         super.init(rootView: PostMediaUploadsView(viewModel: viewModel))
     }
 
-    required dynamic init?(coder aDecoder: NSCoder) {
+    dynamic required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
 }

--- a/WordPress/Classes/ViewRelated/Post/Views/ResolveConflictView.swift
+++ b/WordPress/Classes/ViewRelated/Post/Views/ResolveConflictView.swift
@@ -181,7 +181,7 @@ final class ResolveConflictViewController: UIHostingController<ResolveConflictVi
         rootView.dismiss = { self.dismiss(animated: true) }
     }
 
-    @MainActor required dynamic init?(coder aDecoder: NSCoder) {
+    @MainActor dynamic required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/Cards/ReaderBlockedSiteCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Cards/ReaderBlockedSiteCell.swift
@@ -5,7 +5,7 @@ open class ReaderBlockedSiteCell: UITableViewCell, NibLoadable {
     @IBOutlet fileprivate weak var borderedContentView: UIView!
     @IBOutlet fileprivate weak var label: UILabel!
 
-    open override func awakeFromNib() {
+    override open func awakeFromNib() {
         super.awakeFromNib()
         applyStyles()
     }

--- a/WordPress/Classes/ViewRelated/Reader/Cards/ReaderCardDiscoverAttributionView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Cards/ReaderCardDiscoverAttributionView.swift
@@ -43,7 +43,7 @@ private enum ReaderCardDiscoverAttribution: Int {
 
     // MARK: - Lifecycle Methods
 
-    open override func awakeFromNib() {
+    override open func awakeFromNib() {
         super.awakeFromNib()
 
         // Add a tap gesture for detecting a tap on the label and acting on the current attributionAction.
@@ -172,7 +172,7 @@ private enum ReaderCardDiscoverAttribution: Int {
 
     // MARK: - Touches
 
-    open override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+    override open func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
         super.touchesBegan(touches, with: event)
         // Add highlight if the touch begins inside of the textLabel's frame
         guard let touch: UITouch = event?.allTouches?.first else {
@@ -183,7 +183,7 @@ private enum ReaderCardDiscoverAttribution: Int {
         }
     }
 
-    open override func touchesMoved(_ touches: Set<UITouch>, with event: UIEvent?) {
+    override open func touchesMoved(_ touches: Set<UITouch>, with event: UIEvent?) {
         super.touchesMoved(touches, with: event)
         // Remove highlight if the touch moves outside of the textLabel's frame
         guard textLabel.isHighlighted else {
@@ -197,7 +197,7 @@ private enum ReaderCardDiscoverAttribution: Int {
         }
     }
 
-    open override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {
+    override open func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {
         super.touchesEnded(touches, with: event)
         guard textLabel.isHighlighted else {
             return
@@ -205,7 +205,7 @@ private enum ReaderCardDiscoverAttribution: Int {
         textLabel.isHighlighted = false
     }
 
-    open override func touchesCancelled(_ touches: Set<UITouch>?, with event: UIEvent?) {
+    override open func touchesCancelled(_ touches: Set<UITouch>?, with event: UIEvent?) {
         super.touchesCancelled(touches!, with: event)
         guard textLabel.isHighlighted else {
             return

--- a/WordPress/Classes/ViewRelated/Reader/Cards/ReaderGapMarkerCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Cards/ReaderGapMarkerCell.swift
@@ -9,7 +9,7 @@ open class ReaderGapMarkerCell: UITableViewCell, NibLoadable {
     @IBOutlet fileprivate weak var activityView: UIActivityIndicatorView!
     @IBOutlet fileprivate weak var button: UIButton!
 
-    open override func awakeFromNib() {
+    override open func awakeFromNib() {
         super.awakeFromNib()
         applyStyles()
     }
@@ -49,7 +49,7 @@ open class ReaderGapMarkerCell: UITableViewCell, NibLoadable {
         }
     }
 
-    open override func setHighlighted(_ highlighted: Bool, animated: Bool) {
+    override open func setHighlighted(_ highlighted: Bool, animated: Bool) {
         super.setHighlighted(highlighted, animated: animated)
         button.isHighlighted = highlighted
         button.backgroundColor = highlighted ? WPStyleGuide.gapMarkerButtonBackgroundColorHighlighted() : WPStyleGuide.gapMarkerButtonBackgroundColor()

--- a/WordPress/Classes/ViewRelated/Reader/Controllers/ReaderSearchViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Controllers/ReaderSearchViewController.swift
@@ -46,7 +46,7 @@ final class ReaderSearchViewController: UIViewController {
 
     var isStandaloneAppModeEnabled = false
 
-    public override func viewDidLoad() {
+    override public func viewDidLoad() {
         super.viewDidLoad()
 
         view.backgroundColor = .systemBackground
@@ -75,7 +75,7 @@ final class ReaderSearchViewController: UIViewController {
         }
     }
 
-    public override func didMove(toParent parent: UIViewController?) {
+    override public func didMove(toParent parent: UIViewController?) {
         super.didMove(toParent: parent)
 
         if parent == nil {

--- a/WordPress/Classes/ViewRelated/Reader/Headers/ReaderTagStreamHeader.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Headers/ReaderTagStreamHeader.swift
@@ -34,7 +34,7 @@ final class ReaderTagStreamHeader: ReaderBaseHeaderView, ReaderStreamHeader {
         WPStyleGuide.applyReaderStreamHeaderTitleStyle(titleLabel)
     }
 
-    public override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+    override public func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
 
         if traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) {

--- a/WordPress/Classes/ViewRelated/Reader/Sidebar/ReaderSidebarViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Sidebar/ReaderSidebarViewController.swift
@@ -25,7 +25,7 @@ class ReaderSidebarViewController: UIHostingController<AnyView> {
         title = Strings.reader
     }
 
-    required dynamic init?(coder aDecoder: NSCoder) {
+    dynamic required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/Views/ReaderPostCardContentLabel.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Views/ReaderPostCardContentLabel.swift
@@ -2,7 +2,7 @@ import UIKit
 
 @objc open class ReaderPostCardContentLabel: UILabel {
 
-    open override var intrinsicContentSize: CGSize {
+    override open var intrinsicContentSize: CGSize {
         // HACK
         // iPhone Pluses with 3.0 render scales seem to produce fractional sizes with labels
         // that are sized via UIStackViews.

--- a/WordPress/Classes/ViewRelated/Stats/Charts/StatsLineChartView.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Charts/StatsLineChartView.swift
@@ -338,7 +338,7 @@ class DateValueFormatter: NSObject, AxisValueFormatter {
     var dateFormatter: DateFormatter
     var xAxisDates: [Date] = []
 
-    public override init() {
+    override public init() {
         dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "MMM d"
     }

--- a/WordPress/Classes/ViewRelated/Stats/Helpers/SiteStatsInformation.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Helpers/SiteStatsInformation.swift
@@ -10,7 +10,7 @@ import WordPressShared
     typealias SiteInsights = [String: [Int]]
     private let userDefaultsInsightTypesKey = "StatsInsightTypes"
     @objc public static var sharedInstance = SiteStatsInformation()
-    private override init() {}
+    override private init() {}
 
     @objc public var siteID: NSNumber?
     @objc public var siteTimeZone: TimeZone?

--- a/WordPress/Classes/ViewRelated/Stats/Insights/StatsLatestPostSummaryInsightsCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/StatsLatestPostSummaryInsightsCell.swift
@@ -29,7 +29,7 @@ class StatsLatestPostSummaryInsightsCell: StatsBaseCell, LatestPostSummaryConfig
 
     // MARK: - Initialization
 
-    required override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+    override required init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
 
         configureView()

--- a/WordPress/Classes/ViewRelated/Stats/Insights/StatsMostPopularTimeInsightsCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/StatsMostPopularTimeInsightsCell.swift
@@ -20,7 +20,7 @@ class StatsMostPopularTimeInsightsCell: StatsBaseCell {
 
     // MARK: - Initialization
 
-    required override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+    override required init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
 
         configureView()

--- a/WordPress/Classes/ViewRelated/Stats/Insights/StatsTotalInsightsCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/StatsTotalInsightsCell.swift
@@ -137,7 +137,7 @@ class StatsTotalInsightsCell: StatsBaseCell {
 
     // MARK: - Initialization
 
-    required override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+    override required init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
 
         configureView()

--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboardViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboardViewController.swift
@@ -160,7 +160,7 @@ public class SiteStatsDashboardViewController: UIViewController {
         navigationItemObserver?.invalidate()
     }
 
-    public override func viewDidLoad() {
+    override public func viewDidLoad() {
         super.viewDidLoad()
 
         // Important to make navigation bar match the filter bar
@@ -179,13 +179,13 @@ public class SiteStatsDashboardViewController: UIViewController {
         containerView.pinEdges()
     }
 
-    public override func viewWillAppear(_ animated: Bool) {
+    override public func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         addWillEnterForegroundObserver()
         JetpackFeaturesRemovalCoordinator.presentOverlayIfNeeded(in: self, source: .stats)
     }
 
-    public override func viewDidAppear(_ animated: Bool) {
+    override public func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
 
         NewStatsAnnouncementPresenter.presentIfNeeded(in: self) { [weak self] in
@@ -332,12 +332,12 @@ public class SiteStatsDashboardViewController: UIViewController {
         present(SubmitFeedbackViewController(source: "new_stats", feedbackPrefix: "Stats"), animated: true)
     }
 
-    public override func viewWillDisappear(_ animated: Bool) {
+    override public func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         removeWillEnterForegroundObserver()
     }
 
-    public override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
+    override public func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
         if traitCollection.verticalSizeClass == .regular, traitCollection.horizontalSizeClass == .compact {
             updatePeriodView(oldSelectedTab: currentSelectedTab)
         }

--- a/WordPress/Classes/ViewRelated/Support/SupportTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Support/SupportTableViewController.swift
@@ -706,7 +706,7 @@ open class MigrationCell: WPTableViewCell {
         setup()
     }
 
-    required public init?(coder: NSCoder) {
+    public required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
 

--- a/WordPress/Classes/ViewRelated/System/Action Sheet/ActionSheetViewController.swift
+++ b/WordPress/Classes/ViewRelated/System/Action Sheet/ActionSheetViewController.swift
@@ -184,7 +184,7 @@ class ActionSheetViewController: UIViewController {
         return button
     }
 
-    open override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+    override open func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
         refreshForTraits()
     }

--- a/WordPress/Classes/ViewRelated/System/FilterTabBar.swift
+++ b/WordPress/Classes/ViewRelated/System/FilterTabBar.swift
@@ -107,7 +107,7 @@ public class FilterTabBar: UIControl {
     /// If selectedTitleColor is not provided, tint color will also be applied to
     /// titles of selected tabs.
     ///
-    public override var tintColor: UIColor! {
+    override public var tintColor: UIColor! {
         didSet {
             tabs.forEach({
                 $0.tintColor = tintColor
@@ -284,7 +284,7 @@ public class FilterTabBar: UIControl {
         activateTabSeparatorPlacementConstraints()
     }
 
-    public override func layoutSubviews() {
+    override public func layoutSubviews() {
         super.layoutSubviews()
 
         updateForCurrentEnvironment()
@@ -555,7 +555,7 @@ public class FilterTabBar: UIControl {
         static let initialVelocity: CGFloat = -0.5
     }
 
-    public override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+    override public func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
 
         if isAutomaticTabSizingStyleEnabled {

--- a/WordPress/Classes/ViewRelated/System/Sidebar/SidebarViewController.swift
+++ b/WordPress/Classes/ViewRelated/System/Sidebar/SidebarViewController.swift
@@ -17,7 +17,7 @@ final class SidebarViewController: UIHostingController<AnyView> {
         self.title = Strings.sectionMySites
     }
 
-    required dynamic init?(coder aDecoder: NSCoder) {
+    dynamic required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
 

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController+Swift.swift
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController+Swift.swift
@@ -139,7 +139,7 @@ extension WPTabBarController {
         return true
     }
 
-    open override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
+    override open var supportedInterfaceOrientations: UIInterfaceOrientationMask {
         guard let selectedViewController else {
             return super.supportedInterfaceOrientations
         }

--- a/WordPress/Classes/ViewRelated/Tags/SiteTagsView.swift
+++ b/WordPress/Classes/ViewRelated/Tags/SiteTagsView.swift
@@ -197,7 +197,7 @@ class SiteTagsViewController: UIHostingController<SiteTagsView> {
         super.init(rootView: .init(viewModel: viewModel))
     }
 
-    @MainActor @preconcurrency required dynamic init?(coder aDecoder: NSCoder) {
+    @MainActor @preconcurrency dynamic required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
 }

--- a/WordPress/Classes/ViewRelated/Themes/ThemeBrowserSectionHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Themes/ThemeBrowserSectionHeaderView.swift
@@ -21,7 +21,7 @@ class ThemeBrowserSectionHeaderView: UICollectionReusableView, NibLoadable {
         }
     }
 
-    open override func awakeFromNib() {
+    override open func awakeFromNib() {
         super.awakeFromNib()
         countLabel.isHidden = true
         applyStyles()

--- a/WordPress/Classes/ViewRelated/Themes/ThemeBrowserViewController.swift
+++ b/WordPress/Classes/ViewRelated/Themes/ThemeBrowserViewController.swift
@@ -60,11 +60,11 @@ public protocol ThemePresenter: AnyObject {
 
 /// Invalidates the layout whenever the collection view's bounds change
 @objc open class ThemeBrowserCollectionViewLayout: UICollectionViewFlowLayout {
-    open override func shouldInvalidateLayout(forBoundsChange newBounds: CGRect) -> Bool {
+    override open func shouldInvalidateLayout(forBoundsChange newBounds: CGRect) -> Bool {
         return shouldInvalidateForNewBounds(newBounds)
     }
 
-    open override func invalidationContext(forBoundsChange newBounds: CGRect) -> UICollectionViewFlowLayoutInvalidationContext {
+    override open func invalidationContext(forBoundsChange newBounds: CGRect) -> UICollectionViewFlowLayoutInvalidationContext {
         let context = super.invalidationContext(forBoundsChange: newBounds) as! UICollectionViewFlowLayoutInvalidationContext
         context.invalidateFlowLayoutDelegateMetrics = shouldInvalidateForNewBounds(newBounds)
 
@@ -295,7 +295,7 @@ public protocol ThemePresenter: AnyObject {
 
     // MARK: - UIViewController
 
-    open override func viewDidLoad() {
+    override open func viewDidLoad() {
         super.viewDidLoad()
 
         collectionView.delegate = self
@@ -332,13 +332,13 @@ public protocol ThemePresenter: AnyObject {
         collectionView.register(ThemeBrowserSectionHeaderView.defaultNib, forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader, withReuseIdentifier: ThemeBrowserViewController.reuseIdentifierForCustomThemesHeader)
     }
 
-    open override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+    override open func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
 
         collectionView?.collectionViewLayout.invalidateLayout()
     }
 
-    open override func viewWillAppear(_ animated: Bool) {
+    override open func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
 
         registerForKeyboardNotifications()
@@ -362,7 +362,7 @@ public protocol ThemePresenter: AnyObject {
         }
     }
 
-    open override func viewDidAppear(_ animated: Bool) {
+    override open func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
 
         if isFirstAppearance {
@@ -371,7 +371,7 @@ public protocol ThemePresenter: AnyObject {
         }
     }
 
-    open override func viewWillDisappear(_ animated: Bool) {
+    override open func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
 
         unregisterForKeyboardNotifications()

--- a/WordPress/Classes/ViewRelated/Tools/SettingsListEditorViewController.swift
+++ b/WordPress/Classes/ViewRelated/Tools/SettingsListEditorViewController.swift
@@ -25,7 +25,7 @@ open class SettingsListEditorViewController: UITableViewController {
     }
 
     // MARK: - View Lifecycle
-    open override func viewDidLoad() {
+    override open func viewDidLoad() {
         super.viewDidLoad()
         setupNavBar()
         setupTableView()
@@ -64,17 +64,17 @@ open class SettingsListEditorViewController: UITableViewController {
     }
 
     // MARK: - UITableViewDataSoutce Methods
-    open override func numberOfSections(in tableView: UITableView) -> Int {
+    override open func numberOfSections(in tableView: UITableView) -> Int {
         return 1
     }
 
-    open override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+    override open func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         // Note:
         // We'll always render, at least, one row, with the Empty State text
         return max(rows.count, 1)
     }
 
-    open override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+    override open func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: reuseIdentifier)!
 
         WPStyleGuide.configureTableViewCell(cell)
@@ -86,15 +86,15 @@ open class SettingsListEditorViewController: UITableViewController {
         return cell
     }
 
-    open override func tableView(_ tableView: UITableView, titleForFooterInSection section: Int) -> String? {
+    override open func tableView(_ tableView: UITableView, titleForFooterInSection section: Int) -> String? {
         return footerText
     }
 
-    open override func tableView(_ tableView: UITableView, willDisplayFooterView view: UIView, forSection section: Int) {
+    override open func tableView(_ tableView: UITableView, willDisplayFooterView view: UIView, forSection section: Int) {
         WPStyleGuide.configureTableViewSectionFooter(view)
     }
 
-    open override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+    override open func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectSelectedRowWithAnimation(true)
 
         // Empty State
@@ -117,16 +117,16 @@ open class SettingsListEditorViewController: UITableViewController {
         navigationController?.pushViewController(settingsViewController, animated: true)
     }
 
-    open override func tableView(_ tableView: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {
+    override open func tableView(_ tableView: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {
         return isEmpty() == false
     }
 
-    open override func tableView(_ tableView: UITableView,
+    override open func tableView(_ tableView: UITableView,
                                  editingStyleForRowAt indexPath: IndexPath) -> UITableViewCell.EditingStyle {
         return .delete
     }
 
-    open override func tableView(_ tableView: UITableView,
+    override open func tableView(_ tableView: UITableView,
                                  commit editingStyle: UITableViewCell.EditingStyle,
                                  forRowAt indexPath: IndexPath) {
         // Nuke it from the collection

--- a/WordPress/Classes/ViewRelated/Tools/SettingsPickerViewController.swift
+++ b/WordPress/Classes/ViewRelated/Tools/SettingsPickerViewController.swift
@@ -43,7 +43,7 @@ open class SettingsPickerViewController: UITableViewController {
     @objc open var onChange: ((_ enabled: Bool, _ newValue: Int) -> ())?
 
     // MARK: - View Lifecycle
-    open override func viewDidLoad() {
+    override open func viewDidLoad() {
         assert(selectionText != nil)
         assert(pickerSelectedValue != nil)
         assert(pickerMinimumValue != nil)
@@ -62,15 +62,15 @@ open class SettingsPickerViewController: UITableViewController {
     }
 
     // MARK: - UITableViewDataSoutce Methods
-    open override func numberOfSections(in tableView: UITableView) -> Int {
+    override open func numberOfSections(in tableView: UITableView) -> Int {
         return sections.count
     }
 
-    open override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+    override open func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return sections[section].count
     }
 
-    open override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+    override open func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let row = rowAtIndexPath(indexPath)
         let cell = cellForRow(row, tableView: tableView)
 
@@ -86,14 +86,14 @@ open class SettingsPickerViewController: UITableViewController {
         return cell
     }
 
-    open override func tableView(_ tableView: UITableView, titleForFooterInSection section: Int) -> String? {
+    override open func tableView(_ tableView: UITableView, titleForFooterInSection section: Int) -> String? {
         if section != sectionWithFooter || pickerHint == nil {
             return nil
         }
         return pickerHint!
     }
 
-    open override func tableView(_ tableView: UITableView, willDisplayFooterView view: UIView, forSection section: Int) {
+    override open func tableView(_ tableView: UITableView, willDisplayFooterView view: UIView, forSection section: Int) {
         WPStyleGuide.configureTableViewSectionFooter(view)
     }
 

--- a/WordPress/Classes/ViewRelated/Views/List/ListTableHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Views/List/ListTableHeaderView.swift
@@ -33,7 +33,7 @@ public class ListTableHeaderView: UITableViewHeaderFooterView, NibReusable {
 
     // MARK: Initialization
 
-    public override func awakeFromNib() {
+    override public func awakeFromNib() {
         super.awakeFromNib()
 
         // Hide text label to prevent values being shown due to interaction with

--- a/WordPress/Classes/ViewRelated/Views/List/ListTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Views/List/ListTableViewCell.swift
@@ -76,7 +76,7 @@ public class ListTableViewCell: UITableViewCell, NibReusable {
 
     // MARK: Initialization
 
-    public override func awakeFromNib() {
+    override public func awakeFromNib() {
         super.awakeFromNib()
         configureSubviews()
     }

--- a/WordPress/Classes/ViewRelated/Views/NavigationTitleView.swift
+++ b/WordPress/Classes/ViewRelated/Views/NavigationTitleView.swift
@@ -22,7 +22,7 @@ open class NavigationTitleView: UIView {
         setupSubviews()
     }
 
-    required public init(coder aDecoder: NSCoder) {
+    public required init(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)!
         setupSubviews()
     }

--- a/WordPress/Classes/ViewRelated/Views/RichTextView/RichTextView.swift
+++ b/WordPress/Classes/ViewRelated/Views/RichTextView/RichTextView.swift
@@ -19,7 +19,7 @@ import UniformTypeIdentifiers
         self.init(frame: CGRect.zero)
     }
 
-    public override init(frame: CGRect) {
+    override public init(frame: CGRect) {
         super.init(frame: frame)
         setupSubviews()
     }
@@ -86,7 +86,7 @@ import UniformTypeIdentifiers
         }
     }
 
-    open override var backgroundColor: UIColor? {
+    override open var backgroundColor: UIColor? {
         didSet {
             textView?.backgroundColor = backgroundColor
         }
@@ -191,7 +191,7 @@ import UniformTypeIdentifiers
     }
 
     // MARK: - Overriden Methods
-    open override var intrinsicContentSize: CGSize {
+    override open var intrinsicContentSize: CGSize {
         guard let maxWidth = preferredMaxLayoutWidth else {
             return super.intrinsicContentSize
         }

--- a/WordPress/Classes/ViewRelated/Views/SeparatorsView.swift
+++ b/WordPress/Classes/ViewRelated/Views/SeparatorsView.swift
@@ -58,7 +58,7 @@ open class SeparatorsView: UIView {
             setNeedsDisplay()
         }
     }
-    open override var frame: CGRect {
+    override open var frame: CGRect {
         didSet {
             setNeedsDisplay()
         }
@@ -69,16 +69,16 @@ open class SeparatorsView: UIView {
         self.init(frame: CGRect.zero)
     }
 
-    required override public init(frame: CGRect) {
+    override public required init(frame: CGRect) {
         super.init(frame: frame)
         setupView()
     }
-    required public init(coder aDecoder: NSCoder) {
+    public required init(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)!
         setupView()
     }
 
-    open override func draw(_ rect: CGRect) {
+    override open func draw(_ rect: CGRect) {
         super.draw(rect)
 
         let scale = UIScreen.main.scale


### PR DESCRIPTION
## Rationale

Adds `modifier_order` to `only_rules` in `.swiftlint.yml`.

The rule enforces a canonical order for declaration modifiers (e.g. `public final lazy var`), making declarations easier to scan and removing a class of arbitrary stylistic divergence across the codebase.

## How to test

- CI handles lint and build verification.
- Locally: `rake lint` from the worktree should report zero violations.

## Notes

- `auto_fixed: 161`
- `manual_fixes: 0`
- `suppressions: 0`
- No violations left for human review.
- Build deferred to CI per the established whitespace-only / pure-syntactic-reorder precedent (see also wcios sibling PR https://github.com/woocommerce/woocommerce-ios/pull/17200).
- Part of the Orchard SwiftLint rollout campaign.