### PR TITLE
Custom Posts: Show "Post updated" notice

### DIFF
--- a/WordPress/Classes/ViewRelated/CustomPostTypes/CustomPostListViewModel.swift
+++ b/WordPress/Classes/ViewRelated/CustomPostTypes/CustomPostListViewModel.swift
@@ -417,6 +417,11 @@ final class CustomPostListViewModel: ObservableObject {
                 wpService: service
             )
             let viewModel = CustomPostSettingsViewModel(editorService: editorService, blog: blog, isStandalone: true)
+            viewModel.onEditorPostSaved = { [editorService] in
+                let postTitle = editorService.post?.title?.raw
+                let subtitle = (postTitle?.isEmpty == false) ? postTitle : nil
+                Notice(title: Strings.CustomPostNotice.postUpdated, message: subtitle, feedbackType: .success).post()
+            }
             let settingsVC = PostSettingsViewController(viewModel: viewModel)
             let nav = UINavigationController(rootViewController: settingsVC)
             vc.present(nav, animated: true)
@@ -941,6 +946,27 @@ private enum Strings {
         value: "Page successfully updated",
         comment: "Notice shown after successfully changing a page's role (homepage, posts page, or regular page)"
     )
+
+    /// Localized titles for the success notices emitted when a custom post is
+    /// persisted to the server. Shared between the editor and the standalone
+    /// settings sheet (from the Custom Posts list).
+    enum CustomPostNotice {
+        static let draftSaved = NSLocalizedString(
+            "customPost.notice.draftSaved",
+            value: "Draft saved",
+            comment: "Success notice shown after a new draft custom post is created on the server."
+        )
+        static let postUpdated = NSLocalizedString(
+            "customPost.notice.postUpdated",
+            value: "Post updated",
+            comment: "Success notice shown after an existing custom post is updated on the server."
+        )
+        static let postPublished = NSLocalizedString(
+            "customPost.notice.postPublished",
+            value: "Post published",
+            comment: "Success notice shown after a custom post is published on the server."
+        )
+    }
 }
 
 /// Represents the WordPress "Your homepage displays" setting.

--- a/WordPress/Classes/ViewRelated/CustomPostTypes/CustomPostListViewModel.swift
+++ b/WordPress/Classes/ViewRelated/CustomPostTypes/CustomPostListViewModel.swift
@@ -420,7 +420,7 @@ final class CustomPostListViewModel: ObservableObject {
             viewModel.onEditorPostSaved = { [editorService] in
                 let postTitle = editorService.post?.title?.raw
                 let subtitle = (postTitle?.isEmpty == false) ? postTitle : nil
-                Notice(title: Strings.CustomPostNotice.postUpdated, message: subtitle, feedbackType: .success).post()
+                Notice(title: CustomPostNoticeStrings.postUpdated, message: subtitle, feedbackType: .success).post()
             }
             let settingsVC = PostSettingsViewController(viewModel: viewModel)
             let nav = UINavigationController(rootViewController: settingsVC)
@@ -946,27 +946,6 @@ private enum Strings {
         value: "Page successfully updated",
         comment: "Notice shown after successfully changing a page's role (homepage, posts page, or regular page)"
     )
-
-    /// Localized titles for the success notices emitted when a custom post is
-    /// persisted to the server. Shared between the editor and the standalone
-    /// settings sheet (from the Custom Posts list).
-    enum CustomPostNotice {
-        static let draftSaved = NSLocalizedString(
-            "customPost.notice.draftSaved",
-            value: "Draft saved",
-            comment: "Success notice shown after a new draft custom post is created on the server."
-        )
-        static let postUpdated = NSLocalizedString(
-            "customPost.notice.postUpdated",
-            value: "Post updated",
-            comment: "Success notice shown after an existing custom post is updated on the server."
-        )
-        static let postPublished = NSLocalizedString(
-            "customPost.notice.postPublished",
-            value: "Post published",
-            comment: "Success notice shown after a custom post is published on the server."
-        )
-    }
 }
 
 /// Represents the WordPress "Your homepage displays" setting.

--- a/WordPress/Classes/ViewRelated/CustomPostTypes/CustomPostNoticeStrings.swift
+++ b/WordPress/Classes/ViewRelated/CustomPostTypes/CustomPostNoticeStrings.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+/// Localized titles for the success notices emitted when a custom post is
+/// persisted to the server. Shared between the editor, the publishing sheet,
+/// and the Custom Posts list.
+enum CustomPostNoticeStrings {
+    static let draftSaved = NSLocalizedString(
+        "customPost.notice.draftSaved",
+        value: "Draft saved",
+        comment: "Success notice shown after a new draft custom post is created on the server."
+    )
+    static let postUpdated = NSLocalizedString(
+        "customPost.notice.postUpdated",
+        value: "Post updated",
+        comment: "Success notice shown after an existing custom post is updated on the server."
+    )
+    static let postPublished = NSLocalizedString(
+        "customPost.notice.postPublished",
+        value: "Post published",
+        comment: "Success notice shown after a custom post is published on the server."
+    )
+}

--- a/WordPress/Classes/ViewRelated/NewGutenberg/CustomPostEditorViewController.swift
+++ b/WordPress/Classes/ViewRelated/NewGutenberg/CustomPostEditorViewController.swift
@@ -143,7 +143,7 @@ private extension CustomPostEditorViewController {
                         style: .default,
                         handler: { [weak self] _ in
                             Task {
-                                await self?.save(publish: false)
+                                await self?.save()
                             }
                         }
                     )
@@ -170,7 +170,7 @@ private extension CustomPostEditorViewController {
                         attributes: enabled ? [] : [.disabled]
                     ) { [weak self] _ in
                         Task {
-                            await self?.save(publish: false)
+                            await self?.save()
                         }
                     }
                     resolve([saveDraft])
@@ -197,7 +197,7 @@ private extension CustomPostEditorViewController {
         } else {
             return UIAction(title: PostEditorStrings.update) { [weak self] _ in
                 Task {
-                    await self?.save(publish: false)
+                    await self?.save()
                 }
             }
         }
@@ -244,38 +244,27 @@ private extension CustomPostEditorViewController {
 
 private extension CustomPostEditorViewController {
 
-    func save(publish: Bool) async {
+    func save() async {
         SVProgressHUD.show()
 
         // Capture whether this is a brand-new post (not yet on the server) so the
         // notice can distinguish "Draft saved" (just created) from "Post updated"
-        // (edited an existing post). Any save of an already-existing post — draft
-        // or published — reads as an update from the user's perspective.
+        // (edited an existing post). Any save of an already-existing post (draft
+        // or published) reads as an update from the user's perspective.
         let isNewPost = post == nil
 
         do {
             let data = try await editorViewController.getTitleAndContent()
             try await editorService.save(
                 content: EditorContent(title: data.title, content: data.content),
-                publish: publish
+                publish: false
             )
 
             dismissHUDWithSuccess()
 
-            let title: String
-            if publish {
-                title = CustomPostNoticeStrings.postPublished
-            } else if isNewPost {
-                title = CustomPostNoticeStrings.draftSaved
-            } else {
-                title = CustomPostNoticeStrings.postUpdated
-            }
+            let title = isNewPost ? CustomPostNoticeStrings.draftSaved : CustomPostNoticeStrings.postUpdated
             let subtitle = data.title.isEmpty ? nil : data.title
             Notice(title: title, message: subtitle, feedbackType: .success).post()
-
-            if publish {
-                completion()
-            }
         } catch {
             SVProgressHUD.showError(withStatus: error.localizedDescription)
         }

--- a/WordPress/Classes/ViewRelated/NewGutenberg/CustomPostEditorViewController.swift
+++ b/WordPress/Classes/ViewRelated/NewGutenberg/CustomPostEditorViewController.swift
@@ -231,6 +231,10 @@ private extension CustomPostEditorViewController {
                 guard let self else { return }
                 switch result {
                 case .published:
+                    let postTitle = editorService.post?.title?.raw
+                    let subtitle = (postTitle?.isEmpty == false) ? postTitle : nil
+                    Notice(title: Strings.CustomPostNotice.postPublished, message: subtitle, feedbackType: .success)
+                        .post()
                     completion()
                 case .cancelled:
                     break
@@ -251,6 +255,12 @@ private extension CustomPostEditorViewController {
     func save(publish: Bool) async {
         SVProgressHUD.show()
 
+        // Capture whether this is a brand-new post (not yet on the server) so the
+        // notice can distinguish "Draft saved" (just created) from "Post updated"
+        // (edited an existing post). Any save of an already-existing post — draft
+        // or published — reads as an update from the user's perspective.
+        let isNewPost = post == nil
+
         do {
             let data = try await editorViewController.getTitleAndContent()
             try await editorService.save(
@@ -259,6 +269,17 @@ private extension CustomPostEditorViewController {
             )
 
             dismissHUDWithSuccess()
+
+            let title: String
+            if publish {
+                title = Strings.CustomPostNotice.postPublished
+            } else if isNewPost {
+                title = Strings.CustomPostNotice.draftSaved
+            } else {
+                title = Strings.CustomPostNotice.postUpdated
+            }
+            let subtitle = data.title.isEmpty ? nil : data.title
+            Notice(title: title, message: subtitle, feedbackType: .success).post()
 
             if publish {
                 completion()
@@ -278,5 +299,28 @@ extension CustomPostEditorViewController: CustomPostEditorServiceDelegate {
     func editorContent(for service: CustomPostEditorService) async throws -> EditorContent {
         let result = try await editorViewController.getTitleAndContent()
         return EditorContent(title: result.title, content: result.content)
+    }
+}
+
+private enum Strings {
+    /// Localized titles for the success notices emitted when a custom post is
+    /// persisted to the server. Shared between the editor and the standalone
+    /// settings sheet (from the Custom Posts list).
+    enum CustomPostNotice {
+        static let draftSaved = NSLocalizedString(
+            "customPost.notice.draftSaved",
+            value: "Draft saved",
+            comment: "Success notice shown after a new draft custom post is created on the server."
+        )
+        static let postUpdated = NSLocalizedString(
+            "customPost.notice.postUpdated",
+            value: "Post updated",
+            comment: "Success notice shown after an existing custom post is updated on the server."
+        )
+        static let postPublished = NSLocalizedString(
+            "customPost.notice.postPublished",
+            value: "Post published",
+            comment: "Success notice shown after a custom post is published on the server."
+        )
     }
 }

--- a/WordPress/Classes/ViewRelated/NewGutenberg/CustomPostEditorViewController.swift
+++ b/WordPress/Classes/ViewRelated/NewGutenberg/CustomPostEditorViewController.swift
@@ -228,16 +228,8 @@ private extension CustomPostEditorViewController {
             blog: blog,
             from: self,
             completion: { [weak self] result in
-                guard let self else { return }
-                switch result {
-                case .published:
-                    let postTitle = editorService.post?.title?.raw
-                    let subtitle = (postTitle?.isEmpty == false) ? postTitle : nil
-                    Notice(title: Strings.CustomPostNotice.postPublished, message: subtitle, feedbackType: .success)
-                        .post()
-                    completion()
-                case .cancelled:
-                    break
+                if case .published = result {
+                    self?.completion()
                 }
             }
         )
@@ -272,11 +264,11 @@ private extension CustomPostEditorViewController {
 
             let title: String
             if publish {
-                title = Strings.CustomPostNotice.postPublished
+                title = CustomPostNoticeStrings.postPublished
             } else if isNewPost {
-                title = Strings.CustomPostNotice.draftSaved
+                title = CustomPostNoticeStrings.draftSaved
             } else {
-                title = Strings.CustomPostNotice.postUpdated
+                title = CustomPostNoticeStrings.postUpdated
             }
             let subtitle = data.title.isEmpty ? nil : data.title
             Notice(title: title, message: subtitle, feedbackType: .success).post()
@@ -299,28 +291,5 @@ extension CustomPostEditorViewController: CustomPostEditorServiceDelegate {
     func editorContent(for service: CustomPostEditorService) async throws -> EditorContent {
         let result = try await editorViewController.getTitleAndContent()
         return EditorContent(title: result.title, content: result.content)
-    }
-}
-
-private enum Strings {
-    /// Localized titles for the success notices emitted when a custom post is
-    /// persisted to the server. Shared between the editor and the standalone
-    /// settings sheet (from the Custom Posts list).
-    enum CustomPostNotice {
-        static let draftSaved = NSLocalizedString(
-            "customPost.notice.draftSaved",
-            value: "Draft saved",
-            comment: "Success notice shown after a new draft custom post is created on the server."
-        )
-        static let postUpdated = NSLocalizedString(
-            "customPost.notice.postUpdated",
-            value: "Post updated",
-            comment: "Success notice shown after an existing custom post is updated on the server."
-        )
-        static let postPublished = NSLocalizedString(
-            "customPost.notice.postPublished",
-            value: "Post published",
-            comment: "Success notice shown after a custom post is published on the server."
-        )
     }
 }

--- a/WordPress/Classes/ViewRelated/Post/Publishing/PublishPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Publishing/PublishPostViewController.swift
@@ -221,23 +221,82 @@ private typealias Strings = PrepublishingSheetStrings
 
 enum PrepublishingSheetStrings {
     static let title = NSLocalizedString("prepublishing.title", value: "Publishing", comment: "Navigation title")
-    static let publishingTo = NSLocalizedString("prepublishing.publishingTo", value: "Publishing to", comment: "Label in the header in the pre-publishing sheet")
-    static let publish = NSLocalizedString("prepublishing.publish", value: "Publish", comment: "Primary button label in the pre-publishing sheet")
-    static let schedule = NSLocalizedString("prepublishing.schedule", value: "Schedule", comment: "Primary button label in the pre-publishing shee")
-    static let publishDate = NSLocalizedString("prepublishing.publishDate", value: "Publish Date", comment: "Label for a cell in the pre-publishing sheet")
-    static let visibility = NSLocalizedString("prepublishing.visibility", value: "Visibility", comment: "Label for a cell in the pre-publishing sheet")
-    static let categories = NSLocalizedString("prepublishing.categories", value: "Categories", comment: "Label for a cell in the pre-publishing sheet")
-    static let tags = NSLocalizedString("prepublishing.tags", value: "Tags", comment: "Label for a cell in the pre-publishing sheet")
-    static let jetpackSocial = NSLocalizedString("prepublishing.jetpackSocial", value: "Jetpack Social", comment: "Label for a cell in the pre-publishing sheet")
-    static let immediately = NSLocalizedString("prepublishing.publishDateImmediately", value: "Immediately", comment: "Placeholder value for a publishing date in the prepublishing sheet when the date is not selected")
-    static let uploadingMedia = NSLocalizedString("prepublishing.uploadingMedia", value: "Uploading media", comment: "Title for a publish button state in the pre-publishing sheet")
-    private static let uploadMediaOneItemRemaining = NSLocalizedString("prepublishing.uploadMediaOneItemRemaining", value: "%@ item remaining", comment: "Details label for a publish button state in the pre-publishing sheet")
-    private static let uploadMediaManyItemsRemaining = NSLocalizedString("prepublishing.uploadMediaManyItemsRemaining", value: "%@ items remaining", comment: "Details label for a publish button state in the pre-publishing sheet")
+    static let publishingTo = NSLocalizedString(
+        "prepublishing.publishingTo",
+        value: "Publishing to",
+        comment: "Label in the header in the pre-publishing sheet"
+    )
+    static let publish = NSLocalizedString(
+        "prepublishing.publish",
+        value: "Publish",
+        comment: "Primary button label in the pre-publishing sheet"
+    )
+    static let schedule = NSLocalizedString(
+        "prepublishing.schedule",
+        value: "Schedule",
+        comment: "Primary button label in the pre-publishing shee"
+    )
+    static let publishDate = NSLocalizedString(
+        "prepublishing.publishDate",
+        value: "Publish Date",
+        comment: "Label for a cell in the pre-publishing sheet"
+    )
+    static let visibility = NSLocalizedString(
+        "prepublishing.visibility",
+        value: "Visibility",
+        comment: "Label for a cell in the pre-publishing sheet"
+    )
+    static let categories = NSLocalizedString(
+        "prepublishing.categories",
+        value: "Categories",
+        comment: "Label for a cell in the pre-publishing sheet"
+    )
+    static let tags = NSLocalizedString(
+        "prepublishing.tags",
+        value: "Tags",
+        comment: "Label for a cell in the pre-publishing sheet"
+    )
+    static let jetpackSocial = NSLocalizedString(
+        "prepublishing.jetpackSocial",
+        value: "Jetpack Social",
+        comment: "Label for a cell in the pre-publishing sheet"
+    )
+    static let immediately = NSLocalizedString(
+        "prepublishing.publishDateImmediately",
+        value: "Immediately",
+        comment: "Placeholder value for a publishing date in the prepublishing sheet when the date is not selected"
+    )
+    static let uploadingMedia = NSLocalizedString(
+        "prepublishing.uploadingMedia",
+        value: "Uploading media",
+        comment: "Title for a publish button state in the pre-publishing sheet"
+    )
+    private static let uploadMediaOneItemRemaining = NSLocalizedString(
+        "prepublishing.uploadMediaOneItemRemaining",
+        value: "%@ item remaining",
+        comment: "Details label for a publish button state in the pre-publishing sheet"
+    )
+    private static let uploadMediaManyItemsRemaining = NSLocalizedString(
+        "prepublishing.uploadMediaManyItemsRemaining",
+        value: "%@ items remaining",
+        comment: "Details label for a publish button state in the pre-publishing sheet"
+    )
     static func uploadMediaRemaining(count: Int) -> String {
-        String(format: count == 1 ? Strings.uploadMediaOneItemRemaining : Strings.uploadMediaManyItemsRemaining, count.description)
+        String(
+            format: count == 1 ? Strings.uploadMediaOneItemRemaining : Strings.uploadMediaManyItemsRemaining,
+            count.description
+        )
     }
-    static let mediaUploadFailedTitle = NSLocalizedString("prepublishing.mediaUploadFailedTitle", value: "Failed to upload media", comment: "Title for a publish button state in the pre-publishing sheet")
-    static let mediaUploadFailedDetailsMultipleFailures = NSLocalizedString("prepublishing.mediaUploadFailedDetails", value: "%@ items failed to upload", comment: "Details for a publish button state in the pre-publishing sheet; count as a parameter")
+    static let mediaUploadFailedTitle = NSLocalizedString(
+        "prepublishing.mediaUploadFailedTitle",
+        value: "Failed to upload media",
+        comment: "Title for a publish button state in the pre-publishing sheet"
+    )
+    static let mediaUploadFailedDetailsMultipleFailures = NSLocalizedString(
+        "prepublishing.mediaUploadFailedDetails",
+        value: "%@ items failed to upload",
+        comment: "Details for a publish button state in the pre-publishing sheet; count as a parameter"
+    )
 
     static let discardChangesTitle = NSLocalizedString(
         "prepublishing.discardChanges.title",

--- a/WordPress/Classes/ViewRelated/Post/Publishing/PublishPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Publishing/PublishPostViewController.swift
@@ -81,7 +81,14 @@ final class PublishPostViewController<ViewModel: PostSettingsViewModelProtocol>:
             editorService: editorService,
             blog: blog
         )
-        publishVC.onCompletion = completion
+        publishVC.onCompletion = { result in
+            if case .published = result {
+                let postTitle = editorService.post?.title?.raw
+                let subtitle = (postTitle?.isEmpty == false) ? postTitle : nil
+                Notice(title: CustomPostNoticeStrings.postPublished, message: subtitle, feedbackType: .success).post()
+            }
+            completion(result)
+        }
         let navigationVC = UINavigationController(rootViewController: publishVC)
         navigationVC.sheetPresentationController?.detents = [
             .custom(identifier: .medium, resolver: { _ in 526 }),


### PR DESCRIPTION
## Description

Mirror the existing UX: show notice after post is saved/published.

The first commit is code-format changes and can be ignored.