### PR TITLE
Fix AI undo redo editor test

### DIFF
--- a/Tests/AgentTests/ui-tests/undo-redo-in-editor.md
+++ b/Tests/AgentTests/ui-tests/undo-redo-in-editor.md
@@ -9,15 +9,18 @@
 3. If a bottom sheet appears, select "Post".
 4. Verify the Undo button is disabled.
 5. Verify the Redo button is disabled.
-6. Enter "Rich post title" as the post title.
+6. Enter "Undo test" as the post title.
 7. Tap below the title to add a paragraph block.
-8. Type "Lorem ipsum dolor sit amet" as the paragraph content.
-9. Tap the Undo button twice to undo the paragraph and title.
-10. Verify the editor content is empty (no blocks visible).
-11. Tap the Redo button twice to restore the paragraph and title.
-12. Verify the paragraph content "Lorem ipsum dolor sit amet" is visible again.
+8. Type "Test" as the paragraph content.
+9. Tap the Undo button until the typed title and paragraph text are no longer visible and the Undo button becomes disabled.
+   Undo is granular, so it may take several taps. Stop as soon as Undo is disabled. Do not tap Undo more than 15 times.
+10. Verify the typed title and paragraph text are no longer visible, and the Undo button is disabled.
+    Empty title or paragraph placeholders may still be visible.
+11. Tap the Redo button until the title and paragraph are restored and the Redo button becomes disabled.
+    Redo is granular, so it may take several taps. Stop as soon as Redo is disabled. Do not tap Redo more than 15 times.
+12. Verify the title "Undo test" and paragraph content "Test" are visible again, and the Redo button is disabled.
 
 ## Expected Outcome
-- After undoing, the editor content is empty.
-- After redoing, the title and paragraph content are restored.
+- After undoing all edits, the typed title and paragraph text are gone and the Undo button is disabled.
+- After redoing all edits, the title and paragraph content are restored and the Redo button is disabled.
 - Undo and Redo buttons correctly reflect available actions throughout the flow.

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
@@ -1207,7 +1207,7 @@ extension GutenbergViewController: PostEditorNavigationBarManagerDelegate {
     func gutenbergDidRequestToggleUndoButton(_ isDisabled: Bool) {
         DispatchQueue.main.async {
             UIView.animate(withDuration: 0.2) {
-                self.navigationBarManager.undoButton.isUserInteractionEnabled = isDisabled ? false : true
+                self.navigationBarManager.undoButton.isEnabled = !isDisabled
                 self.navigationBarManager.undoButton.alpha = isDisabled ? 0.3 : 1.0
             }
         }
@@ -1216,7 +1216,7 @@ extension GutenbergViewController: PostEditorNavigationBarManagerDelegate {
     func gutenbergDidRequestToggleRedoButton(_ isDisabled: Bool) {
         DispatchQueue.main.async {
             UIView.animate(withDuration: 0.2) {
-                self.navigationBarManager.redoButton.isUserInteractionEnabled = isDisabled ? false : true
+                self.navigationBarManager.redoButton.isEnabled = !isDisabled
                 self.navigationBarManager.redoButton.alpha = isDisabled ? 0.3 : 1.0
             }
         }

--- a/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
@@ -60,6 +60,15 @@ class NewGutenbergViewController: PostGBKEditorViewController, PostEditor, Publi
 
     // TODO: reimplemet
 //    internal private(set) var contentInfo: ContentInfo?
+    private var isNavigationEnabled = true {
+        didSet { updateHistoryButtons() }
+    }
+    private var isUndoButtonDisabled = true {
+        didSet { updateHistoryButtons() }
+    }
+    private var isRedoButtonDisabled = true {
+        didSet { updateHistoryButtons() }
+    }
 
     // MARK: - GutenbergKit
 
@@ -154,28 +163,34 @@ class NewGutenbergViewController: PostGBKEditorViewController, PostEditor, Publi
 
     private func gutenbergDidRequestToggleRedoButton(_ isDisabled: Bool) {
         DispatchQueue.main.async {
-            UIView.animate(withDuration: 0.2) {
-                self.navigationBarManager.redoButton.isUserInteractionEnabled = isDisabled ? false : true
-                self.navigationBarManager.redoButton.alpha = isDisabled ? 0.3 : 1.0
-            }
+            self.isRedoButtonDisabled = isDisabled
         }
     }
 
     private func gutenbergDidRequestToggleUndoButton(_ isDisabled: Bool) {
         DispatchQueue.main.async {
-            UIView.animate(withDuration: 0.2) {
-                self.navigationBarManager.undoButton.isUserInteractionEnabled = isDisabled ? false : true
-                self.navigationBarManager.undoButton.alpha = isDisabled ? 0.3 : 1.0
-            }
+            self.isUndoButtonDisabled = isDisabled
         }
     }
 
     private func setNavigationItemsEnabled(_ enabled: Bool) {
+        isNavigationEnabled = enabled
         navigationBarManager.closeButton.isEnabled = enabled
         navigationBarManager.moreButton.isEnabled = enabled
-        navigationBarManager.publishButton.isEnabled = enabled
-        navigationBarManager.undoButton.isEnabled = enabled
-        navigationBarManager.redoButton.isEnabled = enabled
+        navigationBarManager.publishButton.isEnabled = enabled && isPublishButtonEnabled
+    }
+
+    private func updateHistoryButtons() {
+        updateHistoryButton(navigationBarManager.undoButton, isDisabled: !isNavigationEnabled || isUndoButtonDisabled)
+        updateHistoryButton(navigationBarManager.redoButton, isDisabled: !isNavigationEnabled || isRedoButtonDisabled)
+    }
+
+    private func updateHistoryButton(_ button: UIButton, isDisabled: Bool) {
+        let isEnabled = !isDisabled
+        UIView.animate(withDuration: 0.2) {
+            button.isEnabled = isEnabled
+            button.alpha = isEnabled ? 1.0 : 0.3
+        }
     }
 
     private func performAutoSave() {

--- a/WordPress/Classes/ViewRelated/Post/PostEditorNavigationBarManager.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditorNavigationBarManager.swift
@@ -40,7 +40,7 @@ class PostEditorNavigationBarManager {
         button.addTarget(self, action: #selector(undoWasPressed), for: .touchUpInside)
         button.sizeToFit()
         button.alpha = 0.3
-        button.isUserInteractionEnabled = false
+        button.isEnabled = false
         return button
     }()
 
@@ -54,7 +54,7 @@ class PostEditorNavigationBarManager {
         button.addTarget(self, action: #selector(redoWasPressed), for: .touchUpInside)
         button.sizeToFit()
         button.alpha = 0.3
-        button.isUserInteractionEnabled = false
+        button.isEnabled = false
         return button
     }()
 


### PR DESCRIPTION
## Summary
- Update the AI undo/redo test to match granular editor history behavior.
- Expose disabled undo/redo button state via isEnabled for accessibility.
- Preserve undo/redo history availability when GutenbergKit modals close.