### PR TITLE
Fix typos in comments and docs

### DIFF
--- a/Modules/Sources/BuildSettingsKit/BuildConfiguration.swift
+++ b/Modules/Sources/BuildSettingsKit/BuildConfiguration.swift
@@ -13,7 +13,7 @@ public enum BuildConfiguration: String, Sendable {
         BuildSettings.current.configuration
     }
 
-    /// Returns `true` if the build is intented only for internal use.
+    /// Returns `true` if the build is intended only for internal use.
     public var isInternal: Bool {
         switch self {
         case .debug, .alpha: true

--- a/Modules/Sources/JetpackStats/Charts/BarChartView.swift
+++ b/Modules/Sources/JetpackStats/Charts/BarChartView.swift
@@ -267,7 +267,7 @@ struct BarChartView: View {
             return 0...100
         }
         guard data.maxValue > 0 else {
-            return data.maxValue...0 // Just in case; should never happend
+            return data.maxValue...0 // Just in case; should never happen
         }
         // Add some padding above the max value
         let padding = max(Int(Double(data.maxValue) * 0.33), 1)

--- a/Modules/Sources/JetpackStats/Charts/LineChartView.swift
+++ b/Modules/Sources/JetpackStats/Charts/LineChartView.swift
@@ -262,7 +262,7 @@ struct LineChartView: View {
             return 0...100
         }
         guard data.maxValue > 0 else {
-            return data.maxValue...0 // Just in case; should never happend
+            return data.maxValue...0 // Just in case; should never happen
         }
         // Add some padding above the max value
         let padding = max(Int(Double(data.maxValue) * 0.33), 1)

--- a/Modules/Sources/UITestsFoundation/XCUIApplication+ScrollDownToElement.swift
+++ b/Modules/Sources/UITestsFoundation/XCUIApplication+ScrollDownToElement.swift
@@ -3,10 +3,10 @@ import XCTest
 // Taken from https://stackoverflow.com/a/46943935
 extension XCUIApplication {
     private struct Constants {
-        // Half way accross the screen and 40% from top
+        // Half way across the screen and 40% from top
         static let topOffset = CGVector(dx: 0.5, dy: 0.4)
 
-        // Half way accross the screen and 70% from top
+        // Half way across the screen and 70% from top
         static let bottomOffset = CGVector(dx: 0.5, dy: 0.7)
     }
 

--- a/Modules/Sources/WordPressIntelligence/UseCases/TranslationViewModel.swift
+++ b/Modules/Sources/WordPressIntelligence/UseCases/TranslationViewModel.swift
@@ -54,8 +54,8 @@ public final class TranslationViewModel: ObservableObject {
     public func checkAvailability(for content: String, to targetLanguage: Locale.Language = Locale.current.language) async -> TranslationAvailability {
         // Important. The `Translation` framework is effective at translating
         // HTML, but the `status(...)` method and `NLLanguageRecognizer`
-        // incorrectly identify dominant langauge as English if a post has a
-        // signifcant amount of HTML tags and/or CSS styles.
+        // incorrectly identify dominant language as English if a post has a
+        // significant amount of HTML tags and/or CSS styles.
         let content = (try? ContentExtractor.extractRelevantText(from: content)) ?? content
 
         guard let identifier = IntelligenceService.detectLanguage(from: content) else {

--- a/Modules/Sources/WordPressKit/WordPressAPIError.swift
+++ b/Modules/Sources/WordPressKit/WordPressAPIError.swift
@@ -5,13 +5,13 @@ import Foundation
         NSLocalizedString(
             "wordpress-api.error.unknown",
             value: "Something went wrong, please try again later.",
-            comment: "Error message that describes an unknown error had occured"
+            comment: "Error message that describes an unknown error had occurred"
         )
     }
 
     /// Can't encode the request arguments into a valid HTTP request. This is a programming error.
     case requestEncodingFailure(underlyingError: Error)
-    /// Error occured in the HTTP connection.
+    /// Error occurred in the HTTP connection.
     case connection(URLError)
     /// The API call returned an error result. For example, an OAuth endpoint may return an 'incorrect username or password' error, an upload media endpoint may return an 'unsupported media type' error.
     case endpointError(EndpointError)
@@ -19,7 +19,7 @@ import Foundation
     case unacceptableStatusCode(response: HTTPURLResponse, body: Data)
     /// The API call returned an HTTP response that WordPressKit can't parse. Receiving this error could be an indicator that there is an error response that's not handled properly by WordPressKit.
     case unparsableResponse(response: HTTPURLResponse?, body: Data?, underlyingError: Error)
-    /// Other error occured.
+    /// Other error occurred.
     case unknown(underlyingError: Error)
 
     static func unparsableResponse(response: HTTPURLResponse?, body: Data?) -> Self {

--- a/Modules/Sources/WordPressKit/WordPressOrgXMLRPCApi.swift
+++ b/Modules/Sources/WordPressKit/WordPressOrgXMLRPCApi.swift
@@ -323,7 +323,7 @@ extension WordPressOrgXMLRPCApiError: LocalizedError {
         case .responseSerializationFailed:
             return NSLocalizedString("The serialization of the response failed.", comment: "A failure reason for when the response couldn't be serialized.")
         case .unknown:
-            return NSLocalizedString("An unknown error occurred.", comment: "A failure reason for when the error that occured wasn't able to be determined.")
+            return NSLocalizedString("An unknown error occurred.", comment: "A failure reason for when the error that occurred wasn't able to be determined.")
         }
     }
 }

--- a/Modules/Sources/WordPressKitObjC/AccountServiceRemoteREST.m
+++ b/Modules/Sources/WordPressKitObjC/AccountServiceRemoteREST.m
@@ -97,7 +97,7 @@ MagicLinkFlow const MagicLinkFlowSignup = @"signup";
         NSParameterAssert([key isKindOfClass:[NSNumber class]]);
         NSParameterAssert([obj isKindOfClass:[NSNumber class]]);
         /*
-         Blog IDs are pased as strings because JSON dictionaries can't take
+         Blog IDs are passed as strings because JSON dictionaries can't take
          non-string keys. If you try, you get a NSInvalidArgumentException
          */
         NSString *blogID = [key stringValue];

--- a/Modules/Sources/WordPressLegacy/WPTableViewHandler.m
+++ b/Modules/Sources/WordPressLegacy/WPTableViewHandler.m
@@ -202,7 +202,7 @@ static CGFloat const DefaultCellHeight = 44.0;
     // Clean up
     [self discardPreservedRowInfo];
 
-    // Notify the delegate that a refresh has occured. Allows the delegate
+    // Notify the delegate that a refresh has occurred. Allows the delegate
     // perform any corrections to the offset, e.g. a negative offset due to a content
     // change that was not a post inserted above the previous zero visible index.
     if ([self.delegate respondsToSelector:@selector(tableViewHandlerDidRefreshTableViewPreservingOffset:)]) {

--- a/Modules/Sources/WordPressReader/Comments/Views/CommentWebView.swift
+++ b/Modules/Sources/WordPressReader/Comments/Views/CommentWebView.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-/// -warning: It's not designed to be used publically yet.
+/// -warning: It's not designed to be used publicly yet.
 @MainActor
 final class CommentWebView: UIView, CommentContentRendererDelegate {
     let renderer = WebCommentContentRenderer()

--- a/Modules/Sources/WordPressShared/Utility/AppLocalizedString.swift
+++ b/Modules/Sources/WordPressShared/Utility/AppLocalizedString.swift
@@ -7,7 +7,7 @@ import Foundation
 /// from App Extensions and Widgets, in order to reference strings whose localization live in the app bundle's `.strings` file
 /// (rather than the AppExtension's own bundle).
 ///
-/// In order to avoid duplicating our strings accross targets, and make our localization process & tooling easier, we keep all
+/// In order to avoid duplicating our strings across targets, and make our localization process & tooling easier, we keep all
 /// localized `.strings` in the app's bundle (and don't have a `.strings` file in the App Extension targets themselves);
 /// then we make those App Extensions & Widgets reference the strings from the `Localizable.strings` files
 /// hosted in the app bundle itself – which is when this helper method is helpful.

--- a/Modules/Sources/WordPressShared/Utility/String+RangeConveresion.swift
+++ b/Modules/Sources/WordPressShared/Utility/String+RangeConveresion.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-// MARK: - String NSRange and Location convertion Extensions
+// MARK: - String NSRange and Location conversion Extensions
 //
 extension String {
 

--- a/Modules/Sources/WordPressUI/Extensions/UIView+Animations.swift
+++ b/Modules/Sources/WordPressUI/Extensions/UIView+Animations.swift
@@ -155,7 +155,7 @@ extension UIView {
     /// Coordinates an animation block alongside a keyboard's notification animation event.
     /// - Parameters:
     ///     - notification: A notficiation from a keyboard change event (keyboardWillShowNotification, keyboardWillHideNotification, etc)
-    ///     - animations: The animation block to be preformed. The block will provide the rects from keyboardFrameBeginUserInfoKey and keyboardFrameEndUserInfoKey to the animation block.
+    ///     - animations: The animation block to be performed. The block will provide the rects from keyboardFrameBeginUserInfoKey and keyboardFrameEndUserInfoKey to the animation block.
     ///
     public static func animate(withKeyboard notification: Notification, _ animations: @escaping (CGRect, CGRect) -> Void ) {
         guard let userInfo = notification.userInfo else { return }

--- a/Sources/WordPressAuthenticator/Helpers/WordPressComAccountService.swift
+++ b/Sources/WordPressAuthenticator/Helpers/WordPressComAccountService.swift
@@ -5,7 +5,7 @@ import WordPressKit
 //
 public class WordPressComAccountService {
 
-    /// Makes the intializer public for external access.
+    /// Makes the initializer public for external access.
     public init() {}
 
     /// Indicates if a WordPress.com account is "PasswordLess": This kind of account must be authenticated via a Magic Link.

--- a/Sources/WordPressAuthenticator/Views/SiteInfoHeaderView.swift
+++ b/Sources/WordPressAuthenticator/Views/SiteInfoHeaderView.swift
@@ -71,7 +71,7 @@ class SiteInfoHeaderView: UIView {
         }
     }
 
-    // MARK: - Overriden Methods
+    // MARK: - Overridden Methods
 
     override func awakeFromNib() {
         super.awakeFromNib()

--- a/Tests/KeystoneTests/Tests/Features/Dashboard/BlogDashboardServiceTests.swift
+++ b/Tests/KeystoneTests/Tests/Features/Dashboard/BlogDashboardServiceTests.swift
@@ -187,7 +187,7 @@ class BlogDashboardServiceTests: CoreDataTestCase {
     }
 
     func testTodaysStats() {
-        let expect = expectation(description: "Parse todays stats")
+        let expect = expectation(description: "Parse today's stats")
         remoteServiceMock.respondWith = .withDraftAndSchedulePosts
 
         let blog = newTestBlog(id: wpComID, context: mainContext)
@@ -215,7 +215,7 @@ class BlogDashboardServiceTests: CoreDataTestCase {
         BlogDashboardPersonalizationService(repository: repositoryMock, siteID: wpComID)
             .setEnabled(false, for: .todaysStats)
 
-        let expect = expectation(description: "Parse todays stats")
+        let expect = expectation(description: "Parse today's stats")
         remoteServiceMock.respondWith = .withDraftAndSchedulePosts
 
         let blog = newTestBlog(id: wpComID, context: mainContext)
@@ -254,7 +254,7 @@ class BlogDashboardServiceTests: CoreDataTestCase {
         BlogDashboardPersonalizationService(repository: repositoryMock, siteID: wpComID + 1)
             .setEnabled(false, for: .todaysStats)
 
-        let expect = expectation(description: "Parse todays stats")
+        let expect = expectation(description: "Parse today's stats")
         remoteServiceMock.respondWith = .withDraftAndSchedulePosts
 
         let blog = newTestBlog(id: wpComID, context: mainContext)
@@ -269,7 +269,7 @@ class BlogDashboardServiceTests: CoreDataTestCase {
     }
 
     func testPersistCardsResponse() {
-        let expect = expectation(description: "Parse todays stats")
+        let expect = expectation(description: "Parse today's stats")
         remoteServiceMock.respondWith = .withDraftAndSchedulePosts
 
         let blog = newTestBlog(id: wpComID, context: mainContext)

--- a/Tests/KeystoneTests/Tests/Features/Posts/PreviewWebKitViewControllerTests.swift
+++ b/Tests/KeystoneTests/Tests/Features/Posts/PreviewWebKitViewControllerTests.swift
@@ -32,7 +32,7 @@ class PreviewWebKitViewControllerTests: CoreDataTestCase {
         XCTAssertFalse(items.contains(vc.safariButton),
                        "Preview toolbar for draft should not contain Safari button.")
         XCTAssertFalse(items.contains(vc.backButton), "Preview toolbar for draft should not contain back button.")
-        XCTAssertFalse(items.contains(vc.forwardButton), "Preview toolbar for draft should not contain foward button.")
+        XCTAssertFalse(items.contains(vc.forwardButton), "Preview toolbar for draft should not contain forward button.")
         XCTAssertTrue(items.contains(vc.previewButton), "Preview toolbar for draft should contain preview button.")
     }
 

--- a/Tests/KeystoneTests/Tests/Login/QRLoginVerifyCoordinatorTests.swift
+++ b/Tests/KeystoneTests/Tests/Login/QRLoginVerifyCoordinatorTests.swift
@@ -110,7 +110,7 @@ class QRLoginVerifyCoordinatorTests: CoreDataTestCase {
 
     // MARK: - Confirm Tapped when waiting for user verification
 
-    /// Tests when the user taps the confirm button and is sucessful
+    /// Tests when the user taps the confirm button and is successful
     func testConfirmFromWaitingForUserVerificationAndSucceeds() {
         let view = QRLoginVerifyViewMock()
         let parentCoordinator = ParentCoorinatorMock()

--- a/Tests/KeystoneTests/Tests/Reader/ReaderInterestsDataSourceTests.swift
+++ b/Tests/KeystoneTests/Tests/Reader/ReaderInterestsDataSourceTests.swift
@@ -92,7 +92,7 @@ class ReaderInterestsDataSourceTests: XCTestCase {
     }
 
     func testInterestsDataSourceDelegateIsCalled() {
-        let delegateExpectation = expectation(description: "DataSource delegate is called sucessfully")
+        let delegateExpectation = expectation(description: "DataSource delegate is called successfully")
         let delegate = MockInterestsDelegate(delegateExpectation)
 
         let service = MockInterestsService()

--- a/Tests/KeystoneTests/Tests/Services/NotificationSettingsServiceTests.swift
+++ b/Tests/KeystoneTests/Tests/Services/NotificationSettingsServiceTests.swift
@@ -21,7 +21,7 @@ class NotificationSettingsServiceTests: CoreDataTestCase {
     let settingsFilename = "notifications-settings.json"
     let dummyDeviceId = "1234"
 
-    // MARK: - Overriden Methods
+    // MARK: - Overridden Methods
     override func setUp() {
         super.setUp()
 

--- a/Tests/KeystoneTests/Tests/Services/NotificationSyncMediatorTests.swift
+++ b/Tests/KeystoneTests/Tests/Services/NotificationSyncMediatorTests.swift
@@ -20,7 +20,7 @@ class NotificationSyncMediatorTests: CoreDataTestCase {
     ///
     fileprivate let timeout = TimeInterval(3)
 
-    // MARK: - Overriden Methods
+    // MARK: - Overridden Methods
 
     override func setUp() {
         super.setUp()

--- a/Tests/KeystoneTests/Tests/Services/PostCoordinatorTests.swift
+++ b/Tests/KeystoneTests/Tests/Services/PostCoordinatorTests.swift
@@ -515,7 +515,7 @@ class PostCoordinatorTests: CoreDataTestCase {
     /// to generate a preview.
     func testSaveDraftPostChangesImmediately() async throws {
         // GIVEN a draft post with an unsynced revision and a local revision
-        // that wasn't commited yet
+        // that wasn't committed yet
         let post = PostBuilder(mainContext, blog: blog).build()
         post.status = .draft
         post.postID = 974
@@ -551,7 +551,7 @@ class PostCoordinatorTests: CoreDataTestCase {
     /// to generate a preview.
     func testSaveDraftPostChangesImmediatelyFailure() async throws {
         // GIVEN a draft post with an unsynced revision and a local revision
-        // that wasn't commited yet
+        // that wasn't committed yet
         let post = PostBuilder(mainContext, blog: blog).build()
         post.status = .draft
         post.postID = 974

--- a/Tests/KeystoneTests/Tests/Services/PostRepositorySaveTests.swift
+++ b/Tests/KeystoneTests/Tests/Services/PostRepositorySaveTests.swift
@@ -914,7 +914,7 @@ class PostRepositorySaveTests: CoreDataTestCase {
     }
 
     /// Scenario: the use sends the updated content to the server, the content
-    /// gets updated on the server, but the app never recieves a response.
+    /// gets updated on the server, but the app never receives a response.
     func testSaveConflictFalsePositiveNoResponseFromTheServer() async throws {
         // GIVEN a draft post (client behind, server has "content-c")
         let clientDateModified = Date(timeIntervalSince1970: 1709852440)

--- a/Tests/KeystoneTests/Tests/Services/ReaderTopicServiceTest.swift
+++ b/Tests/KeystoneTests/Tests/Services/ReaderTopicServiceTest.swift
@@ -331,7 +331,7 @@ final class ReaderTopicSwiftTest: CoreDataTestCase {
         let results = try! mainContext.fetch(request)
 
         var topic = results.last as! ReaderAbstractTopic
-        XCTAssertEqual(service.currentTopic(in: mainContext)?.type, ReaderDefaultTopic.TopicType, "The curent topic should have been a default topic")
+        XCTAssertEqual(service.currentTopic(in: mainContext)?.type, ReaderDefaultTopic.TopicType, "The current topic should have been a default topic")
 
         topic = results.first as! ReaderAbstractTopic
         service.setCurrentTopic(topic)

--- a/Tests/KeystoneTests/Tests/Utility/PagesListTests.swift
+++ b/Tests/KeystoneTests/Tests/Utility/PagesListTests.swift
@@ -125,14 +125,14 @@ class PagesListTests: CoreDataTestCase {
 
         let manyPages = parentPage(childrenCount: 17, additionalLevels: 7)
 
-        // Test 1: place the child page at the begining and the parent page at the end.
+        // Test 1: place the child page at the beginning and the parent page at the end.
         var sorted = PageTree.hierarchyList(of: [child] + manyPages + [parent])
         XCTAssertEqual(parent.hierarchyIndex, 0)
         XCTAssertEqual(child.hierarchyIndex, 1)
         // The child page should follow the parent page in the sorted list
         try XCTAssertEqual(XCTUnwrap(sorted.firstIndex(of: parent)) + 1, XCTUnwrap(sorted.firstIndex(of: child)))
 
-        // Test 2: place the child page at the end and the parent page at the begining.
+        // Test 2: place the child page at the end and the parent page at the beginning.
         sorted = PageTree.hierarchyList(of: [parent] + manyPages + [child])
         XCTAssertEqual(parent.hierarchyIndex, 0)
         XCTAssertEqual(child.hierarchyIndex, 1)
@@ -246,7 +246,7 @@ private extension Array where Element == Page {
 
     /// A string representation of a pages list whose element has a valid `hierarchyIndex` value.
     ///
-    /// The output looks similar to the Pages List in the app, where child page is indented based on it's hierachy level.
+    /// The output looks similar to the Pages List in the app, where child page is indented based on it's hierarchy level.
     ///
     /// For example, this output here represents four page instances. The digits in the string are page ids.
     /// Page 1 and 4 are top level pages. Page 1 has two child page: 2 and 3.

--- a/Tests/WordPressAuthenticatorTests/GoogleSignIn/CodeVerifierTests.swift
+++ b/Tests/WordPressAuthenticatorTests/GoogleSignIn/CodeVerifierTests.swift
@@ -11,7 +11,7 @@ class CodeVerifierTests: XCTestCase {
     }
 
     func testGeneratedCodeVerifierHasLength43() throws {
-        // 43 is the recommended lenght. See https://www.rfc-editor.org/rfc/rfc7636#section-4.1
+        // 43 is the recommended length. See https://www.rfc-editor.org/rfc/rfc7636#section-4.1
         XCTAssertEqual(try ProofKeyForCodeExchange.CodeVerifier.makeRandomCodeVerifier().rawValue.count, 43)
         XCTAssertEqual(try ProofKeyForCodeExchange.CodeVerifier.makeRandomCodeVerifier().rawValue.count, 43)
     }
@@ -34,7 +34,7 @@ class CodeVerifierTests: XCTestCase {
     // MARK: –
 
     func testCodeVerifierInitFailsWithValueShorterThan43() {
-        // 43 is the minimmum lenght from the spec
+        // 43 is the minimum length from the spec
         XCTAssertNil(ProofKeyForCodeExchange.CodeVerifier(value: ""))
         XCTAssertNil(ProofKeyForCodeExchange.CodeVerifier(value: "a".repeated(42)))
         XCTAssertEqual(ProofKeyForCodeExchange.CodeVerifier(value: "a".repeated(43))?.rawValue.count, 43)

--- a/WordPress/Classes/Extensions/Media/Media+Sync.swift
+++ b/WordPress/Classes/Extensions/Media/Media+Sync.swift
@@ -48,7 +48,7 @@ extension Media {
                 if media.remoteStatus == .pushing || media.remoteStatus == .processing {
                     media.remoteStatus = .failed
                 }
-                // If they failed to upload themselfs because no local copy exists then we need to delete this media object
+                // If they failed to upload themselves because no local copy exists then we need to delete this media object
                 // This scenario can happen when media objects were created based on an asset that failed to import to the WordPress App.
                 // For example a that is stored on the iCloud storage and because of the network connection failed the import process.
                 if media.remoteStatus == .failed,

--- a/WordPress/Classes/Services/CommentService.m
+++ b/WordPress/Classes/Services/CommentService.m
@@ -1124,7 +1124,7 @@ static NSTimeInterval const CommentsRefreshTimeoutInSeconds = 60 * 5; // 5 minut
         return nil;
     }
 
-    // (Insert a new comment into core data. Check for its existance first for paranoia sake.
+    // (Insert a new comment into core data. Check for its existence first for paranoia sake.
     // In theory a sync could include a newly created comment before the request that created it returned.
     Comment *comment = [NSEntityDescription insertNewObjectForEntityForName:NSStringFromClass([Comment class]) inManagedObjectContext:context];
 

--- a/WordPress/Classes/Services/MediaImageService.swift
+++ b/WordPress/Classes/Services/MediaImageService.swift
@@ -211,7 +211,7 @@ final class MediaImageService {
         return exporter
     }
 
-    /// - warning: This method was added only for backward-compatability with
+    /// - warning: This method was added only for backward-compatibility with
     /// the editor that relies on using URLs for displaying the preview thumbnail
     /// while the image is loaded. There is no guarantee that the URL will
     /// still be available after a period of time.

--- a/WordPress/Classes/Services/MediaImportService.swift
+++ b/WordPress/Classes/Services/MediaImportService.swift
@@ -35,7 +35,7 @@ class MediaImportService: NSObject {
 
     /// The initialiser for Objective-C code.
     ///
-    /// Using `ContextManager` as the argument becuase `CoreDataStackSwift` is not accessible from Objective-C code.
+    /// Using `ContextManager` as the argument because `CoreDataStackSwift` is not accessible from Objective-C code.
     @objc
     convenience init(contextManager: ContextManager) {
         self.init(coreDataStack: contextManager)

--- a/WordPress/Classes/Services/MediaSettings.swift
+++ b/WordPress/Classes/Services/MediaSettings.swift
@@ -152,7 +152,7 @@ class MediaSettings: NSObject {
     /// be resized on upload.
     /// If you set this to `minImageDimension` or lower, it will be set to `minImageDimension`.
     ///
-    /// - Important: don't access this propery directly to check what size to resize an image, use
+    /// - Important: don't access this property directly to check what size to resize an image, use
     ///             `imageSizeForUpload` instead.
     ///
     @objc var maxImageSizeSetting: Int {

--- a/WordPress/Classes/Services/Reader Post/ReaderPostService.m
+++ b/WordPress/Classes/Services/Reader Post/ReaderPostService.m
@@ -848,7 +848,7 @@ static NSString * const ReaderPostGlobalIDKey = @"globalID";
     marker.sortDate = [post.sortDate dateByAddingTimeInterval:-0.1];
     marker.date_created_gmt = post.sortDate;
 
-    // For compatability with posts that are sorted by score
+    // For compatibility with posts that are sorted by score
     marker.sortRank = @([post.sortRank doubleValue] - CGFLOAT_MIN);
     marker.score = post.score;
 

--- a/WordPress/Classes/Services/SharingService.swift
+++ b/WordPress/Classes/Services/SharingService.swift
@@ -13,7 +13,7 @@ import WordPressKit
 
     /// The initialiser for Objective-C code.
     ///
-    /// Using `ContextManager` as the argument becuase `CoreDataStackSwift` is not accessible from Objective-C code.
+    /// Using `ContextManager` as the argument because `CoreDataStackSwift` is not accessible from Objective-C code.
     @objc
     public init(contextManager: ContextManager) {
         self.coreDataStack = contextManager

--- a/WordPress/Classes/Stores/NoticeStore.swift
+++ b/WordPress/Classes/Stores/NoticeStore.swift
@@ -156,7 +156,7 @@ enum NoticeAction: Action {
     case clearWithTag(Notice.Tag)
     /// Removes all Notices except the current one.
     case empty
-    // Prevents the notices from showing up untill an unlock action.
+    // Prevents the notices from showing up until an unlock action.
     case lock
     // Show the missed notices.
     case unlock

--- a/WordPress/Classes/System/JetpackWindowManager.swift
+++ b/WordPress/Classes/System/JetpackWindowManager.swift
@@ -223,7 +223,7 @@ private extension JetpackWindowManager {
     ///   2. When the Load WordPress screen is shown.
     ///
     /// Note: We should remove this method when the migration phase is concluded and we no longer need
-    /// to perfom the migration.
+    /// to perform the migration.
     ///
     /// - Parameter navigationClosure: The closure containing logic that eventually calls the `show` method.
     func performSafeRootNavigation(with navigationClosure: @escaping () -> Void) {

--- a/WordPress/Classes/Utility/Networking/GutenbergRequestAuthenticator.swift
+++ b/WordPress/Classes/Utility/Networking/GutenbergRequestAuthenticator.swift
@@ -1,6 +1,6 @@
 import WordPressData
 
-/// Small override of RequestAuthenticator to be able to authenticate with writting rights on Atomic sites.
+/// Small override of RequestAuthenticator to be able to authenticate with writing rights on Atomic sites.
 /// Needed to load the gutenberg web editor on a web view on Atomic public and private sites.
 class GutenbergRequestAuthenticator: RequestAuthenticator {
     convenience init?(account: WPAccount, blog: Blog? = nil) {

--- a/WordPress/Classes/Utility/Notifications/InteractiveNotificationsManager.swift
+++ b/WordPress/Classes/Utility/Notifications/InteractiveNotificationsManager.swift
@@ -619,7 +619,7 @@ extension InteractiveNotificationsManager: UNUserNotificationCenterDelegate {
                 return
         }
 
-        // If the notification orginated from the share extension, disregard this current notification and resend a new one.
+        // If the notification originated from the share extension, disregard this current notification and resend a new one.
         ShareExtensionSessionManager.fireUserNotificationIfNeeded(postUploadOpID)
         completionHandler([])
     }

--- a/WordPress/Classes/Utility/WebViewController/WebKitViewController.swift
+++ b/WordPress/Classes/Utility/WebViewController/WebKitViewController.swift
@@ -198,7 +198,7 @@ class WebKitViewController: UIViewController, WebKitAuthenticatable {
         stackView.centerXAnchor.constraint(equalTo: view.centerXAnchor).isActive = true
         stackView.topAnchor.constraint(equalTo: safeArea.topAnchor).isActive = true
 
-        // this constraint saved as a varible so it can be deactivated when the toolbar is hidden, to prevent unintended pinning to the safe area
+        // this constraint saved as a variable so it can be deactivated when the toolbar is hidden, to prevent unintended pinning to the safe area
         let stackViewBottom = stackView.bottomAnchor.constraint(equalTo: safeArea.bottomAnchor)
         stackViewBottomAnchor = stackViewBottom
         NSLayoutConstraint.activate([stackViewBottom])

--- a/WordPress/Classes/Utility/WebViewController/WebNavigationDelegate.swift
+++ b/WordPress/Classes/Utility/WebViewController/WebNavigationDelegate.swift
@@ -2,7 +2,7 @@ import Foundation
 import WebKit
 
 // This is an odd design, but it needs to work on Objective-C
-// Since Swift now allows ommiting the type in static functions, it will
+// Since Swift now allows omitting the type in static functions, it will
 // look like an enum on the delegate implementations:
 //
 // func shouldNavigate(request: URLRequest) -> WebNavigationPolicy {

--- a/WordPress/Classes/ViewRelated/Comments/Views/Detail/CommentContentTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Comments/Views/Detail/CommentContentTableViewCell.swift
@@ -512,7 +512,7 @@ private extension CommentContentTableViewCell {
         fullContentHeight = contentHeight
 
         // - warning: It's important to set height to the minimum supported
-        // value because `WKWebView` can only increase the content height whe
+        // value because `WKWebView` can only increase the content height when
         // calculating content size (it will never decrease it).
         let minContentHeight: CGFloat = 20
         let effectiveContentHeight = contentHeight ?? minContentHeight

--- a/WordPress/Classes/ViewRelated/Media/Crop/ImageCropOverlayView.swift
+++ b/WordPress/Classes/ViewRelated/Media/Crop/ImageCropOverlayView.swift
@@ -16,7 +16,7 @@ class ImageCropOverlayView: UIView {
     @objc var outerColor: UIColor?
     var maskShape: ImageCropOverlayMaskShape = .circle
 
-    // MARK: - Overriden Methods
+    // MARK: - Overridden Methods
     override func layoutSubviews() {
         super.layoutSubviews()
         setNeedsDisplay()

--- a/WordPress/Classes/ViewRelated/Media/SiteMedia/Views/MediaStorageDetailsView.swift
+++ b/WordPress/Classes/ViewRelated/Media/SiteMedia/Views/MediaStorageDetailsView.swift
@@ -406,7 +406,7 @@ private struct MediaTypeBreakdown {
             } else {
                 // Media items with `mediaType` that is not handled by the app are consider "others". In an unlikely
                 // scenario where the media file size is zero, we'll consider them as "others", too. That's to avoid
-                // showing a specifc type with incorrect total file size.
+                // showing a specific type with incorrect total file size.
                 category = .other
             }
             categorized[category, default: []].append(item)

--- a/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
@@ -327,7 +327,7 @@ extension PublishingEditor {
             return wpAssertionFailure("managedObjectContext is missing")
         }
 
-        wpAssert(post.latest() == post, "Must be opened with the latest verison of the post")
+        wpAssert(post.latest() == post, "Must be opened with the latest version of the post")
 
         if !post.isUnsavedRevision && post.status != .trash {
             DDLogDebug("Creating new revision")

--- a/WordPress/Classes/ViewRelated/Reader/Controllers/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Controllers/ReaderStreamViewController.swift
@@ -822,7 +822,7 @@ import AutomatticTracks
     private func updateLastSyncedForTopic(_ objectID: NSManagedObjectID) {
         let context = ContextManager.shared.mainContext
         guard let topic = (try? context.existingObject(with: objectID)) as? ReaderAbstractTopic else {
-            DDLogError("Failed to retrive an existing topic when updating last sync date.")
+            DDLogError("Failed to retrieve an existing topic when updating last sync date.")
             return
         }
         topic.lastSynced = Date()
@@ -874,7 +874,7 @@ import AutomatticTracks
     }
 
     /// Returns the number of posts for the current topic
-    /// This allows the count to be overriden by subclasses
+    /// This allows the count to be overridden by subclasses
     var topicPostsCount: Int {
         return readerTopic?.posts.count ?? 0
     }

--- a/WordPress/Classes/ViewRelated/Reader/Controllers/ReaderTableContent.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Controllers/ReaderTableContent.swift
@@ -39,7 +39,7 @@ final class ReaderTableContent {
         do {
             try tableViewHandler?.resultsController?.performFetch()
         } catch let error as NSError {
-            DDLogError("Error fetching posts after updating the fetch reqeust predicate: \(error.localizedDescription)")
+            DDLogError("Error fetching posts after updating the fetch request predicate: \(error.localizedDescription)")
         }
     }
 

--- a/WordPress/WordPressShareExtension/Sources/Services/AppExtensionsService.swift
+++ b/WordPress/WordPressShareExtension/Sources/Services/AppExtensionsService.swift
@@ -463,7 +463,7 @@ fileprivate extension AppExtensionsService {
         let remote = PostServiceRemoteREST(wordPressComRestApi: simpleRestAPI, siteID: remotePost.siteID)
         remote.createPost(remotePost, success: { post in
             if let post {
-                DDLogInfo("Post \(post.postID.stringValue) sucessfully uploaded to site \(post.siteID.stringValue)")
+                DDLogInfo("Post \(post.postID.stringValue) successfully uploaded to site \(post.siteID.stringValue)")
                 if let postID = post.postID {
                     self.coreDataStack.updatePostOperation(with: .complete, remotePostID: postID.int64Value, forPostUploadOpWithObjectID: uploadOpObjectID)
                 } else {

--- a/WordPress/WordPressShareExtension/Sources/UI/ShareExtensionEditorViewController.swift
+++ b/WordPress/WordPressShareExtension/Sources/UI/ShareExtensionEditorViewController.swift
@@ -1238,7 +1238,7 @@ private extension ShareExtensionEditorViewController {
     }
 
     func makeRichTextViewFirstResponderAndPlaceCursorAtEnd() {
-        // Unfortunatly, we need set the first responder and cursor position in this manner otherwise
+        // Unfortunately, we need set the first responder and cursor position in this manner otherwise
         // some odd scrolling behavior occurs when inserting images into the share ext editor.
         DispatchQueue.main.async {
             if !self.richTextView.isFirstResponder {

--- a/WordPress/WordPressShareExtension/Sources/UI/ShareModularViewController.swift
+++ b/WordPress/WordPressShareExtension/Sources/UI/ShareModularViewController.swift
@@ -155,7 +155,7 @@ class ShareModularViewController: ShareExtensionAbstractViewController {
     fileprivate func setupCategoriesIfNeeded() {
         if shareData.allCategoriesForSelectedSite == nil {
             // Set to `true` so, on first load, the publish button is not enabled until the
-            // catagories for the selected site are fully loaded
+            // categories for the selected site are fully loaded
             isFetchingCategories = true
         }
         refreshModulesTable()

--- a/fastlane/lanes/codesign.rb
+++ b/fastlane/lanes/codesign.rb
@@ -156,7 +156,7 @@ def update_code_signing_app_store(readonly:, app_identifiers:)
 end
 
 def update_code_signing(type:, team_id:, readonly:, app_identifiers:, api_key_path:)
-  # NOTE: It might be neccessary to add `force: true` alongside `readonly: true` in order to regenerate some provisioning profiles.
+  # NOTE: It might be necessary to add `force: true` alongside `readonly: true` in order to regenerate some provisioning profiles.
   # If this turns out to be a hard requirement, we should consider updating the method with logic to toggle the two setting based on whether we're fetching or renewing.
   match(
     type: type,


### PR DESCRIPTION
## Description

Mechanical typo fixes in code comments, doc-comments, test descriptions, and one Fastlane comment.
No behavior changes; no user-facing strings touched.

Each commit fixes typos in a single file so the diff can be reviewed file-by-file or commit-by-commit.

## Testing instructions

- Skim the diff; verify each replacement is the obvious correction.
- CI should be green.

---

*Posted by Claude (Opus 4.7) on behalf of @mokagio with approval.*