### PR TITLE
Fix a couple of Core Data related crashes

### DIFF
--- a/WordPress/Classes/Services/CommentServiceRemoteFactory.swift
+++ b/WordPress/Classes/Services/CommentServiceRemoteFactory.swift
@@ -1,6 +1,7 @@
 import Foundation
 import WordPressData
 import WordPressKit
+import WordPressShared
 
 /// Provides service remote instances for CommentService
 @objc public class CommentServiceRemoteFactory: NSObject {
@@ -12,6 +13,7 @@ import WordPressKit
     @objc public func remote(blog: Blog?) -> CommentServiceRemote? {
         // Workaround for now: `Comment.blog` might be nil, so a nil blog can reach here.
         guard let blog else {
+            wpAssertionFailure("Attempting to create a CommentServiceRemote for a nil blog")
             return nil
         }
 

--- a/WordPress/Classes/Services/CommentServiceRemoteFactory.swift
+++ b/WordPress/Classes/Services/CommentServiceRemoteFactory.swift
@@ -9,7 +9,12 @@ import WordPressKit
     ///
     /// - Parameter blog: A valid Blog object
     /// - Returns: A CommentServiceRemote instance
-    @objc public func remote(blog: Blog) -> CommentServiceRemote? {
+    @objc public func remote(blog: Blog?) -> CommentServiceRemote? {
+        // Workaround for now: `Comment.blog` might be nil, so a nil blog can reach here.
+        guard let blog else {
+            return nil
+        }
+
         if blog.supports(.wpComRESTAPI),
            let api = blog.wordPressComRestApi,
            let dotComID = blog.dotComID {

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergNetworking.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergNetworking.swift
@@ -11,7 +11,8 @@ struct GutenbergNetworkRequest {
     // For example, when uploading an image to a post in a self-hosted site, this struct is instantiated with a path
     // `/wp/v2/media/<id>?context=edit&_locale=user`.
     private let path: String
-    private unowned let blog: Blog
+    private let blogID: TaggedManagedObjectID<Blog>
+    private let coreDataStack: CoreDataStack
     private let method: HTTPMethod
     private let data: [String: AnyObject]?
 
@@ -20,29 +21,46 @@ struct GutenbergNetworkRequest {
         case post = "POST"
     }
 
-    init(path: String, blog: Blog, method: HTTPMethod = .get, data: [String: AnyObject]? = nil) {
+    init(path: String, blogID: TaggedManagedObjectID<Blog>, coreDataStack: CoreDataStack = ContextManager.shared, method: HTTPMethod = .get, data: [String: AnyObject]? = nil) {
         self.path = path
-        self.blog = blog
+        self.blogID = blogID
+        self.coreDataStack = coreDataStack
         self.method = method
         self.data = data
     }
 
     func request(completion: @escaping CompletionHandler) {
+        // Resolve the `Blog` on the main context at request time. The Gutenberg JS bridge can fire requests
+        // while the editor is being torn down, so the blog may have been deleted; `existingObject(with:)`
+        // throws in that case instead of dereferencing an invalidated managed object. Resolving on the
+        // main context (where the editor's blog lives) also reuses its cached REST API client.
+        let context = coreDataStack.mainContext
+        context.perform {
+            do {
+                let blog = try context.existingObject(with: self.blogID)
+                self.request(blog: blog, completion: completion)
+            } catch {
+                completion(.failure(error as NSError))
+            }
+        }
+    }
+
+    private func request(blog: Blog, completion: @escaping CompletionHandler) {
         if blog.isAccessibleThroughWPCom, let dotComID = blog.dotComID {
             switch method {
             case .get:
-                dotComGetRequest(with: dotComID, completion: completion)
+                dotComGetRequest(blog: blog, with: dotComID, completion: completion)
             case .post:
-                dotComPostRequest(with: dotComID, data: data, completion: completion)
+                dotComPostRequest(blog: blog, with: dotComID, data: data, completion: completion)
             }
         } else {
-            selfHostedRequest(completion: completion)
+            selfHostedRequest(blog: blog, completion: completion)
         }
     }
 
     // MARK: - dotCom
 
-    private func dotComGetRequest(with dotComID: NSNumber, completion: @escaping CompletionHandler) {
+    private func dotComGetRequest(blog: Blog, with dotComID: NSNumber, completion: @escaping CompletionHandler) {
         blog.wordPressComRestApi?.GET(dotComPath(with: dotComID), parameters: nil, success: { response, _ in
             completion(.success(response))
         }, failure: { error, httpResponse in
@@ -50,7 +68,7 @@ struct GutenbergNetworkRequest {
         })
     }
 
-    private func dotComPostRequest(with dotComID: NSNumber, data: [String: AnyObject]?, completion: @escaping CompletionHandler) {
+    private func dotComPostRequest(blog: Blog, with dotComID: NSNumber, data: [String: AnyObject]?, completion: @escaping CompletionHandler) {
         blog.wordPressComRestApi?.POST(dotComPath(with: dotComID), parameters: data, success: { response, _ in
             completion(.success(response))
         }, failure: { error, httpResponse in
@@ -66,11 +84,11 @@ struct GutenbergNetworkRequest {
 
     // MARK: - Self-Hosed
 
-    private func selfHostedRequest(completion: @escaping CompletionHandler) {
-        performSelfHostedRequest(completion: completion)
+    private func selfHostedRequest(blog: Blog, completion: @escaping CompletionHandler) {
+        performSelfHostedRequest(blog: blog, completion: completion)
     }
 
-    private func performSelfHostedRequest(completion: @escaping CompletionHandler) {
+    private func performSelfHostedRequest(blog: Blog, completion: @escaping CompletionHandler) {
         guard let api = blog.selfHostedSiteRestApi else {
             completion(.failure(NSError(domain: NSURLErrorDomain, code: NSURLErrorUnknown, userInfo: nil)))
             return

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
@@ -199,6 +199,11 @@ class GutenbergViewController: UIViewController, PostEditor, PublishingEditor {
 
     let navigationBarManager: PostEditorNavigationBarManager
 
+    /// Identifies the site being edited. Stored as an ID (not a `Blog`) so network requests can re-resolve the
+    /// `Blog` on the main context at call time and fail gracefully if it has been deleted, rather than
+    /// dereferencing an invalidated managed object.
+    private let blogID: TaggedManagedObjectID<Blog>
+
     // swiftlint:disable:next weak_delegate
     lazy var attachmentDelegate = AztecAttachmentDelegate(post: post)
 
@@ -296,6 +301,7 @@ class GutenbergViewController: UIViewController, PostEditor, PublishingEditor {
     ) {
 
         self.post = post
+        self.blogID = TaggedManagedObjectID(post.blog)
 
         self.replaceEditor = replaceEditor
         self.editorSession = PostEditorAnalyticsSession(editor: .gutenberg, post: post)
@@ -559,31 +565,11 @@ extension GutenbergViewController {
 /// - warning: the app can't make any assumption about the thread on which `GutenbergBridgeDelegate` gets invoked. In some scenarios, it gets called from the main thread, for example, if being invoked directly from [Gutenberg.swift](https://github.com/WordPress/gutenberg/blob/64f9d9d1ced7a5aa7f3874890306554c5b703ce6/packages/react-native-bridge/ios/Gutenberg.swift). And sometimes, it gets called on a dispatch queue created by the React Native runtime for a native module (see [React Native: Threading](https://reactnative.dev/docs/native-modules-ios#threading). It happens when the methods are invoked directly from JavaScript.
 extension GutenbergViewController: GutenbergBridgeDelegate {
     func gutenbergDidGetRequestFetch(path: String, completion: @escaping (Result<Any, NSError>) -> Void) {
-        guard let context = post.managedObjectContext else {
-            didEncounterMissingContextError()
-            completion(.failure(URLError(.unknown) as NSError))
-            return
-        }
-        context.perform {
-            GutenbergNetworkRequest(path: path, blog: self.post.blog, method: .get).request(completion: completion)
-        }
+        GutenbergNetworkRequest(path: path, blogID: blogID, method: .get).request(completion: completion)
     }
 
     func gutenbergDidPostRequestFetch(path: String, data: [String: AnyObject]?, completion: @escaping (Result<Any, NSError>) -> Void) {
-        guard let context = post.managedObjectContext else {
-            didEncounterMissingContextError()
-            completion(.failure(URLError(.unknown) as NSError))
-            return
-        }
-        context.perform {
-            GutenbergNetworkRequest(path: path, blog: self.post.blog, method: .post, data: data).request(completion: completion)
-        }
-    }
-
-    private func didEncounterMissingContextError() {
-        DispatchQueue.main.async {
-            WordPressAppDelegate.crashLogging?.logError(NSError(domain: self.errorDomain, code: ErrorCode.managedObjectContextMissing.rawValue, userInfo: [NSDebugDescriptionErrorKey: "The post is missing an associated managed object context"]))
-        }
+        GutenbergNetworkRequest(path: path, blogID: blogID, method: .post, data: data).request(completion: completion)
     }
 
     func editorDidAutosave() {


### PR DESCRIPTION
## Description

Fixes https://linear.app/a8c/issue/CMM-2089 and  https://linear.app/a8c/issue/CMM-2090.

The crashes are caused by failing to resolve a `Blog` instance from the GutenbergMobile editor, and the `Comment.blog` property could be nil. I wasn't able to reproduce the crash, though, so it might be worth digging deeper later.