### PR TITLE
Add Bootstrap section to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,26 +10,13 @@ Minimum requires iOS version is iOS 17. The latest iOS version is iOS 26.
 
 ## Bootstrap
 
-Before building or running tests — including in any newly created worktree — run:
+To prepare a fresh clone or worktree to build the app, run:
 
 ```sh
-bundle exec rake dependencies
+rake dependencies
 ```
 
 This is the canonical entry point for getting the repo ready to build.
-It checks Ruby/Bundler, applies mobile-secrets credentials (when configured), downloads the Gutenberg xcframeworks, and generates the internal app icon.
-
-`WordPress/Frameworks/` is gitignored and per-worktree, so this must be re-run in every fresh worktree.
-The Gutenberg xcframeworks themselves are cached at `~/Library/Caches/WordPress-iOS/Gutenberg/<version>`, so the network download only happens once per version.
-
-Other common task-runner entry points:
-
-- `bundle exec rake lint` / `bundle exec rake lintfix` — SwiftLint
-- `bundle exec rake xcode` — open the workspace (runs `dependencies` first)
-- `bundle exec rake mocks` — start the API mock server on port 8282
-
-For first-time machine setup (Xcode, Homebrew tools, credentials, GPG), see the "Getting Started" section in `README.md`.
-
 ## High-Level Architecture
 
 ### Project Structure

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,7 @@ rake dependencies
 ```
 
 This is the canonical entry point for getting the repo ready to build.
+
 ## High-Level Architecture
 
 ### Project Structure

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,28 @@ WordPress for iOS is the official mobile app for WordPress that lets users creat
 
 Minimum requires iOS version is iOS 17. The latest iOS version is iOS 26.
 
+## Bootstrap
+
+Before building or running tests — including in any newly created worktree — run:
+
+```sh
+bundle exec rake dependencies
+```
+
+This is the canonical entry point for getting the repo ready to build.
+It checks Ruby/Bundler, applies mobile-secrets credentials (when configured), downloads the Gutenberg xcframeworks, and generates the internal app icon.
+
+`WordPress/Frameworks/` is gitignored and per-worktree, so this must be re-run in every fresh worktree.
+The Gutenberg xcframeworks themselves are cached at `~/Library/Caches/WordPress-iOS/Gutenberg/<version>`, so the network download only happens once per version.
+
+Other common task-runner entry points:
+
+- `bundle exec rake lint` / `bundle exec rake lintfix` — SwiftLint
+- `bundle exec rake xcode` — open the workspace (runs `dependencies` first)
+- `bundle exec rake mocks` — start the API mock server on port 8282
+
+For first-time machine setup (Xcode, Homebrew tools, credentials, GPG), see the "Getting Started" section in `README.md`.
+
 ## High-Level Architecture
 
 ### Project Structure


### PR DESCRIPTION
## Description

Agents reading `AGENTS.md` had no canonical entry point for getting the repo to a buildable state.
`README.md`'s "Getting Started" section has it, but agents don't look there.

This adds a `## Bootstrap` section near the top pointing at `bundle exec rake dependencies`.

I realized I needed something like this as part of my worktree workflow, because`WordPress/Frameworks/` is gitignored and must be re-populated per worktree and my build kept failing.

Granted, a possible better solution would be to make the setup worktree-compatible somehow. But as far as I understand this is mostly a _me_ problem and I don't think the plumbing and rewiring needed would be a net benefit. Instead, a clearer instruction set seems a net win.