### PR TITLE
Enable SwiftLint rule: untyped_error_in_catch

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -114,6 +114,9 @@ only_rules:
   # Closure arguments don't need to be wrapped in parentheses.
   - unneeded_parentheses_in_closure_argument
 
+  # Catch statements should not declare error variables without type casting.
+  - untyped_error_in_catch
+
   # Unused parameter in a closure should be replaced with _.
   - unused_closure_parameter
 

--- a/Modules/Sources/WordPressKit/DomainsServiceRemote+AllDomains.swift
+++ b/Modules/Sources/WordPressKit/DomainsServiceRemote+AllDomains.swift
@@ -16,7 +16,7 @@ extension DomainsServiceRemote {
 
         do {
             parameters = try queryParameters(from: params)
-        } catch let error {
+        } catch {
             completion(.failure(error))
             return
         }

--- a/Modules/Sources/WordPressKit/FeatureFlagRemote.swift
+++ b/Modules/Sources/WordPressKit/FeatureFlagRemote.swift
@@ -18,7 +18,7 @@ open class FeatureFlagRemote: ServiceRemoteWordPressComREST {
 
         do {
             dictionary = try params.dictionaryRepresentation()
-        } catch let error {
+        } catch {
             callback(.failure(error))
             return
         }

--- a/Modules/Sources/WordPressKit/PlanServiceRemote_ApiVersion1_3.swift
+++ b/Modules/Sources/WordPressKit/PlanServiceRemote_ApiVersion1_3.swift
@@ -49,7 +49,7 @@ import WordPressKitObjC
                 if decodedResult.isCurrentPlan {
                     currentlyActivePlan = decodedResult
                 }
-            } catch let error {
+            } catch {
                 WPKitLogError("Error parsing plans response for site \(error)")
             }
         }

--- a/Modules/Sources/WordPressKit/SiteDesignServiceRemote.swift
+++ b/Modules/Sources/WordPressKit/SiteDesignServiceRemote.swift
@@ -46,7 +46,7 @@ public class SiteDesignServiceRemote {
             do {
                 let result = try parseLayouts(fromResponse: responseObject)
                 completion(.success(result))
-            } catch let error {
+            } catch {
                 NSLog("error response object: %@", String(describing: responseObject))
                 completion(.failure(error))
             }

--- a/Sources/WordPressData/Swift/BlockedAuthor.swift
+++ b/Sources/WordPressData/Swift/BlockedAuthor.swift
@@ -23,7 +23,7 @@ public extension BlockedAuthor {
             request.predicate = query.predicate
             let result = try context.fetch(request)
             return result
-        } catch let error {
+        } catch {
             DDLogError("Couldn't fetch blocked author with error: \(error.localizedDescription)")
             return []
         }

--- a/Sources/WordPressData/Swift/BlockedSite.swift
+++ b/Sources/WordPressData/Swift/BlockedSite.swift
@@ -24,7 +24,7 @@ public extension BlockedSite {
             request.predicate = NSPredicate(format: "\(#keyPath(BlockedSite.accountID)) = %@ AND \(#keyPath(BlockedSite.blogID)) = %@", accountID, blogID)
             let result = try context.fetch(request)
             return result
-        } catch let error {
+        } catch {
             DDLogError("Couldn't fetch blocked site with error: \(error.localizedDescription)")
             return []
         }

--- a/WordPress/Classes/Jetpack/JetpackMigration/Common/MigrationEmailService.swift
+++ b/WordPress/Classes/Jetpack/JetpackMigration/Common/MigrationEmailService.swift
@@ -28,7 +28,7 @@ final class MigrationEmailService {
                 throw MigrationError.accountNotFound
             }
             self.init(api: account.wordPressComRestV2Api)
-        } catch let error {
+        } catch {
             DDLogError("[\(MigrationError.domain)] Object instantiation failed: \(error.localizedDescription)")
             throw error
         }
@@ -44,7 +44,7 @@ final class MigrationEmailService {
                 throw MigrationError.unsuccessfulResponse
             }
             tracker.track(.emailSent)
-        } catch let error {
+        } catch {
             let properties = ["error_type": error.localizedDescription]
             tracker.track(.emailFailed, properties: properties)
             DDLogError("[\(MigrationError.domain)] Migration email sending failed: \(error.localizedDescription)")
@@ -60,7 +60,7 @@ final class MigrationEmailService {
                     let data = try JSONSerialization.data(withJSONObject: responseObject)
                     let response = try decoder.decode(SendMigrationEmailResponse.self, from: data)
                     continuation.resume(returning: response)
-                } catch let error {
+                } catch {
                     continuation.resume(throwing: error)
                 }
             } failure: { error, _ in

--- a/WordPress/Classes/Services/ReaderCardService.swift
+++ b/WordPress/Classes/Services/ReaderCardService.swift
@@ -150,7 +150,7 @@ class ReaderCardService {
                 guard let objectData = object as? NSManagedObject else { continue }
                 context.delete(objectData)
             }
-        } catch let error {
+        } catch {
             print("Clean card error:", error)
         }
     }

--- a/WordPress/Classes/Services/ReaderPostStreamService.swift
+++ b/WordPress/Classes/Services/ReaderPostStreamService.swift
@@ -79,7 +79,7 @@ class ReaderPostStreamService {
                 }
                 context.delete(post)
             }
-        } catch let error {
+        } catch {
             print("Clean post error:", error)
         }
     }

--- a/WordPress/Classes/Utility/BackgroundTasks/WeeklyRoundupBackgroundTask.swift
+++ b/WordPress/Classes/Utility/BackgroundTasks/WeeklyRoundupBackgroundTask.swift
@@ -86,7 +86,7 @@ private class WeeklyRoundupDataProvider {
 
             do {
                 service = try Self.makeRemoteStatsService(for: site)
-            } catch let error {
+            } catch {
                 self.onError(error)
                 continue
             }

--- a/WordPress/Classes/Utility/ZendeskUtils.swift
+++ b/WordPress/Classes/Utility/ZendeskUtils.swift
@@ -747,7 +747,7 @@ private extension ZendeskUtils {
             try eventLogging.enqueueLogForUpload(log: logFile)
         }
         catch {
-            return "Error preparing log file: \(err.localizedDescription)"
+            return "Error preparing log file: \(error.localizedDescription)"
         }
 
         return logFile.uuid

--- a/WordPress/Classes/Utility/ZendeskUtils.swift
+++ b/WordPress/Classes/Utility/ZendeskUtils.swift
@@ -746,7 +746,7 @@ private extension ZendeskUtils {
             let eventLogging = EventLogging(dataSource: dataProvider, delegate: delegate)
             try eventLogging.enqueueLogForUpload(log: logFile)
         }
-        catch let err {
+        catch {
             return "Error preparing log file: \(err.localizedDescription)"
         }
 

--- a/WordPress/Classes/ViewRelated/Me/App Settings/EncryptedLogTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/EncryptedLogTableViewController.swift
@@ -109,7 +109,7 @@ class EncryptedLogTableViewController: UITableViewController {
 
             try self.eventLogging.enqueueLogForUpload(log: LogFile(url: url))
         }
-        catch let err {
+        catch {
             let alert = UIAlertController(title: "Unable to create log", message: err.localizedDescription, preferredStyle: .actionSheet)
             self.present(alert, animated: true)
         }

--- a/WordPress/Classes/ViewRelated/Me/App Settings/EncryptedLogTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/EncryptedLogTableViewController.swift
@@ -110,7 +110,7 @@ class EncryptedLogTableViewController: UITableViewController {
             try self.eventLogging.enqueueLogForUpload(log: LogFile(url: url))
         }
         catch {
-            let alert = UIAlertController(title: "Unable to create log", message: err.localizedDescription, preferredStyle: .actionSheet)
+            let alert = UIAlertController(title: "Unable to create log", message: error.localizedDescription, preferredStyle: .actionSheet)
             self.present(alert, animated: true)
         }
     }

--- a/WordPress/Classes/ViewRelated/Me/Me Main/MeViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/Me Main/MeViewController.swift
@@ -462,7 +462,7 @@ public class MeViewController: UITableViewController {
                 async let refreshSettings: Void = Self.refreshAccountSettings(with: accountSettingsService)
                 let _ = try await [refreshDetails, refreshSettings]
                 self.reloadViewModel()
-            } catch let error {
+            } catch {
                 DDLogError("\(error.localizedDescription)")
             }
         }

--- a/WordPress/Classes/ViewRelated/NUX/Controllers/Social Signup/SignupEpilogueViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/Controllers/Social Signup/SignupEpilogueViewController.swift
@@ -269,7 +269,7 @@ private extension SignupEpilogueViewController {
                 finished(success, error)
             }
         } catch {
-            finished(false, err)
+            finished(false, error)
             return
         }
     }

--- a/WordPress/Classes/ViewRelated/NUX/Controllers/Social Signup/SignupEpilogueViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/Controllers/Social Signup/SignupEpilogueViewController.swift
@@ -268,7 +268,7 @@ private extension SignupEpilogueViewController {
 
                 finished(success, error)
             }
-        } catch let err {
+        } catch {
             finished(false, err)
             return
         }

--- a/WordPress/Classes/ViewRelated/Reader/Controllers/ReaderPostActions/ReaderBlockUserAction.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Controllers/ReaderPostActions/ReaderBlockUserAction.swift
@@ -13,7 +13,7 @@ final class ReaderBlockUserAction {
         do {
             let account = try WPAccount.lookupDefaultWordPressComAccount(in: context)
             return account
-        } catch let error {
+        } catch {
             DDLogError("Couldn't fetch default account: \(error.localizedDescription)")
             return nil
         }
@@ -45,7 +45,7 @@ final class ReaderBlockUserAction {
             try context.save()
             self.trackEvent(authorID: authorID, blocked: blocked)
             completion?(.success(()))
-        } catch let error {
+        } catch {
             let operation = blocked ? "block" : "unblock"
             DDLogError("Couldn't \(operation) author: \(error.localizedDescription)")
             completion?(.failure(error))

--- a/WordPress/WordPressScreenshotGeneration/SnapshotHelper.swift
+++ b/WordPress/WordPressScreenshotGeneration/SnapshotHelper.swift
@@ -74,7 +74,7 @@ open class Snapshot: NSObject {
             setLanguage(app)
             setLocale(app)
             setLaunchArguments(app)
-        } catch let error {
+        } catch {
             NSLog(error.localizedDescription)
         }
     }
@@ -188,7 +188,7 @@ open class Snapshot: NSObject {
                 #else
                     try image.pngData()?.write(to: path, options: .atomic)
                 #endif
-            } catch let error {
+            } catch {
                 NSLog("Problem writing screenshot: \(name) to \(screenshotsDir)/\(simulator)-\(name).png")
                 NSLog(error.localizedDescription)
             }


### PR DESCRIPTION
Enables the `untyped_error_in_catch` SwiftLint rule, which flags `catch let <name>` patterns where the binding doesn't add a type cast — the implicit `error` constant is enough.

- Auto-fixed: 20 violations across 16 files via `bundle exec rake lintfix`.
- Agentic fixes: none.
- Left for human review: none.

Part of the Orchard SwiftLint rollout campaign.