### PR TITLE
Enable SwiftLint rule: return_value_from_void_function

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -94,6 +94,9 @@ only_rules:
   # Type annotations are redundant when the type can be inferred.
   - redundant_type_annotation
 
+  # Returning a value from a function declared as returning Void is disallowed.
+  - return_value_from_void_function
+
   - shorthand_optional_binding
 
   # Prefer `someBool.toggle()` over `someBool = !someBool`.

--- a/Modules/Sources/UITestsFoundation/XCUIElement+TapUntil.swift
+++ b/Modules/Sources/UITestsFoundation/XCUIElement+TapUntil.swift
@@ -73,7 +73,8 @@ public extension XCUIElement {
         retryInterval: TimeInterval
     ) {
         guard retriedCount < maxRetries else {
-            return XCTFail("\(failureMessage) after \(retriedCount) tries.")
+            XCTFail("\(failureMessage) after \(retriedCount) tries.")
+            return
         }
 
         tap()
@@ -81,13 +82,14 @@ public extension XCUIElement {
         guard condition.isMet() else {
             sleep(UInt32(retryInterval))
 
-            return tapUntil(
+            tapUntil(
                 condition,
                 retriedCount: retriedCount + 1,
                 failureMessage: failureMessage,
                 maxRetries: maxRetries,
                 retryInterval: retryInterval
             )
+            return
         }
     }
 }

--- a/Sources/WordPressAuthenticator/Features/NUX/Button/NUXStackedButtonsViewController.swift
+++ b/Sources/WordPressAuthenticator/Features/NUX/Button/NUXStackedButtonsViewController.swift
@@ -166,7 +166,8 @@ private extension NUXStackedButtonsViewController {
 
     func configureDivider() {
         guard showDivider else {
-            return dividerStackView.isHidden = true
+            dividerStackView.isHidden = true
+            return
         }
 
         leadingDividerLine.backgroundColor = style.orDividerSeparatorColor

--- a/Sources/WordPressAuthenticator/Helpers/UnifiedAuth/ViewRelated/2FA/TwoFAViewController.swift
+++ b/Sources/WordPressAuthenticator/Helpers/UnifiedAuth/ViewRelated/2FA/TwoFAViewController.swift
@@ -125,7 +125,8 @@ final class TwoFAViewController: LoginViewController {
         // If the error happened because the security key challenge request started more than 1 minute ago, show a timeout error.
         // This check is needed because the server sends a generic error.
         if let initialChallengeRequestTime, Date().timeIntervalSince(initialChallengeRequestTime) >= 60, err.code == .zero {
-            return displaySecurityKeyErrorMessageAndExitFlow(message: LocalizedText.timeoutError)
+            displaySecurityKeyErrorMessageAndExitFlow(message: LocalizedText.timeoutError)
+            return
         }
 
         configureViewLoading(false)
@@ -187,12 +188,14 @@ private extension TwoFAViewController {
     ///
     func validateForm() {
         guard let nonceInfo = loginFields.nonceInfo else {
-            return validateFormAndLogin()
+            validateFormAndLogin()
+            return
         }
 
         let (authType, nonce) = nonceInfo.authTypeAndNonce(for: loginFields.multifactorCode)
         if nonce.isEmpty {
-            return validateFormAndLogin()
+            validateFormAndLogin()
+            return
         }
 
         loginWithNonce(nonce, authType: authType, code: loginFields.multifactorCode)
@@ -214,7 +217,8 @@ private extension TwoFAViewController {
     func loginWithSecurityKeys() {
 
         guard let twoStepNonce = loginFields.nonceInfo?.nonceWebauthn else {
-            return displaySecurityKeyErrorMessageAndExitFlow()
+            displaySecurityKeyErrorMessageAndExitFlow()
+            return
         }
 
         configureViewLoading(true)
@@ -294,12 +298,14 @@ extension TwoFAViewController: ASAuthorizationControllerDelegate, ASAuthorizatio
         guard let credential = authorization.credential as? ASAuthorizationPlatformPublicKeyCredentialAssertion,
               let challengeInfo = loginFields.webauthnChallengeInfo,
               let clientDataJson = extractClientData(from: credential, challengeInfo: challengeInfo) else {
-            return displaySecurityKeyErrorMessageAndExitFlow()
+            displaySecurityKeyErrorMessageAndExitFlow()
+            return
         }
 
         // Validate that the submitted passkey is allowed.
         guard challengeInfo.allowedCredentialIDs.contains(credential.credentialID.base64URLEncodedString()) else {
-            return displaySecurityKeyErrorMessageAndExitFlow(message: LocalizedText.invalidKey)
+            displaySecurityKeyErrorMessageAndExitFlow(message: LocalizedText.invalidKey)
+            return
         }
 
         loginFacade.authenticateWebauthnSignature(userID: loginFields.nonceUserID,

--- a/Sources/WordPressAuthenticator/Helpers/UnifiedAuth/ViewRelated/GetStarted/GetStartedViewController.swift
+++ b/Sources/WordPressAuthenticator/Helpers/UnifiedAuth/ViewRelated/GetStarted/GetStartedViewController.swift
@@ -316,7 +316,8 @@ private extension GetStartedViewController {
     ///
     func configureDivider() {
         guard showsContinueButtonAtTheBottom == false else {
-            return dividerStackView.isHidden = true
+            dividerStackView.isHidden = true
+            return
         }
         let color = WordPressAuthenticator.shared.unifiedStyle?.borderColor ?? WordPressAuthenticator.shared.style.primaryNormalBorderColor
         leadingDividerLine.backgroundColor = color

--- a/Sources/WordPressAuthenticator/Helpers/UnifiedAuth/ViewRelated/Login/MagicLinkRequestedViewController.swift
+++ b/Sources/WordPressAuthenticator/Helpers/UnifiedAuth/ViewRelated/Login/MagicLinkRequestedViewController.swift
@@ -64,7 +64,8 @@ final class MagicLinkRequestedViewController: LoginViewController {
     ///
     override func styleBackground() {
         guard let unifiedBackgroundColor = WordPressAuthenticator.shared.unifiedStyle?.viewControllerBackgroundColor else {
-            return super.styleBackground()
+            super.styleBackground()
+            return
         }
         view.backgroundColor = unifiedBackgroundColor
     }

--- a/Sources/WordPressAuthenticator/Helpers/UnifiedAuth/ViewRelated/Password/PasswordCoordinator.swift
+++ b/Sources/WordPressAuthenticator/Helpers/UnifiedAuth/ViewRelated/Password/PasswordCoordinator.swift
@@ -59,7 +59,8 @@ private extension PasswordCoordinator {
     /// Navigates the user to enter WP.com password.
     func showPassword() {
         guard let vc = PasswordViewController.instantiate(from: .password) else {
-            return WPLogError("Failed to navigate to PasswordViewController from GetStartedViewController")
+            WPLogError("Failed to navigate to PasswordViewController from GetStartedViewController")
+            return
         }
 
         vc.source = source

--- a/Sources/WordPressAuthenticator/Helpers/UnifiedAuth/ViewRelated/SiteAddress/SiteAddressViewController.swift
+++ b/Sources/WordPressAuthenticator/Helpers/UnifiedAuth/ViewRelated/SiteAddress/SiteAddressViewController.swift
@@ -435,7 +435,8 @@ private extension SiteAddressViewController {
 
         guard let url = URL(string: loginFields.siteAddress) else {
             configureViewLoading(false)
-            return displayError(message: Localization.invalidURL, moveVoiceOverFocus: true)
+            displayError(message: Localization.invalidURL, moveVoiceOverFocus: true)
+            return
         }
 
         // Checks that the site exists

--- a/Sources/WordPressAuthenticator/Helpers/UnifiedAuth/ViewRelated/SiteAddress/SiteCredentialsViewController.swift
+++ b/Sources/WordPressAuthenticator/Helpers/UnifiedAuth/ViewRelated/SiteAddress/SiteCredentialsViewController.swift
@@ -558,7 +558,8 @@ extension SiteCredentialsViewController {
     ///
     @objc func validateForm() {
         guard configuration.enableManualSiteCredentialLogin else {
-            return validateFormAndLogin() // handles login with XMLRPC normally
+            validateFormAndLogin() // handles login with XMLRPC normally
+            return // handles login with XMLRPC normally
         }
 
         // asks the delegate to handle the login

--- a/Sources/WordPressAuthenticator/Helpers/UnifiedAuth/ViewRelated/VerifyEmail/VerifyEmailViewController.swift
+++ b/Sources/WordPressAuthenticator/Helpers/UnifiedAuth/ViewRelated/VerifyEmail/VerifyEmailViewController.swift
@@ -51,7 +51,8 @@ final class VerifyEmailViewController: LoginViewController {
     ///
     override func styleBackground() {
         guard let unifiedBackgroundColor = WordPressAuthenticator.shared.unifiedStyle?.viewControllerBackgroundColor else {
-            return super.styleBackground()
+            super.styleBackground()
+            return
         }
 
         view.backgroundColor = unifiedBackgroundColor

--- a/Sources/WordPressData/Swift/AbstractPost.swift
+++ b/Sources/WordPressData/Swift/AbstractPost.swift
@@ -257,7 +257,8 @@ public extension AbstractPost {
         // - warning: The use of `.original` is intentional – we want to get
         // the previous revision in the list.
         guard let previous = revision.original else {
-            return wpAssertionFailure("missing original")
+            wpAssertionFailure("missing original")
+            return
         }
         let original = revision.getOriginal()
         previous.deleteRevision()

--- a/Sources/WordPressData/Swift/ContextManager.swift
+++ b/Sources/WordPressData/Swift/ContextManager.swift
@@ -302,7 +302,8 @@ extension ContextManager {
         let container = persistentContainer.persistentStoreCoordinator
         assert(container.persistentStores.count == 1)
         guard let store = container.persistentStores.first, let storeURL = store.url else {
-            return assertionFailure()
+            assertionFailure()
+            return
         }
         do {
             try container.destroyPersistentStore(at: storeURL, ofType: store.type, options: nil)

--- a/Sources/WordPressData/Swift/PostMetadataContainer.swift
+++ b/Sources/WordPressData/Swift/PostMetadataContainer.swift
@@ -170,7 +170,8 @@ public struct PostMetadataContainer {
             dict["id"] = existingID
         }
         guard JSONSerialization.isValidJSONObject(dict) else {
-            return wpAssertionFailure("invalid value", userInfo: ["type": String(describing: type(of: value))])
+            wpAssertionFailure("invalid value", userInfo: ["type": String(describing: type(of: value))])
+            return
         }
         items[key] = dict
     }

--- a/Tests/KeystoneTests/Tests/Features/Dashboard/BlazeCampaignsStreamTests.swift
+++ b/Tests/KeystoneTests/Tests/Features/Dashboard/BlazeCampaignsStreamTests.swift
@@ -33,7 +33,8 @@ final class BlazeCampaignsStreamTests: CoreDataTestCase {
         XCTAssertEqual(service.numberOfRequests, 1)
         XCTAssertEqual(delegate.appendedIndexPaths, [[IndexPath(row: 0, section: 0)]])
         guard delegate.states.count == 2 else {
-            return XCTFail("Unexpected state updates recorded: \(delegate.states)")
+            XCTFail("Unexpected state updates recorded: \(delegate.states)")
+            return
         }
         do {
             let state = delegate.states[0]
@@ -56,7 +57,8 @@ final class BlazeCampaignsStreamTests: CoreDataTestCase {
         XCTAssertEqual(service.numberOfRequests, 2)
         XCTAssertEqual(delegate.appendedIndexPaths, [[IndexPath(row: 1, section: 0)]])
         guard delegate.states.count == 2 else {
-            return XCTFail("Unexpected state updates recorded: \(delegate.states)")
+            XCTFail("Unexpected state updates recorded: \(delegate.states)")
+            return
         }
         do {
             let state = delegate.states[0]
@@ -98,7 +100,8 @@ final class BlazeCampaignsStreamTests: CoreDataTestCase {
         XCTAssertEqual(service.numberOfRequests, 1)
         XCTAssertEqual(delegate.appendedIndexPaths, [])
         guard delegate.states.count == 2 else {
-            return XCTFail("Unexpected state updates recorded: \(delegate.states)")
+            XCTFail("Unexpected state updates recorded: \(delegate.states)")
+            return
         }
         do {
             let state = delegate.states[0]
@@ -125,7 +128,8 @@ final class BlazeCampaignsStreamTests: CoreDataTestCase {
         XCTAssertEqual(service.numberOfRequests, 2)
         XCTAssertEqual(delegate.appendedIndexPaths, [[IndexPath(row: 0, section: 0)]])
         guard delegate.states.count == 2 else {
-            return XCTFail("Unexpected state updates recorded: \(delegate.states)")
+            XCTFail("Unexpected state updates recorded: \(delegate.states)")
+            return
         }
         do {
             let state = delegate.states[0]
@@ -161,7 +165,8 @@ final class BlazeCampaignsStreamTests: CoreDataTestCase {
         XCTAssertEqual(service.numberOfRequests, 2)
         XCTAssertEqual(delegate.appendedIndexPaths, [])
         guard delegate.states.count == 2 else {
-            return XCTFail("Unexpected state updates recorded: \(delegate.states)")
+            XCTFail("Unexpected state updates recorded: \(delegate.states)")
+            return
         }
         do {
             let state = delegate.states[0]
@@ -188,7 +193,8 @@ final class BlazeCampaignsStreamTests: CoreDataTestCase {
         XCTAssertEqual(service.numberOfRequests, 3)
         XCTAssertEqual(delegate.appendedIndexPaths, [[IndexPath(row: 1, section: 0)]])
         guard delegate.states.count == 2 else {
-            return XCTFail("Unexpected state updates recorded: \(delegate.states)")
+            XCTFail("Unexpected state updates recorded: \(delegate.states)")
+            return
         }
         do {
             let state = delegate.states[0]
@@ -254,7 +260,8 @@ private final class MockBlazePaginatedService: BlazeServiceProtocol {
         numberOfRequests += 1
 
         guard !isFailing else {
-            return completion(.failure(URLError(.notConnectedToInternet)))
+            completion(.failure(URLError(.notConnectedToInternet)))
+            return
         }
 
         do {

--- a/Tests/KeystoneTests/Tests/Services/BlogServiceDeduplicationTests.swift
+++ b/Tests/KeystoneTests/Tests/Services/BlogServiceDeduplicationTests.swift
@@ -118,7 +118,8 @@ class BlogServiceDeduplicationTests: CoreDataTestCase {
 
         XCTAssertEqual(blog1.posts?.count, 0)
         guard let blog2Final = account.blogs?.first(where: { $0.dotComID == 2 }) else {
-            return XCTFail("There should be one blog with ID = 2")
+            XCTFail("There should be one blog with ID = 2")
+            return
         }
         XCTAssertTrue(findPost(title: "Post 1 in Blog 2", in: blog2Final))
         XCTAssertTrue(findPost(title: "Draft 2 in Blog 2", in: blog2Final))

--- a/Tests/KeystoneTests/Tests/Services/PostCoordinatorTests.swift
+++ b/Tests/KeystoneTests/Tests/Services/PostCoordinatorTests.swift
@@ -329,7 +329,8 @@ class PostCoordinatorTests: CoreDataTestCase {
         } catch {
             guard let error = error as? PostRepository.PostSaveError,
                   case .deleted = error else {
-                return XCTFail("Unexpected error")
+                XCTFail("Unexpected error")
+                return
             }
         }
 
@@ -630,12 +631,13 @@ private extension PostCoordinator {
     func waitForSync(_ post: AbstractPost, to revision: AbstractPost, ignoreErrors: Bool = false, timeout: TimeInterval = 5) async throws {
         var olderRevisionIDs = Set(post.allRevisions.filter(\.isSyncNeeded).map(\.objectID))
         olderRevisionIDs.remove(revision.objectID)
-        return try await waitForSync(post, ignoreErrors: ignoreErrors, timeout: timeout) { operation in
+        try await waitForSync(post, ignoreErrors: ignoreErrors, timeout: timeout) { operation in
             guard !olderRevisionIDs.contains(operation.revision.objectID) else {
                 return false // Skip operation for older revisions
             }
             return true
         }
+        return
     }
 
     /// Taps into the coordinator events and waits until the post syncs to the

--- a/Tests/WordPressAuthenticatorTests/GoogleSignIn/NewGoogleAuthenticatorTests.swift
+++ b/Tests/WordPressAuthenticatorTests/GoogleSignIn/NewGoogleAuthenticatorTests.swift
@@ -27,7 +27,8 @@ class NewGoogleAuthenticatorTests: XCTestCase {
         } catch {
             let error = try XCTUnwrap(error as? OAuthError)
             guard case .urlDidNotContainCodeParameter(let urlFromError) = error else {
-                return XCTFail("Received unexpected error \(error)")
+                XCTFail("Received unexpected error \(error)")
+                return
             }
             XCTAssertEqual(urlFromError, url)
         }
@@ -76,7 +77,8 @@ class NewGoogleAuthenticatorTests: XCTestCase {
         } catch {
             let error = try XCTUnwrap(error as? OAuthError)
             guard case .tokenResponseDidNotIncludeIdToken = error else {
-                return XCTFail("Received unexpected error \(error)")
+                XCTFail("Received unexpected error \(error)")
+                return
             }
         }
     }

--- a/Tests/WordPressAuthenticatorTests/GoogleSignIn/URL+GoogleSignInTests.swift
+++ b/Tests/WordPressAuthenticatorTests/GoogleSignIn/URL+GoogleSignInTests.swift
@@ -47,21 +47,23 @@ func assert(
     line: UInt = #line
 ) {
     guard var components = URLComponents(url: actual, resolvingAgainstBaseURL: false) else {
-        return XCTFail(
+        XCTFail(
             "Could not created `URLComponents` from given `URL` \(actual).",
             file: file,
             line: line
         )
+        return
     }
 
     components.query = .none
 
     guard let baseURL = components.url else {
-        return XCTFail(
+        XCTFail(
             "Could not extract `URL` from `URLComponents` created from \(actual).",
             file: file,
             line: line
         )
+        return
     }
 
     XCTAssertEqual(baseURL.absoluteString, baseURLString, file: file, line: line)
@@ -75,11 +77,12 @@ func assertQueryItems(
     line: UInt = #line
 ) {
     guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
-        return XCTFail(
+        XCTFail(
             "Could not created `URLComponents` from given `URL` \(url).",
             file: file,
             line: line
         )
+        return
     }
 
     guard let queryItems = components.queryItems else {

--- a/Tests/WordPressAuthenticatorTests/SingIn/AppleAuthenticatorTests.swift
+++ b/Tests/WordPressAuthenticatorTests/SingIn/AppleAuthenticatorTests.swift
@@ -35,7 +35,8 @@ class AppleAuthenticatorTests: XCTestCase {
 
         let service = try XCTUnwrap(delegateSpy.socialUser?.service)
         guard case .apple = service else {
-            return XCTFail("Expected Apple social service, got \(service) instead")
+            XCTFail("Expected Apple social service, got \(service) instead")
+            return
         }
     }
 

--- a/Tests/WordPressAuthenticatorTests/SingIn/LoginViewControllerTests.swift
+++ b/Tests/WordPressAuthenticatorTests/SingIn/LoginViewControllerTests.swift
@@ -27,7 +27,8 @@ class LoginViewControllerTests: XCTestCase {
 
         let service = try XCTUnwrap(delegateSpy.socialUser?.service)
         guard case .google = service else {
-            return XCTFail("Expected Google social service, got \(service) instead")
+            XCTFail("Expected Google social service, got \(service) instead")
+            return
         }
     }
 }

--- a/Tests/WordPressKitTests/WordPressKitTests/Tests/JetpackProxyServiceRemoteTests.swift
+++ b/Tests/WordPressKitTests/WordPressKitTests/Tests/JetpackProxyServiceRemoteTests.swift
@@ -19,7 +19,8 @@ class JetpackProxyServiceRemoteTests: XCTestCase {
         remote.proxyRequest(for: siteID, path: "path", method: .get) { _ in }
 
         guard let passedURLString = api.URLStringPassedIn else {
-            return XCTFail()
+            XCTFail()
+            return
         }
         XCTAssertTrue(passedURLString.hasSuffix(urlString))
     }
@@ -28,7 +29,8 @@ class JetpackProxyServiceRemoteTests: XCTestCase {
         remote.proxyRequest(for: siteID, path: "path", method: .get) { _ in }
 
         guard let passedParameter = api.parametersPassedIn as? [String: AnyObject] else {
-            return XCTFail()
+            XCTFail()
+            return
         }
         XCTAssertEqual(passedParameter["json"] as? String, "true")
     }
@@ -40,7 +42,8 @@ class JetpackProxyServiceRemoteTests: XCTestCase {
         remote.proxyRequest(for: siteID, path: path, method: method) { _ in }
 
         guard let passedParameter = api.parametersPassedIn as? [String: AnyObject] else {
-            return XCTFail()
+            XCTFail()
+            return
         }
         XCTAssertEqual(passedParameter["path"] as? String, "\(path)&_method=\(method.rawValue)")
     }
@@ -52,7 +55,8 @@ class JetpackProxyServiceRemoteTests: XCTestCase {
         remote.proxyRequest(for: siteID, path: "path", method: method, parameters: params) { _ in }
 
         guard let passedParameter = api.parametersPassedIn as? [String: AnyObject] else {
-            return XCTFail()
+            XCTFail()
+            return
         }
         XCTAssertNotNil(passedParameter["query"])
     }
@@ -64,7 +68,8 @@ class JetpackProxyServiceRemoteTests: XCTestCase {
         remote.proxyRequest(for: siteID, path: "path", method: method, parameters: params) { _ in }
 
         guard let passedParameter = api.parametersPassedIn as? [String: AnyObject] else {
-            return XCTFail()
+            XCTFail()
+            return
         }
         XCTAssertNotNil(passedParameter["body"])
     }
@@ -82,7 +87,8 @@ class JetpackProxyServiceRemoteTests: XCTestCase {
               let jsonString = passedParameter["body"] as? String,
               let jsonData = jsonString.data(using: .utf8),
               let jsonDictionary = try? JSONSerialization.jsonObject(with: jsonData, options: []) as? [String: String] else {
-            return XCTFail()
+            XCTFail()
+            return
         }
         XCTAssertEqual(jsonDictionary, params)
     }
@@ -93,7 +99,8 @@ class JetpackProxyServiceRemoteTests: XCTestCase {
         remote.proxyRequest(for: siteID, path: "path", method: .post, parameters: params) { _ in }
 
         guard let passedParameter = api.parametersPassedIn as? [String: AnyObject] else {
-            return XCTFail()
+            XCTFail()
+            return
         }
         XCTAssertNil(passedParameter["body"])
     }
@@ -104,7 +111,8 @@ class JetpackProxyServiceRemoteTests: XCTestCase {
         remote.proxyRequest(for: siteID, path: "path", method: .post, locale: locale) { _ in }
 
         guard let passedParameter = api.parametersPassedIn as? [String: AnyObject] else {
-            return XCTFail()
+            XCTFail()
+            return
         }
         XCTAssertEqual(passedParameter["locale"] as? String, locale)
     }
@@ -115,7 +123,8 @@ class JetpackProxyServiceRemoteTests: XCTestCase {
         remote.proxyRequest(for: siteID, path: "path", method: .post, locale: locale) { _ in }
 
         guard let passedParameter = api.parametersPassedIn as? [String: AnyObject] else {
-            return XCTFail()
+            XCTFail()
+            return
         }
         XCTAssertNil(passedParameter["locale"])
     }

--- a/Tests/WordPressKitTests/WordPressKitTests/Tests/RemoteTestCase.swift
+++ b/Tests/WordPressKitTests/WordPressKitTests/Tests/RemoteTestCase.swift
@@ -61,7 +61,8 @@ extension RemoteTestCase {
         // The pattern here should be to XCTUnwrap and throw.
         // In the interest of moving along with the work, let's fail the tests at this level if the file is not found.
         guard let stubPath = OHPathForFile(filename, type(of: self)) else {
-            return XCTFail("Could not find file at path '\(filename)'.")
+            XCTFail("Could not find file at path '\(filename)'.")
+            return
         }
 
         stub(condition: condition) { _ in
@@ -87,7 +88,8 @@ extension RemoteTestCase {
         // The pattern here should be to XCTUnwrap and throw.
         // In the interest of moving along with the work, let's fail the tests at this level if the file is not found.
         guard let stubPath = OHPathForFile(filename, type(of: self)) else {
-            return XCTFail("Could not find file at path '\(filename)'.")
+            XCTFail("Could not find file at path '\(filename)'.")
+            return
         }
 
         stub(condition: { request in

--- a/WordPress/Classes/Apps/Reader/Home/ReaderHomeViewController.swift
+++ b/WordPress/Classes/Apps/Reader/Home/ReaderHomeViewController.swift
@@ -37,7 +37,8 @@ final class ReaderHomeViewController: ReaderStreamViewController {
     private func showCreateSiteFlow() {
         let wizardLauncher = SiteCreationWizardLauncher()
         guard let wizard = wizardLauncher.ui else {
-            return wpAssertionFailure("something went wrong")
+            wpAssertionFailure("something went wrong")
+            return
         }
         present(wizard, animated: true)
         SiteCreationAnalyticsHelper.trackSiteCreationAccessed(source: "home")

--- a/WordPress/Classes/Services/EditorSettingsService.swift
+++ b/WordPress/Classes/Services/EditorSettingsService.swift
@@ -24,12 +24,14 @@ import WordPressKit
     public func syncEditorSettings(for blog: Blog, success: @escaping () -> Void, failure: @escaping (Swift.Error) -> Void) {
         guard let api = api(for: blog) else {
             // SelfHosted non-jetpack sites won't sync with remote.
-            return success()
+            success()
+            return
         }
         guard let siteID = blog.dotComID?.intValue else {
             assertionFailure("Blog with dotCom Rest API but dotCom Site ID not found")
             let error = NSError(domain: "EditorSettingsService", code: 0, userInfo: [NSDebugDescriptionErrorKey: "dotCom Site ID not found"])
-            return failure(error)
+            failure(error)
+            return
         }
 
         let service = EditorServiceRemote(wordPressComRestApi: api)

--- a/WordPress/Classes/Services/PostCoordinator.swift
+++ b/WordPress/Classes/Services/PostCoordinator.swift
@@ -430,7 +430,8 @@ class PostCoordinator: NSObject {
             postDidUpdateNotification(for: post)
         }
         guard let revision = post.getLatestRevisionNeedingSync() else {
-            return DDLogInfo("sync: \(post.objectID.shortDescription) is already up to date")
+            DDLogInfo("sync: \(post.objectID.shortDescription) is already up to date")
+            return
         }
         startSync(for: post, revision: revision)
     }
@@ -446,20 +447,24 @@ class PostCoordinator: NSObject {
            Date.now.timeIntervalSince(date) > SyncWorker.maximumRetryTimeInterval {
             worker.error = PostCoordinator.SavingError.maximumRetryTimeIntervalReached
             postDidUpdateNotification(for: post)
-            return worker.log("stopping – failing to upload changes for too long")
+            worker.log("stopping – failing to upload changes for too long")
+            return
         }
 
         guard !worker.isPaused else {
-            return worker.log("start failed: worker is paused")
+            worker.log("start failed: worker is paused")
+            return
         }
 
         if let operation = worker.operation {
             guard operation.revision != revision else {
-                return worker.log("already syncing to the latest revision")
+                worker.log("already syncing to the latest revision")
+                return
             }
             tryCancelSyncOperation(operation)
             guard operation.isCancelled else {
-                return worker.log("waiting until the current operation finishes")
+                worker.log("waiting until the current operation finishes")
+                return
             }
         } else {
             worker.retryTimer?.invalidate()

--- a/WordPress/Classes/Services/PostRepository.swift
+++ b/WordPress/Classes/Services/PostRepository.swift
@@ -119,7 +119,8 @@ final class PostRepository {
     func sync(_ post: AbstractPost, revision: AbstractPost? = nil) async throws {
         wpAssert(post.original == nil, "Must be called on an original post")
         guard let revision = revision ?? post.getLatestRevisionNeedingSync() else {
-            return wpAssertionFailure("Requires a revision")
+            wpAssertionFailure("Requires a revision")
+            return
         }
         try await _sync(post, revision: revision)
     }
@@ -330,7 +331,8 @@ final class PostRepository {
             context.deleteObject(post)
             ContextManager.shared.saveContextAndWait(context)
 
-            return wpAssertionFailure("Trying to patch a non-existent post")
+            wpAssertionFailure("Trying to patch a non-existent post")
+            return
         }
         try await getRemoteService(for: post.blog).deletePost(withID: postID.intValue)
 

--- a/WordPress/Classes/System/ReaderWindowManager.swift
+++ b/WordPress/Classes/System/ReaderWindowManager.swift
@@ -26,7 +26,8 @@ class ReaderWindowManager: WindowManager {
 
     private func continueWithDotComTapped() {
         guard let presentingViewController = UIViewController.topViewController else {
-            return wpAssertionFailure("missing top view controller")
+            wpAssertionFailure("missing top view controller")
+            return
         }
         Task { @MainActor [weak self] in
             let accountID = await WordPressDotComAuthenticator().signIn(from: presentingViewController, context: .default)

--- a/WordPress/Classes/System/Root View/ReaderPresenter.swift
+++ b/WordPress/Classes/System/Root View/ReaderPresenter.swift
@@ -327,7 +327,8 @@ private extension UINavigationController {
     // A workaround for https://a8c.sentry.io/issues/3140539221.
     func safePushViewController(_ viewController: UIViewController, animated: Bool) {
         guard !children.contains(viewController) else {
-            return wpAssertionFailure("pushing the same view controller more than once", userInfo: ["viewController": "\(viewController)"])
+            wpAssertionFailure("pushing the same view controller more than once", userInfo: ["viewController": "\(viewController)"])
+            return
         }
         pushViewController(viewController, animated: animated)
     }

--- a/WordPress/Classes/System/Root View/RootViewPresenter.swift
+++ b/WordPress/Classes/System/Root View/RootViewPresenter.swift
@@ -34,7 +34,8 @@ extension RootViewPresenter {
 
     func showStats(for blog: Blog, source: BlogDetailsNavigationSource? = nil, tab: StatsTabType? = nil, unit: StatsPeriodUnit? = nil, date: Date? = nil) {
         guard JetpackFeaturesRemovalCoordinator.shouldShowJetpackFeatures() else {
-            return showJetpackOverlayForDisabledEntryPoint()
+            showJetpackOverlayForDisabledEntryPoint()
+            return
         }
         if let date {
             UserPersistentStoreFactory.instance().set(date, forKey: SiteStatsDashboardViewController.lastSelectedStatsDateKey)

--- a/WordPress/Classes/System/Root View/SplitViewRootPresenter.swift
+++ b/WordPress/Classes/System/Root View/SplitViewRootPresenter.swift
@@ -96,7 +96,8 @@ final class SplitViewRootPresenter: RootViewPresenter {
                     siteContent = SiteSplitViewContent(blog: site)
                     content = siteContent!
                 } catch {
-                    return wpAssertionFailure("selected blog not found")
+                    wpAssertionFailure("selected blog not found")
+                    return
                 }
             }
         case .notifications:

--- a/WordPress/Classes/System/WordPressAppDelegate.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate.swift
@@ -544,7 +544,8 @@ extension WordPressAppDelegate {
 
     private func checkForAppUpdates() {
         guard let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String else {
-            return wpAssertionFailure("No CFBundleShortVersionString found in Info.plist")
+            wpAssertionFailure("No CFBundleShortVersionString found in Info.plist")
+            return
         }
         let coordinator = AppUpdateCoordinator(currentVersion: version)
         Task {

--- a/WordPress/Classes/Utility/In-App Feedback/SubmitFeedbackViewController.swift
+++ b/WordPress/Classes/Utility/In-App Feedback/SubmitFeedbackViewController.swift
@@ -139,7 +139,8 @@ private struct SubmitFeedbackView: View {
         wpAssert(!isInputEmpty)
 
         guard let presentingViewController else {
-            return wpAssertionFailure("presentingViewController missing")
+            wpAssertionFailure("presentingViewController missing")
+            return
         }
 
         isSubmitting = true

--- a/WordPress/Classes/Utility/WebViewController/CookieJar.swift
+++ b/WordPress/Classes/Utility/WebViewController/CookieJar.swift
@@ -18,7 +18,8 @@ extension CookieJar {
     func hasWordPressComAuthCookie(username: String, atomicSite: Bool, completion: @escaping (Bool) -> Void) {
         let url = URL(string: "https://wordpress.com/")!
 
-        return hasWordPressAuthCookie(for: url, username: username, atomicSite: atomicSite, completion: completion)
+        hasWordPressAuthCookie(for: url, username: username, atomicSite: atomicSite, completion: completion)
+        return
     }
 
     func hasWordPressSelfHostedAuthCookie(for url: URL, username: String, completion: @escaping (Bool) -> Void) {
@@ -123,7 +124,8 @@ extension WKHTTPCookieStore: CookieJar {
 
     func setCookies(_ cookies: [HTTPCookie], completion: @escaping () -> Void) {
         guard let cookie = cookies.last else {
-            return completion()
+            completion()
+            return
         }
 
         DispatchQueue.main.async {

--- a/WordPress/Classes/Utility/WebViewController/WebKitViewController.swift
+++ b/WordPress/Classes/Utility/WebViewController/WebKitViewController.swift
@@ -16,7 +16,8 @@ extension WebKitAuthenticatable {
 
     func authenticatedRequest(for url: URL, with cookieJar: CookieJar, completion: @escaping (URLRequest) -> Void) {
         guard let authenticator else {
-            return completion(URLRequest(url: url))
+            completion(URLRequest(url: url))
+            return
         }
 
         DispatchQueue.main.async {

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/BlogDashboardPersonalizeCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/BlogDashboardPersonalizeCardCell.swift
@@ -69,7 +69,8 @@ final class BlogDashboardPersonalizeCardCell: DashboardCollectionViewCell {
 
     @objc private func buttonTapped() {
         guard let blog, let siteID = blog.dotComID?.intValue else {
-            return DDLogError("Failed to show dashboard personalization screen: siteID is missing")
+            DDLogError("Failed to show dashboard personalization screen: siteID is missing")
+            return
         }
         WPAnalytics.track(.dashboardCardItemTapped, properties: ["type": DashboardCard.personalize.rawValue], blog: blog)
         let viewController = UIHostingController(rootView: NavigationView {

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+Swift.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+Swift.swift
@@ -160,7 +160,8 @@ extension BlogDetailsViewController {
         trackEvent(.openedSiteSettings, from: source)
 
         guard let settingsVC = SiteSettingsViewController(blog: blog) else {
-            return wpAssertionFailure("failed to instantiate")
+            wpAssertionFailure("failed to instantiate")
+            return
         }
         settingsVC.navigationItem.largeTitleDisplayMode = .never
 
@@ -192,7 +193,8 @@ extension BlogDetailsViewController {
 
     public func showPeople() {
         guard let controller = PeopleViewController.withJPBannerForBlog(blog) else {
-            return wpAssertionFailure("failed to instantiate")
+            wpAssertionFailure("failed to instantiate")
+            return
         }
         presentationDelegate?.presentBlogDetailsViewController(controller)
     }
@@ -248,7 +250,8 @@ extension BlogDetailsViewController {
         trackEvent(.openedComments, from: source)
 
         guard let commentsVC = CommentsViewController(blog: blog) else {
-            return wpAssertionFailure("failed to instantiate")
+            wpAssertionFailure("failed to instantiate")
+            return
         }
         commentsVC.navigationItem.largeTitleDisplayMode = .never
 
@@ -285,7 +288,8 @@ extension BlogDetailsViewController {
         }
 
         guard let site = JetpackSiteRef(blog: blog) else {
-            return wpAssertionFailure("unexpected blog")
+            wpAssertionFailure("unexpected blog")
+            return
         }
         let controller = PluginDirectoryViewController(site: site)
         controller.navigationItem.largeTitleDisplayMode = .never
@@ -318,7 +322,8 @@ extension BlogDetailsViewController {
 
     public func showDomains(from source: BlogDetailsNavigationSource) {
         guard let presentationDelegate else {
-            return wpAssertionFailure("presentationDelegate mising")
+            wpAssertionFailure("presentationDelegate mising")
+            return
         }
         DomainsDashboardCoordinator.presentDomainsDashboard(
             with: presentationDelegate,
@@ -356,7 +361,8 @@ extension BlogDetailsViewController {
         trackEvent(.openedViewSite, from: source)
 
         guard let string = blog.homeURL, let homeURL = URL(string: string as String) else {
-            return wpAssertionFailure("homeURL missing")
+            wpAssertionFailure("homeURL missing")
+            return
         }
 
         let webViewController = WebViewControllerFactory.controller(

--- a/WordPress/Classes/ViewRelated/Blog/BloggingReminders/BloggingRemindersFlowSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/BloggingReminders/BloggingRemindersFlowSettingsViewController.swift
@@ -447,7 +447,8 @@ private extension BloggingRemindersFlowSettingsViewController {
         }
 
         guard let presentingViewController = navigationController?.presentingViewController else {
-            return wpAssertionFailure("Missing presentingViewController")
+            wpAssertionFailure("Missing presentingViewController")
+            return
         }
         presentingViewController.dismiss(animated: true) {
             alert.present(in: presentingViewController)

--- a/WordPress/Classes/ViewRelated/Blog/My Site/Header/HomeSiteHeaderViewController+SiteActions.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/Header/HomeSiteHeaderViewController+SiteActions.swift
@@ -82,7 +82,8 @@ extension HomeSiteHeaderViewController {
 
     private func personalizeHomeTapped() {
         guard let siteID = blog.dotComID?.intValue else {
-            return DDLogError("Failed to show dashboard personalization screen: siteID is missing")
+            DDLogError("Failed to show dashboard personalization screen: siteID is missing")
+            return
         }
 
         let viewController = UIHostingController(rootView: NavigationView {

--- a/WordPress/Classes/ViewRelated/Blog/Site Picker/BlogList/BlogListSiteView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Picker/BlogList/BlogListSiteView.swift
@@ -86,7 +86,8 @@ final class BlogListSiteViewModel: Identifiable {
 
     func buttonViewTapped() {
         guard let siteURL else {
-            return wpAssertionFailure("missing-url")
+            wpAssertionFailure("missing-url")
+            return
         }
         WPAnalytics.track(.siteListViewTapped)
         UIApplication.shared.open(siteURL)

--- a/WordPress/Classes/ViewRelated/Blog/Site Picker/BlogList/BlogListViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Picker/BlogList/BlogListViewModel.swift
@@ -138,14 +138,16 @@ final class BlogListViewModel: NSObject, ObservableObject {
 
     func refresh() async throws {
         if let task = syncBlogsTask {
-            return try await task.value
+            try await task.value
+            return
         }
         let task = Task {
             defer { syncBlogsTask = nil }
             try await syncBlogs()
         }
         syncBlogsTask = task
-        return try await task.value
+        try await task.value
+        return
     }
 
     @MainActor

--- a/WordPress/Classes/ViewRelated/Blog/Subscribers/Details/SubscriberDetailsView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Subscribers/Details/SubscriberDetailsView.swift
@@ -104,7 +104,8 @@ struct SubscriberDetailsView: View {
 
     private func deleteSubscriber() {
         guard let details else {
-            return wpAssertionFailure("action should not be available until details are loaded")
+            wpAssertionFailure("action should not be available until details are loaded")
+            return
         }
         isDeleting = true
         Task {

--- a/WordPress/Classes/ViewRelated/Comments/Controllers/CommentDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Comments/Controllers/CommentDetailViewController.swift
@@ -427,8 +427,9 @@ private extension CommentDetailViewController {
     func configureHeaderCell() {
         // if the comment is a reply, show the author of the parent comment.
         if let parentComment = self.parentComment ?? notificationParentComment {
-            return headerCell.configure(for: .reply(parentComment.authorForDisplay()),
+            headerCell.configure(for: .reply(parentComment.authorForDisplay()),
                                         subtitle: (parentComment.contentPreviewForDisplay() ?? "").trimmingCharacters(in: .whitespacesAndNewlines))
+            return
         }
 
         // otherwise, if this is a comment to a post, show the post title instead.

--- a/WordPress/Classes/ViewRelated/Comments/Controllers/Create/CommentCreateViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Comments/Controllers/Create/CommentCreateViewModel.swift
@@ -129,7 +129,8 @@ final class CommentCreateViewModel {
 
     func saveDraft(_ content: String) {
         guard let key = makeDraftKey() else { return }
-        return UserDefaults.standard.set(content, forKey: key)
+        UserDefaults.standard.set(content, forKey: key)
+        return
     }
 
     func deleteDraft() {

--- a/WordPress/Classes/ViewRelated/Comments/Views/Detail/CommentCellViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Comments/Views/Detail/CommentCellViewModel.swift
@@ -93,7 +93,8 @@ final class CommentCellViewModel: NSObject {
 
     func buttonLikeTapped() {
         guard let siteID else {
-            return wpAssertionFailure("context missing")
+            wpAssertionFailure("context missing")
+            return
         }
         if comment.isLiked {
             notification != nil ? WPAppAnalytics.track(.notificationsCommentUnliked, blogID: siteID) : CommentAnalytics.trackCommentUnLiked(comment: comment)

--- a/WordPress/Classes/ViewRelated/Comments/Views/Detail/CommentContentTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Comments/Views/Detail/CommentContentTableViewCell.swift
@@ -210,7 +210,8 @@ final class CommentContentTableViewCell: UITableViewCell, NibReusable {
         isEmphasized = true
 
         guard let highlightedBackgroundView else {
-            return wpAssertionFailure("background view not configured")
+            wpAssertionFailure("background view not configured")
+            return
         }
 
         let originalBackgroundColor = highlightedBackgroundView.backgroundColor
@@ -567,7 +568,8 @@ private extension CommentContentTableViewCell {
 
     @objc func likeButtonTapped() {
         guard let viewModel else {
-            return wpAssertionFailure("ViewModel missing")
+            wpAssertionFailure("ViewModel missing")
+            return
         }
         if !viewModel.state.isLiked, let imageView = likeButton.imageView {
             // Animate the changes and then update the model to avoid animation interruptions
@@ -582,7 +584,8 @@ private extension CommentContentTableViewCell {
 
     @objc func showMoreButtonTapped() {
         guard let fullContentHeight else {
-            return wpAssertionFailure("Invalid state")
+            wpAssertionFailure("Invalid state")
+            return
         }
         isContentExpanded = true
         if let commentID = viewModel?.comment.objectID {

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
@@ -893,7 +893,8 @@ extension GutenbergViewController: GutenbergBridgeDelegate {
             showGutenbergWeb(controller)
         } catch {
             DDLogError("Error loading Gutenberg Web with unsupported block: \(error)")
-            return showUnsupportedBlockUnexpectedErrorAlert()
+            showUnsupportedBlockUnexpectedErrorAlert()
+            return
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Gutenberg/Utils/GutenbergExternalMeidaPicker.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Utils/GutenbergExternalMeidaPicker.swift
@@ -77,7 +77,8 @@ extension GutenbergExternalMediaPicker: ExternalMediaPickerViewDelegate {
     /// - Parameter assets: Tenor Media objects to add.
     func insertOnBlock(with assets: [ExternalMediaAsset], source: MediaSource) {
         guard let callback = mediaPickerCallback else {
-            return assertionFailure("Image picked without callback")
+            assertionFailure("Image picked without callback")
+            return
         }
 
         let mediaInfo = assets.compactMap { asset -> MediaInfo? in

--- a/WordPress/Classes/ViewRelated/Gutenberg/Utils/GutenbergFilesAppMediaSource.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Utils/GutenbergFilesAppMediaSource.swift
@@ -62,7 +62,8 @@ extension GutenbergFilesAppMediaSource: UIDocumentPickerDelegate {
 
     func insertOnBlock(with urls: [URL]) {
         guard let callback = mediaPickerCallback else {
-            return assertionFailure("Image picked without callback")
+            assertionFailure("Image picked without callback")
+            return
         }
 
         let mediaInfo = urls.compactMap({ url -> MediaInfo? in

--- a/WordPress/Classes/ViewRelated/Me/Me Main/MeViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/Me Main/MeViewController.swift
@@ -469,17 +469,18 @@ public class MeViewController: UITableViewController {
     }
 
     fileprivate static func refreshAccountDetails(with service: AccountService, account: WPAccount) async throws {
-        return try await withCheckedThrowingContinuation { continuation in
+        try await withCheckedThrowingContinuation { continuation in
             service.updateUserDetails(for: account, success: {
                 continuation.resume()
             }, failure: { error in
                 continuation.resume(throwing: error)
             })
         }
+        return
     }
 
     fileprivate static func refreshAccountSettings(with service: AccountSettingsService) async throws {
-        return try await withCheckedThrowingContinuation { continuation in
+        try await withCheckedThrowingContinuation { continuation in
             service.refreshSettings { result in
                 switch result {
                 case .success: continuation.resume()
@@ -487,6 +488,7 @@ public class MeViewController: UITableViewController {
                 }
             }
         }
+        return
     }
 
     // MARK: - LogOut

--- a/WordPress/Classes/ViewRelated/Media/Lightbox/LightboxImageScrollView.swift
+++ b/WordPress/Classes/ViewRelated/Media/Lightbox/LightboxImageScrollView.swift
@@ -84,7 +84,8 @@ final class LightboxImageScrollView: UIScrollView, UIScrollViewDelegate {
 
     private func configureImageView() {
         guard let image = imageView.image else {
-            return centerImageView()
+            centerImageView()
+            return
         }
 
         let imageViewSize = imageView.frame.size

--- a/WordPress/Classes/ViewRelated/Media/MediaPicker/Menu/MediaPickerMenu+ImagePlayground.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaPicker/Menu/MediaPickerMenu+ImagePlayground.swift
@@ -30,7 +30,8 @@ extension MediaPickerMenu {
         guard let presentingViewController else { return }
 
         guard #available(iOS 18.1, *) else {
-            return wpAssertionFailure("Not available on this platform. Use `isImagePlaygroundAvailable`.")
+            wpAssertionFailure("Not available on this platform. Use `isImagePlaygroundAvailable`.")
+            return
         }
 
         let controller = _ImagePlaygroundController()

--- a/WordPress/Classes/ViewRelated/Media/SiteMedia/Controllers/SiteMediaCollectionViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/SiteMedia/Controllers/SiteMediaCollectionViewController.swift
@@ -190,7 +190,8 @@ final class SiteMediaCollectionViewController: UIViewController, NSFetchedResult
 
     private func updateSelection(_ perform: () -> Void) {
         guard !isBatchSelectionUpdate else {
-            return perform()
+            perform()
+            return
         }
 
         let previousSelection = selectedMedia

--- a/WordPress/Classes/ViewRelated/Post/Controllers/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Controllers/AbstractPostListViewController.swift
@@ -222,7 +222,8 @@ class AbstractPostListViewController: UIViewController,
 
     @objc private func postCoordinatorDidUpdate(_ notification: Foundation.Notification) {
         guard let updatedObjects = (notification.userInfo?[NSUpdatedObjectsKey] as? Set<NSManagedObject>) else {
-            return wpAssertionFailure("missing NSUpdatedObjectsKey")
+            wpAssertionFailure("missing NSUpdatedObjectsKey")
+            return
         }
         let updatedIndexPaths = (tableView.indexPathsForVisibleRows ?? []).filter {
             let cell = tableView.cellForRow(at: $0) as? AbstractPostListCell
@@ -676,7 +677,8 @@ class AbstractPostListViewController: UIViewController,
         }
 
         guard !(post.status == .draft || post.status == .pending) || post.revision != nil else {
-            return performAction()
+            performAction()
+            return
         }
 
         let alert = UIAlertController(title: Strings.Trash.actionTitle, message: Strings.Trash.message(for: post.latest()), preferredStyle: .alert)
@@ -749,7 +751,8 @@ class AbstractPostListViewController: UIViewController,
             SiteStatsInformation.sharedInstance.siteID = blog.dotComID
 
             guard let postURL = post.permaLink.flatMap(URL.init) else {
-                return wpAssertionFailure("permalink missing or invalid")
+                wpAssertionFailure("permalink missing or invalid")
+                return
             }
             let postStatsTableViewController = PostStatsTableViewController.withJPBannerForBlog(postID: postID,
                                                                                                 postTitle: post.titleForDisplay(),

--- a/WordPress/Classes/ViewRelated/Post/Controllers/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Controllers/PostListViewController.swift
@@ -200,7 +200,8 @@ final class PostListViewController: AbstractPostListViewController, InteractiveP
 
     private func editDuplicatePost(_ post: AbstractPost) {
         guard let post = post.latest() as? Post else {
-            return wpAssertionFailure("unexpected post type")
+            wpAssertionFailure("unexpected post type")
+            return
         }
         PostListEditorPresenter.handleCopy(post: post, in: self)
     }

--- a/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
@@ -73,7 +73,8 @@ extension PublishingEditor {
         WPAnalytics.track(.editorPostSaveDraftTapped)
         mapUIContentToPostAndSave(immediate: true)
         guard !isUploadingMedia else {
-            return displayMediaIsUploadingAlert()
+            displayMediaIsUploadingAlert()
+            return
         }
         performUpdateAction(analyticsStat: .editorSavedDraft)
     }
@@ -90,12 +91,14 @@ extension PublishingEditor {
             showPublishingConfirmation(for: action, analyticsStat: analyticsStat)
         case .update:
             guard !isUploadingMedia else {
-                return displayMediaIsUploadingAlert()
+                displayMediaIsUploadingAlert()
+                return
             }
             performUpdateAction(analyticsStat: .editorUpdatedPost)
         case .submitForReview:
             guard !isUploadingMedia else {
-                return displayMediaIsUploadingAlert()
+                displayMediaIsUploadingAlert()
+                return
             }
             var changes = RemotePostUpdateParameters()
             changes.status = Post.Status.pending.rawValue
@@ -190,7 +193,8 @@ extension PublishingEditor {
         stopEditing()
 
         guard editorHasChanges && editorHasContent else {
-            return discardAndDismiss()
+            discardAndDismiss()
+            return
         }
 
         if post.getOriginal().isStatus(in: [.draft, .pending]) {
@@ -324,7 +328,8 @@ extension PublishingEditor {
 
     func createRevisionOfPost(loadAutosaveRevision: Bool = false) {
         guard let managedObjectContext = post.managedObjectContext else {
-            return wpAssertionFailure("managedObjectContext is missing")
+            wpAssertionFailure("managedObjectContext is missing")
+            return
         }
 
         wpAssert(post.latest() == post, "Must be opened with the latest verison of the post")

--- a/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsViewModel.swift
@@ -517,7 +517,8 @@ final class PostSettingsViewModel: NSObject, ObservableObject, PostSettingsViewM
 
     private func showSocialSharingSetupScreen() {
         guard let sharingVC = SharingViewController(blog: blog, delegate: self) else {
-            return wpAssertionFailure("failed to instantiate SharingVC")
+            wpAssertionFailure("failed to instantiate SharingVC")
+            return
         }
         track(.jetpackSocialNoConnectionCTATapped)
         let navigationVC = UINavigationController(rootViewController: sharingVC)
@@ -535,7 +536,8 @@ final class PostSettingsViewModel: NSObject, ObservableObject, PostSettingsViewM
     func showSocialSharingOptions() {
         guard let blogID = blog.dotComID?.intValue,
               let settings = settings.sharing else {
-            return wpAssertionFailure("invalid context")
+            wpAssertionFailure("invalid context")
+            return
         }
         let optionsVC = PrepublishingSocialAccountsViewController(
             blogID: blogID,
@@ -632,7 +634,8 @@ extension PostSettingsViewModel: @MainActor PrepublishingSocialAccountsDelegate 
 
     func didFinish(with connectionChanges: [Int: Bool], message: String?) {
         guard var settings = settings.sharing else {
-            return wpAssertionFailure("social sharing settings missing")
+            wpAssertionFailure("social sharing settings missing")
+            return
         }
         settings.services = settings.services.map {
             var service = $0

--- a/WordPress/Classes/ViewRelated/Post/PostSettings/Views/Excerpt/PostSettingsGenerateExcerptView.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettings/Views/Excerpt/PostSettingsGenerateExcerptView.swift
@@ -245,7 +245,8 @@ struct PostSettingsGenerateExcerptView: View {
 
     private func generateMoreExcerpts() {
         guard let session else {
-            return wpAssertionFailure("session missing")
+            wpAssertionFailure("session missing")
+            return
         }
         generationTask = Task {
             do {

--- a/WordPress/Classes/ViewRelated/Post/PostSettings/Views/PostSettingsFeaturedImageRow.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettings/Views/PostSettingsFeaturedImageRow.swift
@@ -171,7 +171,8 @@ public final class PostSettingsFeaturedImageViewModel: ObservableObject {
         WPAnalytics.track(.editorPostFeaturedImageChanged, properties: ["via": "settings", "action": "added", "source": selection.source.rawValue])
 
         guard let item = selection.items.first else {
-            return wpAssertionFailure("selection is empty")
+            wpAssertionFailure("selection is empty")
+            return
         }
         switch item.exported() {
         case .asset(let exportableAsset):
@@ -184,7 +185,8 @@ public final class PostSettingsFeaturedImageViewModel: ObservableObject {
                 media = coordinator.addMedia(from: exportableAsset, to: blog, suppressSuccessNotice: true)
             }
             guard let media else {
-                return wpAssertionFailure("failed to add media")
+                wpAssertionFailure("failed to add media")
+                return
             }
             self.receipt = coordinator.addObserver({ [weak self] media, state in
                 self?.didUpdateUploadState(state, media: media)

--- a/WordPress/Classes/ViewRelated/Post/Utils/PostNoticeNavigationCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Post/Utils/PostNoticeNavigationCoordinator.swift
@@ -23,7 +23,8 @@ class PostNoticeNavigationCoordinator {
 
     private static func presentViewPage(for page: Page) {
         guard let presenter = UIApplication.shared.delegate?.window??.topmostPresentedViewController else {
-            return wpAssertionFailure("presenter missing")
+            wpAssertionFailure("presenter missing")
+            return
         }
 
         let controller = PreviewWebKitViewController(post: page, source: "post_notice_preview")
@@ -39,7 +40,8 @@ class PostNoticeNavigationCoordinator {
 
     private static func presentPostEpilogue(for post: Post) {
         guard let presenter = UIApplication.shared.delegate?.window??.topmostPresentedViewController else {
-            return wpAssertionFailure("presenter missing")
+            wpAssertionFailure("presenter missing")
+            return
         }
 
         let context = PostNoticePublishSuccessView.Context()

--- a/WordPress/Classes/ViewRelated/Post/Utils/PostNoticePublishSuccessView.swift
+++ b/WordPress/Classes/ViewRelated/Post/Utils/PostNoticePublishSuccessView.swift
@@ -114,7 +114,8 @@ struct PostNoticePublishSuccessView: View {
 
     private func buttonViewTapped() {
         guard let presenter = context.viewController else {
-            return wpAssertionFailure("presenter missing")
+            wpAssertionFailure("presenter missing")
+            return
         }
         WPAnalytics.track(.postEpilogueView)
         let controller = PreviewWebKitViewController(post: post, source: "edit_post_preview")
@@ -125,7 +126,8 @@ struct PostNoticePublishSuccessView: View {
 
     private func buttonShareTapped() {
         guard let presenter = context.viewController else {
-            return wpAssertionFailure("presenter missing")
+            wpAssertionFailure("presenter missing")
+            return
         }
         WPAnalytics.track(.postEpilogueShare)
         let shareController = PostSharingController()
@@ -134,7 +136,8 @@ struct PostNoticePublishSuccessView: View {
 
     private func buttonBlazeTapped() {
         guard let presenter = context.viewController else {
-            return wpAssertionFailure("presenter missing")
+            wpAssertionFailure("presenter missing")
+            return
         }
         BlazeEventsTracker.trackEntryPointTapped(for: .publishSuccessView)
         BlazeFlowCoordinator.presentBlaze(in: presenter, source: .publishSuccessView, blog: post.blog, post: post)

--- a/WordPress/Classes/ViewRelated/Reader/Cards/ReaderPostCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Cards/ReaderPostCell.swift
@@ -264,7 +264,8 @@ private final class ReaderPostCellView: UIView {
 
     @objc private func buttonLikeTapped() {
         guard let viewModel else {
-            return wpAssertionFailure("missing ViewModel")
+            wpAssertionFailure("missing ViewModel")
+            return
         }
         if !viewModel.toolbar.isLiked {
             var toolbar = viewModel.toolbar

--- a/WordPress/Classes/ViewRelated/Reader/Cards/ReaderRecommendedSitesCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Cards/ReaderRecommendedSitesCell.swift
@@ -141,14 +141,16 @@ private final class ReaderRecommendedSitesCellView: UIView {
 
     @objc private func buttonShowDetailsTapped() {
         guard let site else {
-            return wpAssertionFailure("site missing")
+            wpAssertionFailure("site missing")
+            return
         }
         delegate?.didSelect(topic: site)
     }
 
     @objc private func buttonSubscribeTapped() {
         guard let site else {
-            return wpAssertionFailure("site missing")
+            wpAssertionFailure("site missing")
+            return
         }
 
         var properties = [String: Any]()

--- a/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.swift
@@ -148,7 +148,8 @@ final class ReaderCommentsViewController: UIViewController, WPContentSyncHelperD
 
     private func fetchPost() {
         guard let postID, let siteID else {
-            return wpAssertionFailure("missing parameters")
+            wpAssertionFailure("missing parameters")
+            return
         }
 
         let service = ReaderPostService(coreDataStack: ContextManager.shared)
@@ -254,7 +255,8 @@ final class ReaderCommentsViewController: UIViewController, WPContentSyncHelperD
 
     func syncHelper(_ syncHelper: WPContentSyncHelper, syncContentWithUserInteraction userInteraction: Bool, success: ((Bool) -> Void)?, failure: ((NSError) -> Void)?) {
         guard let post else {
-            return wpAssertionFailure("post missing")
+            wpAssertionFailure("post missing")
+            return
         }
 
         self.fetchCommentsError = nil
@@ -269,7 +271,8 @@ final class ReaderCommentsViewController: UIViewController, WPContentSyncHelperD
 
     func syncHelper(_ syncHelper: WPContentSyncHelper, syncMoreWithSuccess success: ((Bool) -> Void)?, failure: ((NSError) -> Void)?) {
         guard let post else {
-            return wpAssertionFailure("post missing")
+            wpAssertionFailure("post missing")
+            return
         }
 
         self.fetchCommentsError = nil
@@ -297,7 +300,8 @@ final class ReaderCommentsViewController: UIViewController, WPContentSyncHelperD
 
     private func buttonAddCommentTapped() {
         guard let post else {
-            return wpAssertionFailure("post missing")
+            wpAssertionFailure("post missing")
+            return
         }
         let viewModel = CommentCreateViewModel(post: post)
         showCommentComposer(viewModel: viewModel)
@@ -305,7 +309,8 @@ final class ReaderCommentsViewController: UIViewController, WPContentSyncHelperD
 
     func didTapReply(comment: Comment) {
         guard let post else {
-            return wpAssertionFailure("post missing")
+            wpAssertionFailure("post missing")
+            return
         }
         let viewModel = CommentCreateViewModel(post: post, replyingTo: comment)
         showCommentComposer(viewModel: viewModel)
@@ -321,7 +326,8 @@ final class ReaderCommentsViewController: UIViewController, WPContentSyncHelperD
 
     private func presentWebViewController(with url: URL) {
         guard let post else {
-            return wpAssertionFailure("post missing")
+            wpAssertionFailure("post missing")
+            return
         }
         var linkURL = url
         if let components = URLComponents(string: url.absoluteString), components.host == nil, let blogURL = post.blogURL {

--- a/WordPress/Classes/ViewRelated/Reader/Controllers/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Controllers/ReaderStreamViewController.swift
@@ -443,7 +443,8 @@ import AutomatticTracks
             displayLoadingStream()
         }
         guard let tagSlug else {
-            return wpAssertionFailure("tag slug is missing")
+            wpAssertionFailure("tag slug is missing")
+            return
         }
         let service = ReaderTopicService(coreDataStack: ContextManager.shared)
         service.tagTopicForTag(withSlug: tagSlug, success: { [weak self] objectID in

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailCoordinator.swift
@@ -191,7 +191,8 @@ class ReaderDetailCoordinator {
 
     private func startObservingLikes() {
         guard let post else {
-            return wpAssertionFailure("post missing")
+            wpAssertionFailure("post missing")
+            return
         }
 
         likesObserver = Publishers.CombineLatest(

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -1479,7 +1479,8 @@ extension ReaderDetailViewController: BorderedButtonTableViewCellDelegate {
 
     func buttonLeaveCommentTapped(replyingTo comment: Comment?) {
         guard let post else {
-            return wpAssertionFailure("post missing")
+            wpAssertionFailure("post missing")
+            return
         }
         let viewModel = CommentCreateViewModel(post: post, replyingTo: comment)
         let composerVC = CommentCreateViewController(viewModel: viewModel)

--- a/WordPress/Classes/ViewRelated/Reader/Subscriptions/ReaderSubscriptionsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Subscriptions/ReaderSubscriptionsViewModel.swift
@@ -29,7 +29,8 @@ final class ReaderSubscriptionsViewModel: ObservableObject {
             await _refresh()
         }
         refreshTask = task
-        return await task.value
+        await task.value
+        return
     }
 
     private func _refresh() async {

--- a/WordPress/Classes/ViewRelated/Stats/Subscribers/StatsSubscribersViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Subscribers/StatsSubscribersViewController.swift
@@ -87,10 +87,12 @@ extension StatsSubscribersViewController: SiteStatsPeriodDelegate {
             WPAnalytics.track(.statsSubscribersViewMoreTapped)
 
             guard let blog = RootViewCoordinator.sharedPresenter.currentlyVisibleBlog() else {
-                return wpAssertionFailure("blog missing")
+                wpAssertionFailure("blog missing")
+                return
             }
             guard let subscribersBlog = SubscribersBlog(blog: blog) else {
-                return wpAssertionFailure("unsupported blog")
+                wpAssertionFailure("unsupported blog")
+                return
             }
             let subscribersVC = SubscribersViewController(blog: subscribersBlog)
             navigationController?.pushViewController(subscribersVC, animated: true)

--- a/WordPress/Classes/ViewRelated/Tags/TagsService.swift
+++ b/WordPress/Classes/ViewRelated/Tags/TagsService.swift
@@ -123,13 +123,14 @@ class TagsService: TaxonomyServiceProtocol {
             throw TagsServiceError.invalidTag
         }
 
-        return try await withCheckedThrowingContinuation { continuation in
+        try await withCheckedThrowingContinuation { continuation in
             remote.delete(tag, success: {
                 continuation.resume()
             }, failure: { error in
                 continuation.resume(throwing: error)
             })
         }
+        return
     }
 
     func getTerms(ids: [Int64]) async throws -> [AnyTermWithViewContext] {

--- a/WordPress/WordPressShareExtension/Sources/Extensions/Tracks+ShareExtension.swift
+++ b/WordPress/WordPressShareExtension/Sources/Extensions/Tracks+ShareExtension.swift
@@ -56,7 +56,8 @@ extension Tracks {
 
     private func trackExtensionEvent(_ event: ExtensionEvents, properties: [String: AnyObject]? = nil) {
         guard let namespace = Bundle.main.object(forInfoDictionaryKey: "WPAppExtensionType") as? String else {
-            return assertionFailure("WPAppExtensionType missing")
+            assertionFailure("WPAppExtensionType missing")
+            return
         }
         let eventName = "\(namespace)_extension_\(event.rawValue)"
         track(eventName, properties: properties)


### PR DESCRIPTION
## Description

Enable the SwiftLint [`return_value_from_void_function`](https://realm.github.io/SwiftLint/return_value_from_void_function.html) rule and resolve all 129 existing violations across the codebase.

- The rule disallows `return <expr>` inside a function whose return type is `Void`. The expression is usually a no-op call to another Void function; splitting it into two statements makes intent explicit and avoids the trap of accidentally returning a non-Void value from a Void function later.
- SwiftLint auto-fixed 128 violations mechanically (each `return foo()` becomes `foo()` followed by `return`).
- One manual fix in `BlogListViewModel.refresh()`: the early-out had `return try await task.value`; rewritten as two statements so the function no longer returns the value.
- No agentic edits beyond that single split. Nothing left for human review.

Part of the [Orchard SwiftLint rollout campaign](https://github.com/Automattic/orchard-swiftlint-campaign).

## Testing instructions

- CI build + lint should pass.
- Optional spot-check: open one of the touched files (e.g. `PostEditor+Publish.swift`) and confirm the `guard !isUploadingMedia else { ... }` blocks still behave the same — the only change is statement order on the early-out branch.