### PR TITLE
Enable SwiftLint rule: explicit_init

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -57,6 +57,9 @@ only_rules:
   # Prefer checking `isEmpty` over comparing to empty string literal `""`.
   - empty_string
 
+  # Avoid explicitly calling `.init()`; prefer `Type(...)` over `Type.init(...)`.
+  - explicit_init
+
   # Prefer `first(where:)` over `filter { }.first`.
   - first_where
 

--- a/Modules/Sources/WordPressKitModels/RemoteUser+Likes.swift
+++ b/Modules/Sources/WordPressKitModels/RemoteUser+Likes.swift
@@ -33,7 +33,7 @@ import Foundation
 
         preferredBlog = {
             if let preferredBlogDict = dictionary["preferred_blog"] as? [String: Any] {
-                return RemoteLikeUserPreferredBlog.init(dictionary: preferredBlogDict)
+                return RemoteLikeUserPreferredBlog(dictionary: preferredBlogDict)
             }
             return nil
         }()

--- a/Modules/Sources/WordPressKitModels/RemoteVideoPressVideo.swift
+++ b/Modules/Sources/WordPressKitModels/RemoteVideoPressVideo.swift
@@ -54,7 +54,7 @@ import Foundation
         displayEmbed = metadataDict.object(forKey: "display_embed") as? Bool
         allowDownload = metadataDict.object(forKey: "allow_download") as? Bool
         rating = metadataDict.string(forKey: "rating")
-        if let privacySettingValue = metadataDict.number(forKey: "privacy_setting")?.intValue, let privacySettingEnum = VideoPressPrivacySetting.init(rawValue: privacySettingValue) {
+        if let privacySettingValue = metadataDict.number(forKey: "privacy_setting")?.intValue, let privacySettingEnum = VideoPressPrivacySetting(rawValue: privacySettingValue) {
             privacySetting = privacySettingEnum
         }
         if let poster = metadataDict.string(forKey: "poster") {

--- a/Modules/Tests/WordPressSharedTests/WPUserAgentTests.swift
+++ b/Modules/Tests/WordPressSharedTests/WPUserAgentTests.swift
@@ -23,7 +23,7 @@ class WPWPUserAgentTests {
         let userDefaults = UserDefaults.standard
         let appVersion = try #require(Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String)
         let defaultUserAgent = WPUserAgent.defaultUserAgent(userDefaults: userDefaults)
-        let expectedUserAgent = String.init(format: "%@ wp-iphone/%@", defaultUserAgent, appVersion)
+        let expectedUserAgent = String(format: "%@ wp-iphone/%@", defaultUserAgent, appVersion)
 
         #expect(WPUserAgent.wordPressUserAgent(userDefaults: userDefaults) == expectedUserAgent)
     }

--- a/Tests/KeystoneTests/Helpers/ModelTestHelper.swift
+++ b/Tests/KeystoneTests/Helpers/ModelTestHelper.swift
@@ -6,7 +6,7 @@ import WordPressData
 public class ModelTestHelper: NSObject {
     @objc
     public class func insertSelfHostedBlog(context: NSManagedObjectContext) -> Blog {
-        let blog = Blog.init(context: context)
+        let blog = Blog(context: context)
         blog.url = "http://example.com/"
         blog.xmlrpc = "http://example.com/xmlrpc.php"
         return blog
@@ -14,7 +14,7 @@ public class ModelTestHelper: NSObject {
 
     @objc
     public class func insertDotComBlog(context: NSManagedObjectContext) -> Blog {
-        let blog = Blog.init(context: context)
+        let blog = Blog(context: context)
         blog.url = "https://example.wordpress.com/"
         blog.xmlrpc = "https://example.wordpress.com/xmlrpc.php"
         blog.account = insertAccount(context: context)
@@ -23,7 +23,7 @@ public class ModelTestHelper: NSObject {
 
     @objc
     public class func insertAccount(context: NSManagedObjectContext) -> WPAccount {
-        let account = WPAccount.init(context: context)
+        let account = WPAccount(context: context)
         account.username = "test_user"
         return account
     }

--- a/Tests/KeystoneTests/Helpers/NSManagedObject+Fixture.swift
+++ b/Tests/KeystoneTests/Helpers/NSManagedObject+Fixture.swift
@@ -10,7 +10,7 @@ extension NSManagedObject {
     /// - Returns: A new instance with property values of the given JSON file.
     static func fixture(fromFile fileName: String, insertInto context: NSManagedObjectContext) throws -> Self {
         let jsonObject = try JSONObject(fromFileNamed: fileName)
-        let model = Self.init(context: context)
+        let model = Self(context: context)
         for (key, value) in jsonObject {
             model.setValue(value, forKey: key)
         }

--- a/Tests/KeystoneTests/Tests/Features/Domains/AllDomainsListItemViewModelTests.swift
+++ b/Tests/KeystoneTests/Tests/Features/Domains/AllDomainsListItemViewModelTests.swift
@@ -37,7 +37,7 @@ final class AllDomainsListItemViewModelTests: XCTestCase {
     }
 
     func testMappingWithValidDomain() throws {
-        let futureDate = Date.init(timeIntervalSinceNow: 365 * 24 * 60 * 60)
+        let futureDate = Date(timeIntervalSinceNow: 365 * 24 * 60 * 60)
         let iso8601Date = ViewModel.Row.DateFormatters.iso8601.string(from: futureDate)
         let humanReadableDate = ViewModel.Row.DateFormatters.humanReadable.string(from: futureDate)
         self.assert(

--- a/Tests/KeystoneTests/Tests/Features/Stats/StatsMockDataLoader.swift
+++ b/Tests/KeystoneTests/Tests/Features/Stats/StatsMockDataLoader.swift
@@ -9,7 +9,7 @@ struct StatsMockDataLoader {
         let feb21 = DateComponents(year: 2019, month: 2, day: 21)
         let date = Calendar.autoupdatingCurrent.date(from: feb21)!
 
-        let jsonDictionary = try JSONObject.init(fromFileNamed: fileName)
+        let jsonDictionary = try JSONObject(fromFileNamed: fileName)
 
         guard let statsSummaryTimeIntervalData = StatsSummaryTimeIntervalData(
             date: date,

--- a/Tests/WordPressKitTests/CoreAPITests/WordPressComRestApiTests.swift
+++ b/Tests/WordPressKitTests/CoreAPITests/WordPressComRestApiTests.swift
@@ -366,7 +366,7 @@ class WordPressComRestApiTests: XCTestCase {
 
     func testCancelationOfRequest() {
         stub(condition: isRestAPIMediaNewRequest()) { _ in
-            return HTTPStubsResponse.init(error: NSError(domain: NSURLErrorDomain, code: NSURLErrorCancelled, userInfo: nil))
+            return HTTPStubsResponse(error: NSError(domain: NSURLErrorDomain, code: NSURLErrorCancelled, userInfo: nil))
         }
         let expect = self.expectation(description: "One callback should be invoked")
         let api = WordPressComRestApi(oAuthToken: "fakeToken")

--- a/Tests/WordPressKitTests/WordPressKitTests/Tests/IPLocationRemoteTests.swift
+++ b/Tests/WordPressKitTests/WordPressKitTests/Tests/IPLocationRemoteTests.swift
@@ -9,7 +9,7 @@ final class IPLocationRemoteTests: XCTestCase {
         super.setUp()
         let configuration = URLSessionConfiguration.default
         configuration.protocolClasses = [MockURLProtocol.self]
-        let urlSession = URLSession.init(configuration: configuration)
+        let urlSession = URLSession(configuration: configuration)
 
         remote = IPLocationRemote(urlSession: urlSession)
     }

--- a/WordPress/Classes/Models/Blog/BlogSettings+DateAndTimeFormat.swift
+++ b/WordPress/Classes/Models/Blog/BlogSettings+DateAndTimeFormat.swift
@@ -125,7 +125,7 @@ extension BlogSettings {
         // MARK: - Private Properties
 
         fileprivate static var weekdays: [String] {
-            var calendar = Calendar.init(identifier: .gregorian)
+            var calendar = Calendar(identifier: .gregorian)
             calendar.locale = Locale.current
             return calendar.weekdaySymbols
         }

--- a/WordPress/Classes/Services/AccountSettingsService.swift
+++ b/WordPress/Classes/Services/AccountSettingsService.swift
@@ -233,7 +233,7 @@ class AccountSettingsService {
                 return nil
             }
 
-            return AccountSettings.init(managed: managedAccount)
+            return AccountSettings(managed: managedAccount)
         }
     }
 

--- a/WordPress/Classes/Utility/BackgroundTasks/WeeklyRoundupBackgroundTask.swift
+++ b/WordPress/Classes/Utility/BackgroundTasks/WeeklyRoundupBackgroundTask.swift
@@ -368,7 +368,7 @@ class WeeklyRoundupBackgroundTask: BackgroundTask {
 
         // The run date is when the task is scheduled to run, but the period end date is actually
         // the previous day at 24:59:59.
-        let periodEndDate = Calendar.current.date(bySettingHour: 0, minute: 0, second: 0, of: runDate)!.addingTimeInterval(TimeInterval.init(-1))
+        let periodEndDate = Calendar.current.date(bySettingHour: 0, minute: 0, second: 0, of: runDate)!.addingTimeInterval(TimeInterval(-1))
 
         return periodEndDate
     }

--- a/WordPress/Classes/Utility/BackgroundTasks/WeeklyRoundupBackgroundTask.swift
+++ b/WordPress/Classes/Utility/BackgroundTasks/WeeklyRoundupBackgroundTask.swift
@@ -367,7 +367,7 @@ class WeeklyRoundupBackgroundTask: BackgroundTask {
             direction: .backward) ?? Date()
 
         // The run date is when the task is scheduled to run, but the period end date is actually
-        // the previous day at 24:59:59.
+        // the previous day at 23:59:59.
         let periodEndDate = Calendar.current.date(bySettingHour: 0, minute: 0, second: 0, of: runDate)!.addingTimeInterval(TimeInterval(-1))
 
         return periodEndDate

--- a/WordPress/Classes/Utility/BuildInformation/RemoteConfigParameter.swift
+++ b/WordPress/Classes/Utility/BuildInformation/RemoteConfigParameter.swift
@@ -11,7 +11,7 @@ extension RemoteParameter {
                                              overrideStore: RemoteConfigOverrideStore = .init()) -> T? {
         if let overriddenStringValue = overrideStore.overriddenValue(for: self) {
             DDLogInfo("🚩 Returning overridden value for remote config param: \(description).")
-            return T.init(overriddenStringValue)
+            return T(overriddenStringValue)
         }
         if let remoteValue = remoteStore.value(for: key) {
             return remoteValue as? T

--- a/WordPress/Classes/Utility/Sharing/ShareNoticeNavigationCoordinator.swift
+++ b/WordPress/Classes/Utility/Sharing/ShareNoticeNavigationCoordinator.swift
@@ -19,7 +19,7 @@ class ShareNoticeNavigationCoordinator {
     static func presentEditor(for post: Post, source: String) {
         WPAppAnalytics.track(.notificationsShareSuccessEditPost, post: post)
 
-        let editor = EditPostViewController.init(post: post)
+        let editor = EditPostViewController(post: post)
         editor.modalPresentationStyle = .fullScreen
         RootViewCoordinator.sharedPresenter.rootViewController.present(editor, animated: false)
     }

--- a/WordPress/Classes/Utility/Spotlight/SearchManager.swift
+++ b/WordPress/Classes/Utility/Spotlight/SearchManager.swift
@@ -437,7 +437,7 @@ fileprivate extension SearchManager {
     func openEditor(for post: Post) {
         closePreviewIfNeeded(for: post)
         openListView(for: post)
-        let editor = EditPostViewController.init(post: post)
+        let editor = EditPostViewController(post: post)
         editor.modalPresentationStyle = .fullScreen
         RootViewCoordinator.sharedPresenter.rootViewController.present(editor, animated: true)
     }

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/UnknownEditorViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/UnknownEditorViewController.swift
@@ -143,6 +143,6 @@ extension UnknownEditorViewController {
 
     struct Constants {
         static let defaultContentFont = UIFont.systemFont(ofSize: 14)
-        static let defaultContentInsets = UIEdgeInsets.init(top: 0, left: 5, bottom: 0, right: -5)
+        static let defaultContentInsets = UIEdgeInsets(top: 0, left: 5, bottom: 0, right: -5)
     }
 }

--- a/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainDetails/ViewController/RegisterDomainDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainDetails/ViewController/RegisterDomainDetailsViewController.swift
@@ -303,7 +303,7 @@ extension RegisterDomainDetailsViewController {
     private func showItemSelectionPage(onSelectionAt indexPath: IndexPath, title: String, items: [String]) {
         var options: [OptionsTableViewOption] = []
         for item in items {
-            let attributedItem = NSAttributedString.init(
+            let attributedItem = NSAttributedString(
                 string: item,
                 attributes: [.font: WPStyleGuide.tableviewTextFont(),
                              .foregroundColor: UIColor.label]

--- a/WordPress/Classes/ViewRelated/Jetpack/Login/JetpackConnectionViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Login/JetpackConnectionViewModel.swift
@@ -293,11 +293,11 @@ class JetpackConnectionService {
 }
 
 extension PluginSlug {
-    static let jetpack = Self.init(slug: "jetpack/jetpack")
+    static let jetpack = Self(slug: "jetpack/jetpack")
 }
 
 extension PluginWpOrgDirectorySlug {
-    static let jetpack = Self.init(slug: "jetpack")
+    static let jetpack = Self(slug: "jetpack")
 }
 
 enum JetpackConnectionStep: Int, CaseIterable {

--- a/WordPress/Classes/ViewRelated/Notifications/Views/CommentLargeButton.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Views/CommentLargeButton.swift
@@ -41,7 +41,7 @@ final class CommentLargeButton: UIView {
 
         addSubview(leaveCommentView)
         leaveCommentView.displaySettings = .standard
-        leaveCommentView.pinEdges(to: safeAreaLayoutGuide, insets: UIEdgeInsets.init(top: 14, left: 20, bottom: 8, right: 20))
+        leaveCommentView.pinEdges(to: safeAreaLayoutGuide, insets: UIEdgeInsets(top: 14, left: 20, bottom: 8, right: 20))
 
         let divider = SeparatorView.horizontal()
         addSubview(divider)

--- a/WordPress/Classes/ViewRelated/Reader/Cards/ReaderPostCellViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Cards/ReaderPostCellViewModel.swift
@@ -63,7 +63,7 @@ final class ReaderPostCellViewModel {
     }
 
     private init() {
-        self.post = ReaderPost.init(entity: NSEntityDescription.entity(forEntityName: ReaderPost.entityName(), in: ContextManager.shared.mainContext)!, insertInto: nil)
+        self.post = ReaderPost(entity: NSEntityDescription.entity(forEntityName: ReaderPost.entityName(), in: ContextManager.shared.mainContext)!, insertInto: nil)
         self.avatarURL = URL(string: "https://picsum.photos/120/120.jpg")
         self.author = "WordPress Mobile Apps"
         self.time = "9d ago"

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailCommentsHeader.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailCommentsHeader.swift
@@ -54,7 +54,7 @@ class ReaderDetailCommentsHeader: UITableViewHeaderFooterView, NibReusable {
         configureTitle()
         configureButton()
 
-        readerCommentsFollowPresenter = ReaderCommentsFollowPresenter.init(
+        readerCommentsFollowPresenter = ReaderCommentsFollowPresenter(
             post: post,
             delegate: self,
             presentingViewController: presentingViewController
@@ -99,7 +99,7 @@ private extension ReaderDetailCommentsHeader {
         followButton.addTarget(self, action: #selector(followButtonTapped), for: .touchUpInside)
 
         if isSubscribedComments {
-            followButton.setImage(UIImage.init(systemName: "bell"), for: .normal)
+            followButton.setImage(UIImage(systemName: "bell"), for: .normal)
             followButton.setTitle(nil, for: .normal)
         } else {
             followButton.setTitle(Titles.followButton, for: .normal)

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailLikesListController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailLikesListController.swift
@@ -86,7 +86,7 @@ extension ReaderDetailLikesListController: LikesListControllerDelegate {
     }
 
     func showErrorView(title: String, subtitle: String?) {
-        let stateView = UIHostingView(view: EmptyStateView.init(title, systemImage: "exclamationmark.circle", description: subtitle))
+        let stateView = UIHostingView(view: EmptyStateView(title, systemImage: "exclamationmark.circle", description: subtitle))
         view.addSubview(stateView)
         stateView.pinEdges()
     }

--- a/WordPress/Classes/ViewRelated/Reader/Theme/ReaderDisplaySettingViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Theme/ReaderDisplaySettingViewController.swift
@@ -302,7 +302,7 @@ extension ReaderDisplaySettingSelectionView {
                 fontSelectionView
                 sizeSelectionView
                     .padding(.horizontal, .DS.Padding.double)
-                DSButton(title: Strings.doneButton, style: DSButtonStyle.init(emphasis: .primary, size: .large)) {
+                DSButton(title: Strings.doneButton, style: DSButtonStyle(emphasis: .primary, size: .large)) {
                     viewModel.doneButtonTapped()
                 }
                 .padding(.horizontal, .DS.Padding.double)

--- a/WordPress/Classes/ViewRelated/Stats/Helpers/StatsDataHelper.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Helpers/StatsDataHelper.swift
@@ -89,7 +89,7 @@ import WordPressShared
 
     class func childRowsForItems(_ children: [StatsTagAndCategory]) -> [StatsTotalRowData] {
         return children.map {
-            StatsTotalRowData.init(name: $0.name,
+            StatsTotalRowData(name: $0.name,
                                    data: "",
                                    icon: StatsDataHelper.tagsAndCategoriesIconForKind($0.kind),
                                    showDisclosure: true,

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
@@ -357,7 +357,7 @@ extension SiteStatsInsightsTableViewController: SiteStatsInsightsDelegate {
 
     func displayWebViewWithURL(_ url: URL) {
         let webViewController = WebViewControllerFactory.controllerAuthenticatedWithDefaultAccount(url: url, source: "site_stats_insights")
-        let navController = UINavigationController.init(rootViewController: webViewController)
+        let navController = UINavigationController(rootViewController: webViewController)
         present(navController, animated: true)
     }
 

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
@@ -563,12 +563,12 @@ private extension SiteStatsInsightsViewModel {
 
         var dataRows = [StatsTwoColumnRowData]()
 
-        dataRows.append(StatsTwoColumnRowData.init(leftColumnName: AllTimeStats.viewsTitle,
+        dataRows.append(StatsTwoColumnRowData(leftColumnName: AllTimeStats.viewsTitle,
                                                    leftColumnData: allTimeInsight.viewsCount.abbreviatedString(),
                                                    rightColumnName: AllTimeStats.visitorsTitle,
                                                    rightColumnData: allTimeInsight.visitorsCount.abbreviatedString()))
 
-        dataRows.append(StatsTwoColumnRowData.init(leftColumnName: AllTimeStats.postsTitle,
+        dataRows.append(StatsTwoColumnRowData(leftColumnName: AllTimeStats.postsTitle,
                                                    leftColumnData: allTimeInsight.postsCount.abbreviatedString(),
                                                    rightColumnName: AllTimeStats.bestViewsEverTitle,
                                                    rightColumnData: allTimeInsight.bestViewsPerDayCount.abbreviatedString()))
@@ -638,12 +638,12 @@ private extension SiteStatsInsightsViewModel {
 
         var dataRows = [StatsTwoColumnRowData]()
 
-        dataRows.append(StatsTwoColumnRowData.init(leftColumnName: TodaysStats.viewsTitle,
+        dataRows.append(StatsTwoColumnRowData(leftColumnName: TodaysStats.viewsTitle,
                                                    leftColumnData: todaysStats.viewsCount.abbreviatedString(),
                                                    rightColumnName: TodaysStats.visitorsTitle,
                                                    rightColumnData: todaysStats.visitorsCount.abbreviatedString()))
 
-        dataRows.append(StatsTwoColumnRowData.init(leftColumnName: TodaysStats.likesTitle,
+        dataRows.append(StatsTwoColumnRowData(leftColumnName: TodaysStats.likesTitle,
                                                    leftColumnData: todaysStats.likesCount.abbreviatedString(),
                                                    rightColumnName: TodaysStats.commentsTitle,
                                                    rightColumnData: todaysStats.commentsCount.abbreviatedString()))
@@ -684,22 +684,22 @@ private extension SiteStatsInsightsViewModel {
 
         var dataRows = [StatsTwoColumnRowData]()
 
-        dataRows.append(StatsTwoColumnRowData.init(leftColumnName: AnnualSiteStats.year,
+        dataRows.append(StatsTwoColumnRowData(leftColumnName: AnnualSiteStats.year,
                                                    leftColumnData: annualInsights.year,
                                                    rightColumnName: AnnualSiteStats.totalPosts,
                                                    rightColumnData: annualInsights.totalPosts.abbreviatedString()))
 
-        dataRows.append(StatsTwoColumnRowData.init(leftColumnName: AnnualSiteStats.totalComments,
+        dataRows.append(StatsTwoColumnRowData(leftColumnName: AnnualSiteStats.totalComments,
                                                    leftColumnData: annualInsights.totalComments.abbreviatedString(),
                                                    rightColumnName: AnnualSiteStats.commentsPerPost,
                                                    rightColumnData: annualInsights.averageComments.abbreviatedString()))
 
-        dataRows.append(StatsTwoColumnRowData.init(leftColumnName: AnnualSiteStats.totalLikes,
+        dataRows.append(StatsTwoColumnRowData(leftColumnName: AnnualSiteStats.totalLikes,
                                                    leftColumnData: annualInsights.totalLikes.abbreviatedString(),
                                                    rightColumnName: AnnualSiteStats.likesPerPost,
                                                    rightColumnData: annualInsights.averageLikes.abbreviatedString()))
 
-        dataRows.append(StatsTwoColumnRowData.init(leftColumnName: AnnualSiteStats.totalWords,
+        dataRows.append(StatsTwoColumnRowData(leftColumnName: AnnualSiteStats.totalWords,
                                                    leftColumnData: annualInsights.totalWords.abbreviatedString(),
                                                    rightColumnName: AnnualSiteStats.wordsPerPost,
                                                    rightColumnData: annualInsights.averageWords.abbreviatedString()))

--- a/WordPress/Classes/ViewRelated/Stats/Insights/StatsMostPopularTimeInsightsCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/StatsMostPopularTimeInsightsCell.swift
@@ -208,7 +208,7 @@ extension StatsAnnualAndMostPopularTimeInsight {
             return nil
         }
 
-        var calendar = Calendar.init(identifier: .gregorian)
+        var calendar = Calendar(identifier: .gregorian)
         calendar.locale = Locale.autoupdatingCurrent
 
         // Back up mostPopularWeekday by 1 to get correct index for standaloneWeekdaySymbols.
@@ -217,7 +217,7 @@ extension StatsAnnualAndMostPopularTimeInsight {
     }
 
     func formattedMostPopularTime() -> String? {
-        var calendar = Calendar.init(identifier: .gregorian)
+        var calendar = Calendar(identifier: .gregorian)
         calendar.locale = Locale.autoupdatingCurrent
 
         guard let hour = mostPopularHour.hour,

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodTableViewController.swift
@@ -252,7 +252,7 @@ extension SiteStatsPeriodTableViewController: SiteStatsPeriodDelegate {
 
     func displayWebViewWithURL(_ url: URL) {
         let webViewController = WebViewControllerFactory.controllerAuthenticatedWithDefaultAccount(url: url, source: "site_stats_period")
-        let navController = UINavigationController.init(rootViewController: webViewController)
+        let navController = UINavigationController(rootViewController: webViewController)
         present(navController, animated: true)
     }
 

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
@@ -661,7 +661,7 @@ private extension SiteStatsPeriodViewModel {
     }
 
     func publishedDataRows() -> [StatsTotalRowData] {
-        return store.getTopPublished()?.publishedPosts.prefix(10).map { StatsTotalRowData.init(name: $0.title.stringByDecodingXMLCharacters(),
+        return store.getTopPublished()?.publishedPosts.prefix(10).map { StatsTotalRowData(name: $0.title.stringByDecodingXMLCharacters(),
                                                                                                data: "",
                                                                                                showDisclosure: true,
                                                                                                disclosureURL: $0.postURL,

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Post Stats/PostStatsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Post Stats/PostStatsTableViewController.swift
@@ -201,7 +201,7 @@ extension PostStatsTableViewController: PostStatsDelegate {
 
     func displayWebViewWithURL(_ url: URL) {
         let webViewController = WebViewControllerFactory.controllerAuthenticatedWithDefaultAccount(url: url, source: "stats_post_stats")
-        let navController = UINavigationController.init(rootViewController: webViewController)
+        let navController = UINavigationController(rootViewController: webViewController)
         present(navController, animated: true)
     }
 

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailTableViewController.swift
@@ -271,7 +271,7 @@ extension SiteStatsDetailTableViewController: SiteStatsDetailsDelegate {
 
     func displayWebViewWithURL(_ url: URL) {
         let webViewController = WebViewControllerFactory.controllerAuthenticatedWithDefaultAccount(url: url, source: "site_stats_detail")
-        let navController = UINavigationController.init(rootViewController: webViewController)
+        let navController = UINavigationController(rootViewController: webViewController)
         present(navController, animated: true)
     }
 

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsInsightsDetailsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsInsightsDetailsTableViewController.swift
@@ -267,7 +267,7 @@ extension SiteStatsInsightsDetailsTableViewController: SiteStatsDetailsDelegate 
 
     func displayWebViewWithURL(_ url: URL) {
         let webViewController = WebViewControllerFactory.controllerAuthenticatedWithDefaultAccount(url: url, source: "site_stats_detail")
-        let navController = UINavigationController.init(rootViewController: webViewController)
+        let navController = UINavigationController(rootViewController: webViewController)
         present(navController, animated: true)
     }
 

--- a/WordPress/Classes/ViewRelated/Stats/StatsLikesListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/StatsLikesListViewController.swift
@@ -94,7 +94,7 @@ extension StatsLikesListViewController: LikesListControllerDelegate {
     }
 
     func showErrorView(title: String, subtitle: String?) {
-        let stateView = UIHostingView(view: EmptyStateView.init(title, systemImage: "exclamationmark.circle", description: subtitle))
+        let stateView = UIHostingView(view: EmptyStateView(title, systemImage: "exclamationmark.circle", description: subtitle))
         view.addSubview(stateView)
         stateView.pinEdges()
     }

--- a/WordPress/Classes/ViewRelated/Support/SupportTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Support/SupportTableViewController.swift
@@ -82,7 +82,7 @@ class SupportTableViewController: UITableViewController {
     }
 
     func show(from presentingViewController: UIViewController) {
-        let navigationController = UINavigationController.init(rootViewController: self)
+        let navigationController = UINavigationController(rootViewController: self)
 
         if WPDeviceIdentification.isiPad() {
             navigationController.modalTransitionStyle = .crossDissolve
@@ -94,7 +94,7 @@ class SupportTableViewController: UITableViewController {
 
     // TODO: Refactor this method to use the general `show(from:)` method
     func showFromTabBar() {
-        let navigationController = UINavigationController.init(rootViewController: self)
+        let navigationController = UINavigationController(rootViewController: self)
 
         if WPDeviceIdentification.isiPad() {
             navigationController.modalTransitionStyle = .crossDissolve

--- a/WordPress/Classes/ViewRelated/Support/SupportTableViewControllerConfiguration.swift
+++ b/WordPress/Classes/ViewRelated/Support/SupportTableViewControllerConfiguration.swift
@@ -12,7 +12,7 @@ struct SupportTableViewControllerConfiguration {
     // MARK: Default Configurations
 
     static func currentAccountConfiguration() -> Self {
-        var config = Self.init()
+        var config = Self()
         if let account = Self.makeAccount() {
             config.meHeaderConfiguration = .init(account: account)
             config.showsLogOutButton = true

--- a/WordPress/Classes/ViewRelated/Views/BadgeLabel.swift
+++ b/WordPress/Classes/ViewRelated/Views/BadgeLabel.swift
@@ -37,7 +37,7 @@ class BadgeLabel: UILabel {
     // MARK: Padding
 
     override func drawText(in rect: CGRect) {
-        let insets = UIEdgeInsets.init(top: verticalPadding, left: horizontalPadding, bottom: verticalPadding, right: horizontalPadding)
+        let insets = UIEdgeInsets(top: verticalPadding, left: horizontalPadding, bottom: verticalPadding, right: horizontalPadding)
         super.drawText(in: rect.inset(by: insets))
     }
 


### PR DESCRIPTION
## Description

Enables the `explicit_init` SwiftLint rule, which discourages writing `Type.init(...)` when `Type(...)` is sufficient (the contextual init is enough).

- Auto-fixed: 36 violations across 36 files via `bundle exec rake lintfix`.
- Agentic fixes: none.
- Left for human review: none.

Part of the Orchard SwiftLint rollout campaign.

## Testing instructions

CI: build + tests should remain green. The autofix is purely syntactic — it only removes the `.init` token between a type and its argument list.