### PR TITLE
Enable SwiftLint rule: comma_inheritance

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -22,6 +22,9 @@ only_rules:
   # There should be no space before and one after any comma.
   - comma
 
+  # There should be a space after the comma in inheritance lists.
+  - comma_inheritance
+
   # Prefer `contains` over `filter(where:).count`.
   - contains_over_filter_count
 

--- a/Modules/Sources/WordPressCore/DataStore/DataStore.swift
+++ b/Modules/Sources/WordPressCore/DataStore/DataStore.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// An abstraction of local data storage, with CRUD operations.
 public protocol DataStore: Actor {
-    associatedtype T: Identifiable & Sendable
+    associatedtype T: Identifiable, Sendable
     associatedtype Query: Sendable
 
     func list(query: Query) async throws -> [T]


### PR DESCRIPTION
Enables SwiftLint's [`comma_inheritance`](https://realm.github.io/SwiftLint/comma_inheritance.html) rule, which enforces a space after the comma in inheritance lists (e.g. `Foo: A, B` rather than `Foo: A,B`).

Auto-fixed with `bundle exec rake lintfix`.

Part of the progressive SwiftLint rollout campaign.

## How to test

CI green.

---

Generated with the help of Claude Code, https://code.claude.com