### PR TITLE
Fix typos in comments, docs, and a test message

### DIFF
--- a/Tests/WordPressKitTests/CoreAPITests/WordPressComRestApiTests.swift
+++ b/Tests/WordPressKitTests/CoreAPITests/WordPressComRestApiTests.swift
@@ -358,7 +358,7 @@ class WordPressComRestApiTests: XCTestCase {
             expect.fulfill()
             }, failure: { _, _ in
                 expect.fulfill()
-                XCTFail("This call should successful")
+                XCTFail("This call should be successful")
             }
         )
         self.waitForExpectations(timeout: 5, handler: nil)

--- a/Tests/WordPressKitTests/CoreAPITests/WordPressComRestApiTests.swift
+++ b/Tests/WordPressKitTests/CoreAPITests/WordPressComRestApiTests.swift
@@ -358,7 +358,7 @@ class WordPressComRestApiTests: XCTestCase {
             expect.fulfill()
             }, failure: { _, _ in
                 expect.fulfill()
-                XCTFail("This call should succesful")
+                XCTFail("This call should successful")
             }
         )
         self.waitForExpectations(timeout: 5, handler: nil)

--- a/Tests/WordPressKitTests/WordPressKitTests/Tests/BlogServiceRemoteRESTTests.m
+++ b/Tests/WordPressKitTests/WordPressKitTests/Tests/BlogServiceRemoteRESTTests.m
@@ -13,7 +13,7 @@ static NSTimeInterval const TestExpectationTimeout = 5;
 
 @implementation BlogServiceRemoteRESTTests
 
-#pragma mark - Overriden Methods
+#pragma mark - Overridden Methods
 
 - (void)tearDown
 {

--- a/Tests/WordPressKitTests/WordPressKitTests/Tests/NotificationSyncServiceRemoteTests.swift
+++ b/Tests/WordPressKitTests/WordPressKitTests/Tests/NotificationSyncServiceRemoteTests.swift
@@ -23,7 +23,7 @@ class NotificationSyncServiceRemoteTests: RemoteTestCase, RESTTestable {
 
     var remote: NotificationSyncServiceRemote!
 
-    // MARK: - Overriden Methods
+    // MARK: - Overridden Methods
 
     override func setUp() {
         super.setUp()

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecNavigationController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecNavigationController.swift
@@ -20,7 +20,7 @@ class AztecNavigationController: UINavigationController {
         return delegate as? AztecNavigationControllerDelegate
     }
 
-    // MARK: - Overriden Methods
+    // MARK: - Overridden Methods
 
     override func dismiss(animated flag: Bool, completion: (() -> Void)? = nil) {
         guard let alertController = presentedViewController as? UIAlertController else {

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/UnknownEditorViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/UnknownEditorViewController.swift
@@ -50,7 +50,7 @@ class UnknownEditorViewController: UIViewController {
         super.init(nibName: nil, bundle: nil)
     }
 
-    /// Overriden Initializers
+    /// Overridden Initializers
     ///
     required init?(coder aDecoder: NSCoder) {
         fatalError("You should use the `init(rawHTML:)` initializer!")

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/SiteDetailsSiteIconView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/SiteDetailsSiteIconView.swift
@@ -32,7 +32,7 @@ final class SiteDetailsSiteIconView: UIView {
     private var dropInteraction: UIDropInteraction?
 
     /// Set the menu to be displayed when the button is tapped. The menu replaces
-    /// teh default on tap action.
+    /// the default on tap action.
     func setMenu(_ menu: UIMenu, onMenuTriggered: @escaping () -> Void) {
         button.menu = menu
         button.showsMenuAsPrimaryAction = true

--- a/WordPress/Classes/ViewRelated/Blog/BloggingReminders/BloggingRemindersFlowSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/BloggingReminders/BloggingRemindersFlowSettingsViewController.swift
@@ -473,7 +473,7 @@ private extension BloggingRemindersFlowSettingsViewController {
         return view
     }
 
-    /// instantiates a UIView with transparent background, intented to be used as a spacer in a UIStackView
+    /// instantiates a UIView with transparent background, intended to be used as a spacer in a UIStackView
     func makeSpacer() -> UIView {
         let view = UIView()
         view.translatesAutoresizingMaskIntoConstraints = false

--- a/WordPress/Classes/ViewRelated/Blog/Sharing/SharingAuthorizationHelper.m
+++ b/WordPress/Classes/ViewRelated/Blog/Sharing/SharingAuthorizationHelper.m
@@ -48,7 +48,7 @@
 }
 
 /**
- Dismisses the curently presented modal view controller.
+ Dismisses the currently presented modal view controller.
  */
 - (void)dismissNavViewController
 {
@@ -422,7 +422,7 @@
     }
 
     // Check to see if the chosen connection and external ID matches an existin PublicizeConnection.
-    // If this is true the user has selected the already connected account and we can just treat it as a sucess.
+    // If this is true the user has selected the already connected account and we can just treat it as a success.
     if ([self publicizeConnection:connection usesKeyringConnection:keyringConnection withExternalID:externalID]) {
         // The user selected the existing connection. Treat this as success and bail.
         if ([self.delegate respondsToSelector:@selector(sharingAuthorizationHelper:didConnectToService:withPublicizeConnection:)]) {

--- a/WordPress/Classes/ViewRelated/Blog/Site Settings/DiscussionSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Settings/DiscussionSettingsViewController.swift
@@ -307,7 +307,7 @@ open class DiscussionSettingsViewController: UITableViewController {
         pickerViewController.title = NSLocalizedString("Links in comments", comment: "Comments Paging")
         pickerViewController.switchVisible = false
         pickerViewController.selectionText = NSLocalizedString("Links in comments", comment: "A label title")
-        pickerViewController.pickerHint = NSLocalizedString("Require manual approval for comments that include more than this number of links.", comment: "An explaination of a setting.")
+        pickerViewController.pickerHint = NSLocalizedString("Require manual approval for comments that include more than this number of links.", comment: "An explanation of a setting.")
         pickerViewController.pickerMinimumValue = commentsLinksMinimumValue
         pickerViewController.pickerMaximumValue = commentsLinksMaximumValue
         pickerViewController.pickerSelectedValue = settings.commentsMaximumLinks as? Int

--- a/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteSettingsViewController.m
@@ -1105,10 +1105,10 @@ NS_ENUM(NSInteger, SiteSettingsJetpack) {
 
 - (NSString *)getTagsCountPresentableString:(NSInteger)tagCount
 {
-    NSString *format = NSLocalizedString(@"%@ Tags", @"The number of tags in the writting settings. Plural. %@ is a placeholder for the number");
+    NSString *format = NSLocalizedString(@"%@ Tags", @"The number of tags in the writing settings. Plural. %@ is a placeholder for the number");
 
     if (tagCount == 1) {
-        format = NSLocalizedString(@"%@ Tag", @"The number of tags in the writting settings. Singular. %@ is a placeholder for the number");
+        format = NSLocalizedString(@"%@ Tag", @"The number of tags in the writing settings. Singular. %@ is a placeholder for the number");
     }
 
     NSString *numberOfTags = [NSString stringWithFormat: format, @(tagCount)];

--- a/WordPress/Classes/ViewRelated/Gutenberg/Collapsable Header/Collapsable Header Collection View Cell/CollapsableHeaderCollectionViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Collapsable Header/Collapsable Header Collection View Cell/CollapsableHeaderCollectionViewCell.swift
@@ -152,7 +152,7 @@ class CollapsableHeaderCollectionViewCell: UICollectionViewCell, NibLoadable {
         })
     }
 
-    /// This will retry the polling of the image URL in the situation where a mismatch was recieved for the requested image. This can happen for endpoints that
+    /// This will retry the polling of the image URL in the situation where a mismatch was received for the requested image. This can happen for endpoints that
     /// dynamically generate the images. This will stop retrying if the view scrolled off screen. Or if the view was updated with a new URL to fetch. It will also stop
     /// retrying for any other error type.
     func handleError(_ error: Error?, forURL url: String?) {

--- a/WordPress/Classes/ViewRelated/Gutenberg/Collapsable Header/CollapsableHeaderViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Collapsable Header/CollapsableHeaderViewController.swift
@@ -295,15 +295,15 @@ class CollapsableHeaderViewController: UIViewController, NoResultsViewHost {
 
     // MARK: - Footer Actions
     @IBAction open func defaultActionSelected(_ sender: Any) {
-        /* This should be overriden in a child class in order to enable support. */
+        /* This should be overridden in a child class in order to enable support. */
     }
 
     @IBAction open func primaryActionSelected(_ sender: Any) {
-        /* This should be overriden in a child class in order to enable support. */
+        /* This should be overridden in a child class in order to enable support. */
     }
 
     @IBAction open func secondaryActionSelected(_ sender: Any) {
-        /* This should be overriden in a child class in order to enable support. */
+        /* This should be overridden in a child class in order to enable support. */
     }
 
     // MARK: - Format Nav Bar
@@ -582,7 +582,7 @@ class CollapsableHeaderViewController: UIViewController, NoResultsViewHost {
         }
     }
 
-    // MARK: - Seperator styling
+    // MARK: - Separator styling
     private func updateSeperatorStyle(animated: Bool = true) {
         let shouldBeHidden: Bool
         switch separatorStyle {

--- a/WordPress/Classes/ViewRelated/Gutenberg/Layout Picker/GutenbergLayoutPickerViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Layout Picker/GutenbergLayoutPickerViewController.swift
@@ -133,7 +133,7 @@ class GutenbergLayoutPickerViewController: FilterableCategoriesViewController {
     private func handleErrors(_ error: Error) {
         guard resultsController.isEmpty() else { return }
         isLoading = false
-        let titleText = NSLocalizedString("Unable to load this content right now.", comment: "Informing the user that a network request failed becuase the device wasn't able to establish a network connection.")
+        let titleText = NSLocalizedString("Unable to load this content right now.", comment: "Informing the user that a network request failed because the device wasn't able to establish a network connection.")
         let subtitleText = NSLocalizedString("Check your network connection and try again or create a blank page.", comment: "Default subtitle for no-results when there is no connection with a prompt to create a new page instead.")
         displayNoResultsController(title: titleText, subtitle: subtitleText, resultsDelegate: self)
     }

--- a/WordPress/Classes/ViewRelated/Gutenberg/Processors/GutenbergBlockProcessor.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Processors/GutenbergBlockProcessor.swift
@@ -60,7 +60,7 @@ public class GutenbergBlockProcessor: Processor {
     /// Processes the block and for any needed replacements from a given opening tag match.
     ///     - Parameters:
     ///         - text: The string that the following parameter is found in.
-    ///     - Returns: The resulting string after the necessary replacements have occured
+    ///     - Returns: The resulting string after the necessary replacements have occurred
     ///
     public func process(_ text: String) -> String {
         let matches = openTagRegex.matches(in: text, options: [], range: text.utf16NSRange(from: text.startIndex ..< text.endIndex))

--- a/WordPress/Classes/ViewRelated/Gutenberg/Utils/GutenbergExternalMeidaPicker.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Utils/GutenbergExternalMeidaPicker.swift
@@ -53,7 +53,7 @@ extension GutenbergExternalMediaPicker: ExternalMediaPickerViewDelegate {
         }
 
         // For blocks that support multiple uploads this will upload all images.
-        // If multiple uploads are not supported then it will seperate them out to Image Blocks.
+        // If multiple uploads are not supported then it will separate them out to Image Blocks.
         if multipleSelection {
             insertOnBlock(with: assets, source: viewController.source)
         } else {
@@ -61,7 +61,7 @@ extension GutenbergExternalMediaPicker: ExternalMediaPickerViewDelegate {
         }
     }
 
-    /// Adds the given image object to the requesting block and seperates multiple images to seperate image blocks
+    /// Adds the given image object to the requesting block and seperates multiple images to separate image blocks
     /// - Parameter asset: Tenor Media object to add.
     func insertSingleImages(_ assets: [ExternalMediaAsset], source: MediaSource) {
         // Append the first item via callback given by Gutenberg.

--- a/WordPress/Classes/ViewRelated/Gutenberg/Utils/GutenbergExternalMeidaPicker.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Utils/GutenbergExternalMeidaPicker.swift
@@ -61,7 +61,7 @@ extension GutenbergExternalMediaPicker: ExternalMediaPickerViewDelegate {
         }
     }
 
-    /// Adds the given image object to the requesting block and seperates multiple images to separate image blocks
+    /// Adds the given image object to the requesting block and separates multiple images to separate image blocks
     /// - Parameter asset: Tenor Media object to add.
     func insertSingleImages(_ assets: [ExternalMediaAsset], source: MediaSource) {
         // Append the first item via callback given by Gutenberg.

--- a/WordPress/Classes/ViewRelated/Menus/Controllers/MenuItemSourceResultsViewController.h
+++ b/WordPress/Classes/ViewRelated/Menus/Controllers/MenuItemSourceResultsViewController.h
@@ -45,7 +45,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, assign) BOOL defersFooterViewMessageUpdates;
 
 /**
- Refreshes any data appearences within the view.
+ Refreshes any data appearances within the view.
  */
 - (void)refresh;
 
@@ -157,7 +157,7 @@ NS_ASSUME_NONNULL_BEGIN
 @protocol MenuItemSourceResultsViewControllerDelegate <NSObject>
 
 /**
- Helper method for informing whether or not the name should be overriden by itemType changes.
+ Helper method for informing whether or not the name should be overridden by itemType changes.
  */
 - (BOOL)sourceResultsViewControllerCanOverrideItemName:(MenuItemSourceResultsViewController *)sourceResultsViewController;
 

--- a/WordPress/Classes/ViewRelated/Notifications/Views/LikeUserTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Views/LikeUserTableViewCell.swift
@@ -61,6 +61,6 @@ private extension LikeUserTableViewCell {
     }
 
     struct Constants {
-        static let usernameFormat = NSLocalizedString("@%1$@", comment: "Label displaying the user's username preceeded by an '@' symbol. %1$@ is a placeholder for the username.")
+        static let usernameFormat = NSLocalizedString("@%1$@", comment: "Label displaying the user's username preceded by an '@' symbol. %1$@ is a placeholder for the username.")
     }
 }

--- a/WordPress/Classes/ViewRelated/Notifications/Views/NoteBlockHeaderTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Views/NoteBlockHeaderTableViewCell.swift
@@ -90,7 +90,7 @@ class NoteBlockHeaderTableViewCell: NoteBlockTableViewCell {
         authorAvatarImageView.image = .gravatarPlaceholderImage
     }
 
-    // MARK: - Overriden Methods
+    // MARK: - Overridden Methods
 
     override func prepareForReuse() {
         super.prepareForReuse()

--- a/WordPress/Classes/ViewRelated/Reader/Detail/WebView/ReaderWebView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/WebView/ReaderWebView.swift
@@ -158,7 +158,7 @@ class ReaderWebView: WKWebView {
         """, completionHandler: nil)
     }
 
-    /// Change all occurences of elements to change it's HTML tag to "element-placeholder"
+    /// Change all occurrences of elements to change it's HTML tag to "element-placeholder"
     /// Ie.: img -> img-placeholder
     /// This will make the text to appear fast, so the user can start reading
     ///

--- a/WordPress/Classes/ViewRelated/User Profile Sheet/UserProfileUserInfoCell.swift
+++ b/WordPress/Classes/ViewRelated/User Profile Sheet/UserProfileUserInfoCell.swift
@@ -58,6 +58,6 @@ private extension UserProfileUserInfoCell {
     }
 
     struct Constants {
-        static let usernameFormat = NSLocalizedString("@%1$@", comment: "Label displaying the user's username preceeded by an '@' symbol. %1$@ is a placeholder for the username.")
+        static let usernameFormat = NSLocalizedString("@%1$@", comment: "Label displaying the user's username preceded by an '@' symbol. %1$@ is a placeholder for the username.")
     }
 }

--- a/WordPress/Classes/ViewRelated/Views/RichTextView/RichTextView.swift
+++ b/WordPress/Classes/ViewRelated/Views/RichTextView/RichTextView.swift
@@ -190,7 +190,7 @@ import UniformTypeIdentifiers
         }
     }
 
-    // MARK: - Overriden Methods
+    // MARK: - Overridden Methods
     open override var intrinsicContentSize: CGSize {
         guard let maxWidth = preferredMaxLayoutWidth else {
             return super.intrinsicContentSize


### PR DESCRIPTION
## Description

Mechanical typo fixes in code comments, doc comments, `NSLocalizedString` translator hints, and an `XCTFail` message — no behaviour change. User-facing localized strings and code identifiers are untouched.

Each commit is one file, so the change is easy to review file by file.

## Testing instructions

No runtime impact — comment/test-string only. A green CI build is sufficient.

---

*Posted by Claude (Opus 4.8) on behalf of @mokagio with approval.*
