### PR TITLE
Bump GutenbergKit to 0.17.1 (test xcframework resources)

### DIFF
--- a/Modules/Package.resolved
+++ b/Modules/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "84257158eee34b797c4f5c81ad33c2f508fe93818c99642c468f31136376cda1",
+  "originHash" : "e9beeef5b5a88cb27b7ec9dbfda60de6bb3ba45352c92932b2b086226c94cfc6",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -131,8 +131,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/wordpress-mobile/GutenbergKit",
       "state" : {
-        "revision" : "f390848952e98d241075c4e65f1e0f6791a695fa",
-        "version" : "0.15.0"
+        "revision" : "b274c08a93677c3c8481094d91f3c2b213ff915a",
+        "version" : "0.17.1"
       }
     },
     {

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -60,7 +60,7 @@ let package = Package(
             revision: "b34794c9a3f32312e1593d4a3d120572afa0d010"
         ),
         .package(url: "https://github.com/zendesk/support_sdk_ios", from: "8.0.3"),
-        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", from: "0.15.0"),
+        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", exact: "0.17.1"),
         .package(
             url: "https://github.com/automattic/wordpress-rs",
             exact: "0.3.0"

--- a/WordPress/Classes/ViewRelated/NewGutenberg/GBKExtensions.swift
+++ b/WordPress/Classes/ViewRelated/NewGutenberg/GBKExtensions.swift
@@ -44,6 +44,11 @@ private func getLocalizedString(for value: GutenbergKit.EditorLocalizableString)
     case .patternsCategoryAll: NSLocalizedString("editor.patterns.all", value: "All", comment: "Category name for section showing all patterns")
     case .loadingEditor: NSLocalizedString("editor.loading.title", value: "Loading Editor", comment: "Text shown while the editor is loading")
     case .editorError: NSLocalizedString("editor.error.title", value: "Editor Error", comment: "Title shown when the editor encounters an error")
+    case .lockdownModeTitle: NSLocalizedString("editor.lockdownMode.title", value: "Lockdown Mode Detected", comment: "Title shown when the editor detects that Lockdown Mode is enabled")
+    case .lockdownModeWarning: NSLocalizedString("editor.lockdownMode.warning", value: "Lockdown Mode is enabled. The editor may not work correctly.", comment: "Warning shown when the editor detects that Lockdown Mode is enabled")
+    case .lockdownModeExcludeHint: NSLocalizedString("editor.lockdownMode.excludeHint", value: "You can exclude this app from Lockdown Mode in Settings, then re-open the editor to restore full functionality.", comment: "Hint explaining how to exclude the app from Lockdown Mode so the editor works")
+    case .lockdownModeLearnMore: NSLocalizedString("editor.lockdownMode.learnMore", value: "Learn More", comment: "Button title to learn more about Lockdown Mode and the editor")
+    case .lockdownModeDismiss: NSLocalizedString("editor.lockdownMode.dismiss", value: "Dismiss", comment: "Button title to dismiss the Lockdown Mode warning in the editor")
     }
 }
 


### PR DESCRIPTION
> 🤖 **Auto agent note:** Opened by Claude (Opus 4.8) doing background investigation on behalf of @mokagio. **Test bump** to validate the GutenbergKit xcframework resource distribution against CI — not intended to merge as-is.

## Description

Bumps `GutenbergKit` from `0.15.0` to `0.17.1`.

`0.17.1` is the **first GutenbergKit release** that ships the `GutenbergKitResources` sub-dependency as a prebuilt **xcframework** (`DependencyMode.release`, fetched from CDN) instead of building it from local source. This PR exercises that distribution path end-to-end in WordPress-iOS.

Pinned with `exact: "0.17.1"` to keep the test deterministic.

Part of [AINFRA-1968](https://linear.app/a8c/issue/AINFRA-1968/test-gutenbergkitresources-via-beta-tags-in-wordpress-ios-till-its).

## Findings so far

- **The xcframework distribution itself works.** On the first CI run, `GutenbergKitResources.framework` downloaded from CDN, was copied into the app, and code-signed cleanly.
- The first run failed only on an **app-side source-compat break**: 0.17.1 adds five `lockdownMode*` cases to `EditorLocalizableString`, which made the exhaustive `switch` in `GBKExtensions.swift` non-exhaustive. Second commit maps those cases, which should be the only app change required by this bump.

## Testing instructions

- Let CI build the app and run the editor-related tests.
- Smoke-test the block editor (open a post, insert/edit blocks) to confirm the xcframework-distributed resources load at runtime.
