### PR TITLE
Custom Posts: Support "Access" and "Email to Subscribers" options

### DIFF
--- a/Modules/Sources/WordPressData/Swift/Blog+Features.swift
+++ b/Modules/Sources/WordPressData/Swift/Blog+Features.swift
@@ -53,6 +53,7 @@ import Foundation
     case siteMonitoring
     case publicize
     case shareButtons
+    case jetpackNewsletter
 }
 
 extension Blog {
@@ -134,6 +135,8 @@ extension Blog {
             return supportsPublicize
         case .shareButtons:
             return supportsShareButtons
+        case .jetpackNewsletter:
+            return supportsJetpackNewsletter
         }
     }
 
@@ -171,6 +174,14 @@ private extension Blog {
         } else {
             return isJetpackModuleActive("publicize")
         }
+    }
+
+    var supportsJetpackNewsletter: Bool {
+        guard supportsRestAPI else { return false }
+        if isHostedAtWPcom {
+            return true
+        }
+        return isJetpackModuleActive("subscriptions")
     }
 
     var supportsShareButtons: Bool {

--- a/Modules/Sources/WordPressData/Swift/PostMetadata.swift
+++ b/Modules/Sources/WordPressData/Swift/PostMetadata.swift
@@ -20,6 +20,11 @@ public struct PostMetadata: Hashable {
         self.isJetpackNewsletterEmailDisabled = container.getAdaptiveBool(for: .jetpackNewsletterEmailDisabled)
     }
 
+    public init(accessLevel: JetpackPostAccessLevel?, isJetpackNewsletterEmailDisabled: Bool = false) {
+        self.accessLevel = accessLevel
+        self.isJetpackNewsletterEmailDisabled = isJetpackNewsletterEmailDisabled
+    }
+
     /// Applies the metadata values to the container and returns them
     /// as metadata values.
     public func encode(in container: inout PostMetadataContainer) {

--- a/Modules/Sources/WordPressData/Swift/PostMetadata.swift
+++ b/Modules/Sources/WordPressData/Swift/PostMetadata.swift
@@ -28,7 +28,10 @@ public struct PostMetadata: Hashable {
             container.accessLevel = accessLevel
         }
         if previous.isJetpackNewsletterEmailDisabled != isJetpackNewsletterEmailDisabled {
-            container.setValue(String(describing: isJetpackNewsletterEmailDisabled), for: .jetpackNewsletterEmailDisabled)
+            container.setValue(
+                String(describing: isJetpackNewsletterEmailDisabled),
+                for: .jetpackNewsletterEmailDisabled
+            )
         }
     }
 

--- a/Modules/Tests/WordPressDataTests/PostMetadataTests.swift
+++ b/Modules/Tests/WordPressDataTests/PostMetadataTests.swift
@@ -81,6 +81,23 @@ struct PostMetadataTests {
         // THEN
         #expect(container.getString(for: .jetpackNewsletterEmailDisabled)?.isEmpty == true)
     }
+
+    @Test("memberwise init populates accessLevel and isJetpackNewsletterEmailDisabled")
+    func memberwiseInit() {
+        let metadata = PostMetadata(
+            accessLevel: .paidSubscribers,
+            isJetpackNewsletterEmailDisabled: true
+        )
+        #expect(metadata.accessLevel == .paidSubscribers)
+        #expect(metadata.isJetpackNewsletterEmailDisabled)
+    }
+
+    @Test("memberwise init defaults isJetpackNewsletterEmailDisabled to false when omitted")
+    func memberwiseInitDefaults() {
+        let metadata = PostMetadata(accessLevel: nil)
+        #expect(metadata.accessLevel == nil)
+        #expect(!metadata.isJetpackNewsletterEmailDisabled)
+    }
 }
 
 private extension PostMetadata {

--- a/Tests/KeystoneTests/Tests/Features/Posts/CustomPostSettingsViewModelTests.swift
+++ b/Tests/KeystoneTests/Tests/Features/Posts/CustomPostSettingsViewModelTests.swift
@@ -191,6 +191,41 @@ struct CustomPostSettingsViewModelTests {
         #expect(viewModel.v2SocialSharing == nil)
         #expect(viewModel.getSettingsToSave(for: viewModel.settings).socialSharingDraft == nil)
     }
+
+    // MARK: - shouldShow Jetpack rows
+
+    @Test("shouldShow .jetpackAccessLevel is true for post type on wpcom site")
+    func shouldShowAccessLevelTrue() throws {
+        let viewModel = try makeViewModel(postTypeSlug: "post", wpComRESTAPI: true)
+        #expect(viewModel.shouldShow(.jetpackAccessLevel))
+    }
+
+    @Test("shouldShow .jetpackAccessLevel is false for non-post type")
+    func shouldShowAccessLevelFalseForNonPost() throws {
+        let viewModel = try makeViewModel(postTypeSlug: "page", wpComRESTAPI: true)
+        #expect(!viewModel.shouldShow(.jetpackAccessLevel))
+    }
+
+    @Test("shouldShow .jetpackAccessLevel is false on non-wpcom site")
+    func shouldShowAccessLevelFalseForNonWpcom() throws {
+        let viewModel = try makeViewModel(postTypeSlug: "post", wpComRESTAPI: false)
+        #expect(!viewModel.shouldShow(.jetpackAccessLevel))
+    }
+
+    @Test("shouldShow .jetpackNewsletterEmailOptions is true only in publishing context")
+    func shouldShowNewsletterTrueOnlyInPublishing() throws {
+        let publishingVM = try makeViewModel(postTypeSlug: "post", wpComRESTAPI: true, context: .publishing)
+        #expect(publishingVM.shouldShow(.jetpackNewsletterEmailOptions))
+
+        let settingsVM = try makeViewModel(postTypeSlug: "post", wpComRESTAPI: true, context: .settings)
+        #expect(!settingsVM.shouldShow(.jetpackNewsletterEmailOptions))
+    }
+
+    @Test("shouldShow .jetpackNewsletterEmailOptions is false for non-post type")
+    func shouldShowNewsletterFalseForNonPost() throws {
+        let viewModel = try makeViewModel(postTypeSlug: "page", wpComRESTAPI: true, context: .publishing)
+        #expect(!viewModel.shouldShow(.jetpackNewsletterEmailOptions))
+    }
 }
 
 // MARK: - Test Helpers
@@ -295,7 +330,43 @@ private func makeConnectionsService() -> SiteSocialConnectionsService {
     )
 }
 
-private func makePostTypeDetails(supportsPublicize: Bool = true) -> PostTypeDetailsWithEditContext {
+@MainActor
+private func makeViewModel(
+    postTypeSlug: String,
+    wpComRESTAPI: Bool,
+    context: PostSettingsContext = .settings
+) throws -> CustomPostSettingsViewModel {
+    let coreData = ContextManager.forTesting().mainContext
+    let builder = BlogBuilder(coreData)
+    let blog: Blog
+    if wpComRESTAPI {
+        blog = builder.withAnAccount().build()
+    } else {
+        blog = builder.build()
+    }
+    let post = try makePostWithDisabledConnection()
+    let details = makePostTypeDetails(supportsPublicize: true, slug: postTypeSlug)
+    let dependencies = try makeServiceDependencies()
+    let editorService = CustomPostEditorService(
+        blog: blog,
+        post: post,
+        details: details,
+        client: dependencies.client,
+        wpService: dependencies.wpService,
+        initialSettings: nil
+    )
+    return CustomPostSettingsViewModel(
+        editorService: editorService,
+        blog: blog,
+        socialConnectionsService: nil,
+        context: context
+    )
+}
+
+private func makePostTypeDetails(
+    supportsPublicize: Bool = true,
+    slug: String = "test_post_type"
+) -> PostTypeDetailsWithEditContext {
     var supports: [PostTypeSupports: JsonValue] = [
         .title: .bool(true),
         .editor: .bool(true)
@@ -311,11 +382,11 @@ private func makePostTypeDetails(supportsPublicize: Bool = true) -> PostTypeDeta
         viewable: true,
         labels: makePostTypeLabels(),
         name: "Test Post Type",
-        slug: "test_post_type",
+        slug: slug,
         supports: PostTypeSupportsMap(map: supports),
         hasArchive: .bool(false),
         taxonomies: [],
-        restBase: "test_post_type",
+        restBase: slug,
         restNamespace: "wp/v2",
         visibility: PostTypeVisibility(showInNavMenus: true, showUi: true),
         icon: nil

--- a/Tests/KeystoneTests/Tests/Features/Posts/CustomPostSettingsViewModelTests.swift
+++ b/Tests/KeystoneTests/Tests/Features/Posts/CustomPostSettingsViewModelTests.swift
@@ -194,36 +194,36 @@ struct CustomPostSettingsViewModelTests {
 
     // MARK: - shouldShow Jetpack rows
 
-    @Test("shouldShow .jetpackAccessLevel is true for post type on wpcom site")
+    @Test("shouldShow .jetpackAccessLevel is true for post type when Jetpack newsletter is available")
     func shouldShowAccessLevelTrue() throws {
-        let viewModel = try makeViewModel(postTypeSlug: "post", wpComRESTAPI: true)
+        let viewModel = try makeViewModel(postTypeSlug: "post", jetpackNewsletter: true)
         #expect(viewModel.shouldShow(.jetpackAccessLevel))
     }
 
     @Test("shouldShow .jetpackAccessLevel is false for non-post type")
     func shouldShowAccessLevelFalseForNonPost() throws {
-        let viewModel = try makeViewModel(postTypeSlug: "page", wpComRESTAPI: true)
+        let viewModel = try makeViewModel(postTypeSlug: "page", jetpackNewsletter: true)
         #expect(!viewModel.shouldShow(.jetpackAccessLevel))
     }
 
-    @Test("shouldShow .jetpackAccessLevel is false on non-wpcom site")
-    func shouldShowAccessLevelFalseForNonWpcom() throws {
-        let viewModel = try makeViewModel(postTypeSlug: "post", wpComRESTAPI: false)
+    @Test("shouldShow .jetpackAccessLevel is false when Jetpack newsletter is unavailable")
+    func shouldShowAccessLevelFalseWithoutNewsletter() throws {
+        let viewModel = try makeViewModel(postTypeSlug: "post", jetpackNewsletter: false)
         #expect(!viewModel.shouldShow(.jetpackAccessLevel))
     }
 
     @Test("shouldShow .jetpackNewsletterEmailOptions is true only in publishing context")
     func shouldShowNewsletterTrueOnlyInPublishing() throws {
-        let publishingVM = try makeViewModel(postTypeSlug: "post", wpComRESTAPI: true, context: .publishing)
+        let publishingVM = try makeViewModel(postTypeSlug: "post", jetpackNewsletter: true, context: .publishing)
         #expect(publishingVM.shouldShow(.jetpackNewsletterEmailOptions))
 
-        let settingsVM = try makeViewModel(postTypeSlug: "post", wpComRESTAPI: true, context: .settings)
+        let settingsVM = try makeViewModel(postTypeSlug: "post", jetpackNewsletter: true, context: .settings)
         #expect(!settingsVM.shouldShow(.jetpackNewsletterEmailOptions))
     }
 
     @Test("shouldShow .jetpackNewsletterEmailOptions is false for non-post type")
     func shouldShowNewsletterFalseForNonPost() throws {
-        let viewModel = try makeViewModel(postTypeSlug: "page", wpComRESTAPI: true, context: .publishing)
+        let viewModel = try makeViewModel(postTypeSlug: "page", jetpackNewsletter: true, context: .publishing)
         #expect(!viewModel.shouldShow(.jetpackNewsletterEmailOptions))
     }
 }
@@ -333,16 +333,16 @@ private func makeConnectionsService() -> SiteSocialConnectionsService {
 @MainActor
 private func makeViewModel(
     postTypeSlug: String,
-    wpComRESTAPI: Bool,
+    jetpackNewsletter: Bool,
     context: PostSettingsContext = .settings
 ) throws -> CustomPostSettingsViewModel {
     let coreData = ContextManager.forTesting().mainContext
     let builder = BlogBuilder(coreData)
     let blog: Blog
-    if wpComRESTAPI {
-        blog = builder.withAnAccount().build()
+    if jetpackNewsletter {
+        blog = builder.withAnAccount().with(modules: ["subscriptions"]).build()
     } else {
-        blog = builder.build()
+        blog = builder.withAnAccount().build()
     }
     let post = try makePostWithDisabledConnection()
     let details = makePostTypeDetails(supportsPublicize: true, slug: postTypeSlug)

--- a/Tests/KeystoneTests/Tests/Features/Posts/CustomPostSettingsViewModelTests.swift
+++ b/Tests/KeystoneTests/Tests/Features/Posts/CustomPostSettingsViewModelTests.swift
@@ -344,6 +344,7 @@ private func makeViewModel(
     } else {
         blog = builder.withAnAccount().build()
     }
+    try coreData.save()
     let post = try makePostWithDisabledConnection()
     let details = makePostTypeDetails(supportsPublicize: true, slug: postTypeSlug)
     let dependencies = try makeServiceDependencies()

--- a/Tests/KeystoneTests/Tests/Features/Posts/PostMetaJetpackNewsletterTests.swift
+++ b/Tests/KeystoneTests/Tests/Features/Posts/PostMetaJetpackNewsletterTests.swift
@@ -1,0 +1,61 @@
+import Testing
+import Foundation
+import WordPressAPIInternal
+import WordPressData
+
+@testable import WordPress
+
+struct PostMetaJetpackNewsletterTests {
+
+    // MARK: - Access Level
+
+    @Test("addingJetpackNewsletterAccess round-trips through jetpackNewsletterAccess")
+    func accessLevelRoundTrip() {
+        let meta = PostMeta().addingJetpackNewsletterAccess(.subscribers)
+        #expect(meta.jetpackNewsletterAccess == .subscribers)
+    }
+
+    @Test("addingJetpackNewsletterAccess supports paid_subscribers")
+    func accessLevelPaidSubscribers() {
+        let meta = PostMeta().addingJetpackNewsletterAccess(.paidSubscribers)
+        #expect(meta.jetpackNewsletterAccess == .paidSubscribers)
+    }
+
+    @Test("addingJetpackNewsletterAccess with nil clears the value")
+    func accessLevelClear() {
+        let meta = PostMeta()
+            .addingJetpackNewsletterAccess(.subscribers)
+            .addingJetpackNewsletterAccess(nil)
+        #expect(meta.jetpackNewsletterAccess == nil)
+    }
+
+    @Test("jetpackNewsletterAccess returns nil when key is absent")
+    func accessLevelAbsent() {
+        #expect(PostMeta().jetpackNewsletterAccess == nil)
+    }
+
+    @Test("jetpackNewsletterAccess returns nil for unknown raw values")
+    func accessLevelUnknownRawValue() {
+        let meta = PostMeta().withValue(key: "_jetpack_newsletter_access", value: .string("not_a_level"))
+        #expect(meta.jetpackNewsletterAccess == nil)
+    }
+
+    // MARK: - Email Disabled
+
+    @Test("addingJetpackNewsletterEmailDisabled true round-trips")
+    func emailDisabledTrueRoundTrip() {
+        let meta = PostMeta().addingJetpackNewsletterEmailDisabled(true)
+        #expect(meta.isJetpackNewsletterEmailDisabled)
+    }
+
+    @Test("addingJetpackNewsletterEmailDisabled false round-trips")
+    func emailDisabledFalseRoundTrip() {
+        let meta = PostMeta().addingJetpackNewsletterEmailDisabled(false)
+        #expect(!meta.isJetpackNewsletterEmailDisabled)
+    }
+
+    @Test("isJetpackNewsletterEmailDisabled returns false when key is absent")
+    func emailDisabledAbsent() {
+        #expect(!PostMeta().isJetpackNewsletterEmailDisabled)
+    }
+}

--- a/Tests/KeystoneTests/Tests/Features/Posts/PostSettingsTests.swift
+++ b/Tests/KeystoneTests/Tests/Features/Posts/PostSettingsTests.swift
@@ -1368,6 +1368,58 @@ struct PostSettingsTests {
         #expect(!pingsOnlyView.showsCommentsSection)
         #expect(pingsOnlyView.showsPingsSection)
     }
+
+    // MARK: - Jetpack newsletter row visibility gate (post-type)
+
+    /// Positive control: proves the blog setup actually enables newsletter, so the
+    /// Page assertions below fail for the post-type reason, not a mis-configured blog.
+    @Test("shouldShow .jetpackAccessLevel is true for a Post on a newsletter site")
+    func testAccessLevelShownForPost() throws {
+        let context = ContextManager.forTesting().mainContext
+        let blog = newsletterBlog(context)
+        let post = PostBuilder(context, blog: blog).build()
+        try context.save()
+
+        let viewModel = PostSettingsViewModel(post: post)
+        #expect(viewModel.shouldShow(.jetpackAccessLevel))
+    }
+
+    @Test("shouldShow .jetpackAccessLevel is false for a Page even on a newsletter site")
+    func testAccessLevelHiddenForPage() throws {
+        let context = ContextManager.forTesting().mainContext
+        let blog = newsletterBlog(context)
+        let page = PageBuilder(context).build()
+        page.blog = blog // PageBuilder builds its own accountless blog; move it onto the newsletter-capable one
+        try context.save()
+
+        let viewModel = PostSettingsViewModel(post: page)
+        #expect(!viewModel.shouldShow(.jetpackAccessLevel))
+    }
+
+    /// Positive control for the publishing branch: proves a Post in publishing context
+    /// shows the newsletter row, so the Page assertion below fails for the post-type reason.
+    @Test("shouldShow .jetpackNewsletterEmailOptions is true for a Post in publishing context")
+    func testNewsletterEmailShownForPostInPublishing() throws {
+        let context = ContextManager.forTesting().mainContext
+        let blog = newsletterBlog(context)
+        let post = PostBuilder(context, blog: blog).build()
+        try context.save()
+
+        let viewModel = PostSettingsViewModel(post: post, context: .publishing)
+        #expect(viewModel.shouldShow(.jetpackNewsletterEmailOptions))
+    }
+
+    @Test("shouldShow .jetpackNewsletterEmailOptions is false for a Page in publishing context")
+    func testNewsletterEmailHiddenForPage() throws {
+        let context = ContextManager.forTesting().mainContext
+        let blog = newsletterBlog(context)
+        let page = PageBuilder(context).build()
+        page.blog = blog
+        try context.save()
+
+        let viewModel = PostSettingsViewModel(post: page, context: .publishing)
+        #expect(!viewModel.shouldShow(.jetpackNewsletterEmailOptions))
+    }
 }
 
 // MARK: - Test Helpers
@@ -1383,6 +1435,15 @@ private func makeDiscussionView(allowComments: Bool?, allowPings: Bool?) -> Post
     settings.allowComments = allowComments
     settings.allowPings = allowPings
     return PostDiscussionSettingsView(postSettings: .constant(settings))
+}
+
+/// A blog that supports Jetpack newsletter: the "subscriptions" module is what
+/// `Blog.supports(.jetpackNewsletter)` checks for a self-hosted (account-backed) site.
+private func newsletterBlog(_ context: NSManagedObjectContext) -> Blog {
+    BlogBuilder(context)
+        .withAnAccount()
+        .with(modules: ["subscriptions"])
+        .build()
 }
 
 private func makeRemotePost(

--- a/Tests/KeystoneTests/Tests/Features/Posts/PostSettingsTests.swift
+++ b/Tests/KeystoneTests/Tests/Features/Posts/PostSettingsTests.swift
@@ -720,6 +720,30 @@ struct PostSettingsTests {
         #expect(settings.socialSharingDraft == expectedDraft)
     }
 
+    @Test("init(from: AnyPostWithEditContext) populates jetpack newsletter access from meta")
+    func initFromRestPopulatesAccessLevel() throws {
+        let meta = PostMeta().addingJetpackNewsletterAccess(.paidSubscribers)
+        let post = makeRemotePost(meta: meta)
+        let settings = PostSettings(from: post)
+        #expect(settings.metadata.accessLevel == .paidSubscribers)
+    }
+
+    @Test("init(from: AnyPostWithEditContext) populates email-disabled flag from meta")
+    func initFromRestPopulatesEmailDisabled() throws {
+        let meta = PostMeta().addingJetpackNewsletterEmailDisabled(true)
+        let post = makeRemotePost(meta: meta)
+        let settings = PostSettings(from: post)
+        #expect(settings.metadata.isJetpackNewsletterEmailDisabled)
+    }
+
+    @Test("init(from: AnyPostWithEditContext) defaults metadata when meta is nil")
+    func initFromRestDefaultsMetadata() throws {
+        let post = makeRemotePost(meta: nil)
+        let settings = PostSettings(from: post)
+        #expect(settings.metadata.accessLevel == nil)
+        #expect(!settings.metadata.isJetpackNewsletterEmailDisabled)
+    }
+
     @Test("apply(to:) converts terms back to name strings")
     func testApplyConvertsTermsToNameStrings() {
         // Given
@@ -1046,6 +1070,88 @@ struct PostSettingsTests {
             }
         )
         #expect(flagsByID == ["1": true, "2": false])
+    }
+
+    // MARK: - makeUpdateParameters(from: AnyPostWithEditContext) Newsletter Meta Tests
+
+    @Test("makeUpdateParameters(from: AnyPostWithEditContext) omits meta when newsletter settings unchanged")
+    func updateParamsOmitsMetaWhenUnchanged() throws {
+        let meta = PostMeta()
+            .addingJetpackNewsletterAccess(.subscribers)
+            .addingJetpackNewsletterEmailDisabled(true)
+        let post = makeRemotePost(meta: meta)
+        let settings = PostSettings(from: post)
+        // Sanity: metadata read back correctly.
+        #expect(settings.metadata.accessLevel == .subscribers)
+
+        let params = settings.makeUpdateParameters(from: post)
+        #expect(params.meta?.jetpackNewsletterAccess == nil)
+        #expect(params.meta?.valueForKey(key: "_jetpack_dont_email_post_to_subs") == nil)
+    }
+
+    @Test("makeUpdateParameters(from: AnyPostWithEditContext) writes access level when changed")
+    func updateParamsWritesAccessLevelChange() throws {
+        let post = makeRemotePost(meta: nil)
+        var settings = PostSettings(from: post)
+        settings.metadata.accessLevel = .paidSubscribers
+
+        let params = settings.makeUpdateParameters(from: post)
+        #expect(params.meta?.jetpackNewsletterAccess == .paidSubscribers)
+        // Email-disabled key should NOT be written because it didn't change.
+        #expect(params.meta?.valueForKey(key: "_jetpack_dont_email_post_to_subs") == nil)
+    }
+
+    @Test("makeUpdateParameters(from: AnyPostWithEditContext) writes email-disabled when changed")
+    func updateParamsWritesEmailDisabledChange() throws {
+        let post = makeRemotePost(meta: nil)
+        var settings = PostSettings(from: post)
+        settings.metadata.isJetpackNewsletterEmailDisabled = true
+
+        let params = settings.makeUpdateParameters(from: post)
+        #expect(params.meta?.isJetpackNewsletterEmailDisabled == true)
+        #expect(params.meta?.valueForKey(key: "_jetpack_newsletter_access") == nil)
+    }
+
+    @Test("makeUpdateParameters(from: AnyPostWithEditContext) clears access level when set to nil")
+    func updateParamsClearsAccessLevel() throws {
+        let meta = PostMeta().addingJetpackNewsletterAccess(.subscribers)
+        let post = makeRemotePost(meta: meta)
+        var settings = PostSettings(from: post)
+        settings.metadata.accessLevel = nil
+
+        let params = settings.makeUpdateParameters(from: post)
+        // A nil access level writes `.null` so the server clears the meta.
+        #expect(params.meta?.valueForKey(key: "_jetpack_newsletter_access") == JsonValue.null)
+    }
+
+    // MARK: - makeCreateParameters Newsletter Meta Tests
+
+    @Test("makeCreateParameters emits access level when set")
+    func createParamsEmitsAccessLevel() throws {
+        var settings = PostSettings()
+        settings.metadata.accessLevel = .subscribers
+
+        let params = settings.makeCreateParameters()
+        #expect(params.meta?.jetpackNewsletterAccess == .subscribers)
+    }
+
+    @Test("makeCreateParameters emits email-disabled when true")
+    func createParamsEmitsEmailDisabled() throws {
+        var settings = PostSettings()
+        settings.metadata.isJetpackNewsletterEmailDisabled = true
+
+        let params = settings.makeCreateParameters()
+        #expect(params.meta?.isJetpackNewsletterEmailDisabled == true)
+    }
+
+    @Test("makeCreateParameters omits newsletter meta at defaults")
+    func createParamsOmitsDefaults() throws {
+        let settings = PostSettings()
+        // Defaults: accessLevel nil, isJetpackNewsletterEmailDisabled false.
+
+        let params = settings.makeCreateParameters()
+        #expect(params.meta?.valueForKey(key: "_jetpack_newsletter_access") == nil)
+        #expect(params.meta?.valueForKey(key: "_jetpack_dont_email_post_to_subs") == nil)
     }
 
     // MARK: - defaults(from: Blog) Tests

--- a/WordPress/Classes/ViewRelated/Post/PostSettings/CustomPostSettingsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettings/CustomPostSettingsViewModel.swift
@@ -297,9 +297,9 @@ final class CustomPostSettingsViewModel: NSObject, ObservableObject, PostSetting
     func shouldShow(_ row: PostSettingsRow) -> Bool {
         switch row {
         case .jetpackAccessLevel:
-            return isPost && blog.supports(.wpComRESTAPI)
+            return isPost && blog.supports(.jetpackNewsletter)
         case .jetpackNewsletterEmailOptions:
-            return isPost && blog.supports(.wpComRESTAPI) && context == .publishing
+            return isPost && blog.supports(.jetpackNewsletter) && context == .publishing
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Post/PostSettings/CustomPostSettingsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettings/CustomPostSettingsViewModel.swift
@@ -295,8 +295,12 @@ final class CustomPostSettingsViewModel: NSObject, ObservableObject, PostSetting
     func onAppear() {}
 
     func shouldShow(_ row: PostSettingsRow) -> Bool {
-        // FIXME: meta support missing in AnyPostWithEditContext
-        false
+        switch row {
+        case .jetpackAccessLevel:
+            return isPost && blog.supports(.wpComRESTAPI)
+        case .jetpackNewsletterEmailOptions:
+            return isPost && blog.supports(.wpComRESTAPI) && context == .publishing
+        }
     }
 
     func buttonCancelTapped() {

--- a/WordPress/Classes/ViewRelated/Post/PostSettings/Extensions/PostMeta+JetpackNewsletter.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettings/Extensions/PostMeta+JetpackNewsletter.swift
@@ -1,0 +1,42 @@
+import Foundation
+import WordPressAPIInternal
+import WordPressData
+
+extension PostMeta {
+    /// The Jetpack Newsletter access level stored in this meta, if any.
+    ///
+    /// Jetpack registers `_jetpack_newsletter_access` for the built-in `post`
+    /// type only (see `extensions/blocks/subscriptions/subscriptions.php` in
+    /// the Jetpack plugin).
+    var jetpackNewsletterAccess: JetpackPostAccessLevel? {
+        guard case let .string(raw)? = valueForKey(key: Self.newsletterAccessKey) else {
+            return nil
+        }
+        return JetpackPostAccessLevel(rawValue: raw)
+    }
+
+    /// Returns a new `PostMeta` with the access level set. Pass `nil` to
+    /// clear any previously-saved value.
+    func addingJetpackNewsletterAccess(_ accessLevel: JetpackPostAccessLevel?) -> PostMeta {
+        let value: JsonValue = accessLevel.map { .string($0.rawValue) } ?? .null
+        return withValue(key: Self.newsletterAccessKey, value: value)
+    }
+
+    /// Whether the post is configured to NOT be sent in an email to
+    /// subscribers. Defaults to `false` when the key is absent, matching
+    /// `PostMetadataContainer.getAdaptiveBool` semantics.
+    var isJetpackNewsletterEmailDisabled: Bool {
+        guard case let .bool(value)? = valueForKey(key: Self.dontEmailKey) else {
+            return false
+        }
+        return value
+    }
+
+    /// Returns a new `PostMeta` with the "don't email" flag set.
+    func addingJetpackNewsletterEmailDisabled(_ disabled: Bool) -> PostMeta {
+        withValue(key: Self.dontEmailKey, value: .bool(disabled))
+    }
+
+    private static let newsletterAccessKey = "_jetpack_newsletter_access"
+    private static let dontEmailKey = "_jetpack_dont_email_post_to_subs"
+}

--- a/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettings.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettings.swift
@@ -165,8 +165,10 @@ struct PostSettings: Hashable {
         }
         self.otherTerms = otherTerms
 
-        // FIXME: Post metadata is not supported yet. Require wordpress-rs changes.
-        metadata = PostMetadata(from: .init())
+        metadata = PostMetadata(
+            accessLevel: post.meta?.jetpackNewsletterAccess,
+            isJetpackNewsletterEmailDisabled: post.meta?.isJetpackNewsletterEmailDisabled ?? false
+        )
 
         postFormat = post.format.map { $0.id }
         isStickyPost = post.sticky ?? false
@@ -446,6 +448,19 @@ struct PostSettings: Hashable {
             }
         }
 
+        let originalMetadata = PostMetadata(
+            accessLevel: post.meta?.jetpackNewsletterAccess,
+            isJetpackNewsletterEmailDisabled: post.meta?.isJetpackNewsletterEmailDisabled ?? false
+        )
+        if originalMetadata.accessLevel != self.metadata.accessLevel {
+            params.meta = (params.meta ?? PostMeta())
+                .addingJetpackNewsletterAccess(self.metadata.accessLevel)
+        }
+        if originalMetadata.isJetpackNewsletterEmailDisabled != self.metadata.isJetpackNewsletterEmailDisabled {
+            params.meta = (params.meta ?? PostMeta())
+                .addingJetpackNewsletterEmailDisabled(self.metadata.isJetpackNewsletterEmailDisabled)
+        }
+
         let postParentPageID = post.parent.map { Int($0) }
         if postParentPageID != self.parentPageID {
             params.parent = self.parentPageID.map { PostId(Int64($0)) } ?? PostId(0)
@@ -499,6 +514,15 @@ struct PostSettings: Hashable {
         // Social meta
         if let message = socialSharingDraft?.customMessage {
             params.meta = (params.meta ?? PostMeta()).addingPublicizeMessage(message)
+        }
+
+        if metadata.accessLevel != nil {
+            params.meta = (params.meta ?? PostMeta())
+                .addingJetpackNewsletterAccess(metadata.accessLevel)
+        }
+        if metadata.isJetpackNewsletterEmailDisabled {
+            params.meta = (params.meta ?? PostMeta())
+                .addingJetpackNewsletterEmailDisabled(true)
         }
 
         return params

--- a/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsViewModel.swift
@@ -229,9 +229,9 @@ final class PostSettingsViewModel: NSObject, ObservableObject, PostSettingsViewM
     func shouldShow(_ row: PostSettingsRow) -> Bool {
         switch row {
         case .jetpackAccessLevel:
-            return blog.supports(.wpComRESTAPI)
+            return blog.supports(.jetpackNewsletter)
         case .jetpackNewsletterEmailOptions:
-            return blog.supports(.wpComRESTAPI) && context == .publishing
+            return blog.supports(.jetpackNewsletter) && context == .publishing
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsViewModel.swift
@@ -229,9 +229,9 @@ final class PostSettingsViewModel: NSObject, ObservableObject, PostSettingsViewM
     func shouldShow(_ row: PostSettingsRow) -> Bool {
         switch row {
         case .jetpackAccessLevel:
-            return blog.supports(.jetpackNewsletter)
+            return isPost && blog.supports(.jetpackNewsletter)
         case .jetpackNewsletterEmailOptions:
-            return blog.supports(.jetpackNewsletter) && context == .publishing
+            return isPost && blog.supports(.jetpackNewsletter) && context == .publishing
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsViewModel.swift
@@ -104,7 +104,8 @@ final class PostSettingsViewModel: NSObject, ObservableObject, PostSettingsViewM
 
     var postFormatText: String {
         guard capabilities.supportsPostFormats else { return "" }
-        return blog.postFormatText(fromSlug: settings.postFormat) ?? NSLocalizedString("Standard", comment: "Default post format")
+        return blog.postFormatText(fromSlug: settings.postFormat)
+            ?? NSLocalizedString("Standard", comment: "Default post format")
     }
 
     var timeZone: TimeZone {
@@ -204,9 +205,11 @@ final class PostSettingsViewModel: NSObject, ObservableObject, PostSettingsViewM
         super.init()
 
         // Observe selection changes from featured image view model
-        featuredImageViewModel?.$selection.dropFirst().sink { [weak self] media in
-            self?.settings.featuredImageID = media?.mediaID?.intValue
-        }.store(in: &cancellables)
+        featuredImageViewModel?.$selection.dropFirst()
+            .sink { [weak self] media in
+                self?.settings.featuredImageID = media?.mediaID?.intValue
+            }
+            .store(in: &cancellables)
 
         // Initialize all cached properties
         refreshDisplayedCategories()
@@ -254,20 +257,26 @@ final class PostSettingsViewModel: NSObject, ObservableObject, PostSettingsViewM
                 self.track(.intelligenceSuggestedTagsGenerated, properties: ["count": tags.count])
             } catch {
                 guard let self else { return }
-                self.track(.intelligenceGenerationFailed, properties: ["description": (error as NSError).debugDescription])
+                self.track(
+                    .intelligenceGenerationFailed,
+                    properties: ["description": (error as NSError).debugDescription]
+                )
             }
         }
-        cancellables.insert(AnyCancellable {
-            task.cancel()
-        })
+        cancellables.insert(
+            AnyCancellable {
+                task.cancel()
+            }
+        )
     }
 
     private func refreshCustomTaxonomies() {
-        let postType: String? = switch post {
-        case is Post: "post"
-        case is Page: "page"
-        default: nil
-        }
+        let postType: String? =
+            switch post {
+            case is Post: "post"
+            case is Page: "page"
+            default: nil
+            }
         guard let postType else {
             customTaxonomies = []
             return
@@ -331,8 +340,9 @@ final class PostSettingsViewModel: NSObject, ObservableObject, PostSettingsViewM
 
     private func refreshParentPageText() {
         if let page = post as? Page,
-           let context = page.managedObjectContext,
-           let parentPageID = settings.parentPageID {
+            let context = page.managedObjectContext,
+            let parentPageID = settings.parentPageID
+        {
             parentPageText = Page.parentPageText(in: context, parentID: NSNumber(value: parentPageID))
         } else {
             parentPageText = nil
@@ -348,7 +358,8 @@ final class PostSettingsViewModel: NSObject, ObservableObject, PostSettingsViewM
     func buttonSaveTapped() {
         // Check if the post still exists
         guard let context = post.managedObjectContext,
-              let _ = try? context.existingObject(with: post.objectID) else {
+            let _ = try? context.existingObject(with: post.objectID)
+        else {
             isShowingDeletedAlert = true
             return
         }
@@ -400,7 +411,8 @@ final class PostSettingsViewModel: NSObject, ObservableObject, PostSettingsViewM
     func buttonPublishTapped() {
         // Check if the post still exists
         guard let context = post.managedObjectContext,
-              let _ = try? context.existingObject(with: post.objectID) else {
+            let _ = try? context.existingObject(with: post.objectID)
+        else {
             isShowingDeletedAlert = true
             return
         }
@@ -490,8 +502,9 @@ final class PostSettingsViewModel: NSObject, ObservableObject, PostSettingsViewM
     private var isSocialConnectionSetupDismissed: Bool {
         get {
             guard let blogID = blog.dotComID?.intValue,
-                  let dictionary = preferences.dictionary(forKey: Constants.noConnectionKey) as? [String: Bool],
-                  let value = dictionary["\(blogID)"] else {
+                let dictionary = preferences.dictionary(forKey: Constants.noConnectionKey) as? [String: Bool],
+                let value = dictionary["\(blogID)"]
+            else {
                 return false
             }
             return value
@@ -534,7 +547,8 @@ final class PostSettingsViewModel: NSObject, ObservableObject, PostSettingsViewM
 
     func showSocialSharingOptions() {
         guard let blogID = blog.dotComID?.intValue,
-              let settings = settings.sharing else {
+            let settings = settings.sharing
+        else {
             return wpAssertionFailure("invalid context")
         }
         let optionsVC = PrepublishingSocialAccountsViewController(

--- a/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsViewModel.swift
@@ -227,7 +227,6 @@ final class PostSettingsViewModel: NSObject, ObservableObject, PostSettingsViewM
     }
 
     func shouldShow(_ row: PostSettingsRow) -> Bool {
-        // FIXME: meta support missing in AnyPostWithEditContext
         switch row {
         case .jetpackAccessLevel:
             return blog.supports(.wpComRESTAPI)


### PR DESCRIPTION
> [!Note]
> I recommend reviewing by commits. The first commit is pure code format changes and can be ignored.

## Description

Fixes https://linear.app/a8c/issue/CMM-2069.

Custom Posts settings now support the same Jetpack newsletter options as regular Posts:
1. The Access section shows the Jetpack newsletter access level.
2. The Publish sheet shows "Email to Subscribers".
3. The selected access level and email setting are read from and written back to REST `meta`.

This PR also fixes a bug where these two options remain visible even when the "Subscriptions" Jetpack module is not activated.

## Testing instructions

"Subscriptions" Jetpack module must be activated, which is the case for all simple sites. For jetpack sites, you'll need to go to the Newsletter -> turn on "Let visitors subscribe to this site and receive emails when you publish a post".

<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., VoiceOver)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->
