### PR TITLE
Remove a couple of usages of WordPressAuthenticator

### DIFF
--- a/WordPress/Classes/System/WordPressAppDelegate+openURL.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate+openURL.swift
@@ -1,6 +1,5 @@
 import AutomatticTracks
 import BuildSettingsKit
-import WordPressAuthenticator
 import WordPressData
 import WordPressShared
 
@@ -46,8 +45,6 @@ import WordPressShared
             return handleNewPost(url: url)
         case "newpage":
             return handleNewPage(url: url)
-        case "magic-login":
-            return handleMagicLogin(url: url)
         case "viewpost":
             return handleViewPost(url: url)
         case "viewstats":
@@ -57,21 +54,6 @@ import WordPressShared
         default:
             return false
         }
-    }
-
-    private func handleMagicLogin(url: URL) -> Bool {
-        DDLogInfo("App launched with authentication link")
-
-        guard AccountHelper.noWordPressDotComAccount || url.isJetpackConnect else {
-            DDLogInfo("The user clicked on a login or signup magic link when already logged into a WPCom account.  Since this is not a Jetpack connection attempt we're cancelling the operation.")
-            return false
-        }
-
-        guard let rvc = window?.rootViewController else {
-            return false
-        }
-
-        return WordPressAuthenticator.openAuthenticationURL(url, fromRootViewController: rvc)
     }
 
     private func handleViewPost(url: URL) -> Bool {

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -1,4 +1,3 @@
-import WordPressAuthenticator
 import WordPressData
 import UIKit
 import SwiftUI
@@ -645,7 +644,8 @@ final class MySiteViewController: UIViewController, UIScrollViewDelegate, NoSite
     }
 
     private func launchLoginForSelfHostedSite() {
-        WordPressAuthenticator.showLoginForSelfHostedSite(self)
+        AddSiteController(viewController: self, source: "my_site_no_sites")
+            .showSelfHostedSiteLoginScreen()
     }
 
     func launchSiteCreation(source: String) {
@@ -667,11 +667,6 @@ final class MySiteViewController: UIViewController, UIScrollViewDelegate, NoSite
                 SiteCreationAnalyticsHelper.trackSiteCreationAccessed(source: source)
             }
         )
-    }
-
-    @objc
-    private func showAddSelfHostedSite() {
-        WordPressAuthenticator.showLoginForSelfHostedSite(self)
     }
 
     // MARK: - Blog Details UI Logic

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -85,8 +85,10 @@ final class MySiteViewController: UIViewController, UIScrollViewDelegate, NoSite
         return viewContoller
     }
 
-    init(blogService: BlogService? = nil,
-         overlaysCoordinator: MySiteOverlaysCoordinator = .init()) {
+    init(
+        blogService: BlogService? = nil,
+        overlaysCoordinator: MySiteOverlaysCoordinator = .init()
+    ) {
         self.blogService = blogService ?? BlogService(coreDataStack: ContextManager.shared)
         self.viewModel = MySiteViewModel()
         self.overlaysCoordinator = overlaysCoordinator
@@ -118,7 +120,7 @@ final class MySiteViewController: UIViewController, UIScrollViewDelegate, NoSite
         }
 
         get {
-            return headerViewController?.blog
+            headerViewController?.blog
         }
     }
 
@@ -215,28 +217,40 @@ final class MySiteViewController: UIViewController, UIScrollViewDelegate, NoSite
 
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
-        createButtonCoordinator?.presentingTraitCollectionWillChange(traitCollection, newTraitCollection: traitCollection)
+        createButtonCoordinator?
+            .presentingTraitCollectionWillChange(traitCollection, newTraitCollection: traitCollection)
     }
 
-    override func willTransition(to newCollection: UITraitCollection, with coordinator: UIViewControllerTransitionCoordinator) {
+    override func willTransition(
+        to newCollection: UITraitCollection,
+        with coordinator: UIViewControllerTransitionCoordinator
+    ) {
         super.willTransition(to: newCollection, with: coordinator)
         createButtonCoordinator?.presentingTraitCollectionWillChange(traitCollection, newTraitCollection: newCollection)
     }
 
     private func subscribeToPostPublished() {
-        NotificationCenter.default.addObserver(self, selector: #selector(handlePostPublished), name: .newPostPublished, object: nil)
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handlePostPublished),
+            name: .newPostPublished,
+            object: nil
+        )
     }
 
     private func subscribeToWillEnterForeground() {
-        NotificationCenter.default.addObserver(self,
-                                               selector: #selector(displayOverlayIfNeeded),
-                                               name: UIApplication.willEnterForegroundNotification,
-                                               object: nil)
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(displayOverlayIfNeeded),
+            name: UIApplication.willEnterForegroundNotification,
+            object: nil
+        )
     }
 
     func updateNavigationTitle(for blog: Blog) {
         let blogName = blog.settings?.name
-        let title = blogName != nil && blogName?.isEmpty == false
+        let title =
+            blogName != nil && blogName?.isEmpty == false
             ? blogName
             : Strings.mySite
         navigationItem.title = title
@@ -286,12 +300,19 @@ final class MySiteViewController: UIViewController, UIScrollViewDelegate, NoSite
         navigationController?.navigationBar.accessibilityIdentifier = "my-site-navigation-bar"
 
         if isSidebarModeEnabled {
-            notificationsButtonViewModel.$image.sink { [weak self] in
-                guard let self else { return }
-                let button = UIBarButtonItem(image: $0, style: .plain, target: self, action: #selector(buttonShowNotificationsTapped))
-                button.accessibilityIdentifier = "bar-button-item-notifications"
-                self.navigationItem.rightBarButtonItem = button
-            }.store(in: &cancellables)
+            notificationsButtonViewModel.$image
+                .sink { [weak self] in
+                    guard let self else { return }
+                    let button = UIBarButtonItem(
+                        image: $0,
+                        style: .plain,
+                        target: self,
+                        action: #selector(buttonShowNotificationsTapped)
+                    )
+                    button.accessibilityIdentifier = "bar-button-item-notifications"
+                    self.navigationItem.rightBarButtonItem = button
+                }
+                .store(in: &cancellables)
         }
     }
 
@@ -318,14 +339,20 @@ final class MySiteViewController: UIViewController, UIScrollViewDelegate, NoSite
 
     private func setNavigationBarHidden(_ isHidden: Bool, animated: Bool) {
         if isSidebarModeEnabled {
-            navigationItem.titleView = isHidden ? UIView() : {
-                let button = UIButton.makeMenuButton(title: navigationItem.title ?? Strings.mySite)
-                button.addAction(UIAction { [weak self, weak button] _ in
-                    guard let self, let button else { return }
-                    self.headerViewController?.siteSwitcherTapped(sourceView: button)
-                }, for: .primaryActionTriggered)
-                return button
-            }()
+            navigationItem.titleView =
+                isHidden
+                ? UIView()
+                : {
+                    let button = UIButton.makeMenuButton(title: navigationItem.title ?? Strings.mySite)
+                    button.addAction(
+                        UIAction { [weak self, weak button] _ in
+                            guard let self, let button else { return }
+                            self.headerViewController?.siteSwitcherTapped(sourceView: button)
+                        },
+                        for: .primaryActionTriggered
+                    )
+                    return button
+                }()
         } else {
             navigationController?.setNavigationBarHidden(isHidden, animated: animated)
         }
@@ -360,11 +387,14 @@ final class MySiteViewController: UIViewController, UIScrollViewDelegate, NoSite
         showSitePicker(for: blog)
         updateNavigationTitle(for: blog)
 
-        let section = (isSidebarModeEnabled || isReaderAppModeEnabled) ? .dashboard : viewModel.getSection(
-            for: blog,
-            jetpackFeaturesEnabled: JetpackFeaturesRemovalCoordinator.jetpackFeaturesEnabled(),
-            splitViewControllerIsHorizontallyCompact: splitViewControllerIsHorizontallyCompact
-        )
+        let section =
+            (isSidebarModeEnabled || isReaderAppModeEnabled)
+            ? .dashboard
+            : viewModel.getSection(
+                for: blog,
+                jetpackFeaturesEnabled: JetpackFeaturesRemovalCoordinator.jetpackFeaturesEnabled(),
+                splitViewControllerIsHorizontallyCompact: splitViewControllerIsHorizontallyCompact
+            )
 
         self.currentSection = section
         switch section {
@@ -429,22 +459,24 @@ final class MySiteViewController: UIViewController, UIScrollViewDelegate, NoSite
         switch currentSection {
         case .siteMenu:
 
-            blogDetailsViewController?.pulledToRefresh(with: refreshControl) { [weak self] in
-                guard let self else {
-                    return
-                }
+            blogDetailsViewController?
+                .pulledToRefresh(with: refreshControl) { [weak self] in
+                    guard let self else {
+                        return
+                    }
 
-                self.updateNavigationTitle(for: blog)
-                self.headerViewController?.blogDetailHeaderView.blog = blog
-            }
+                    self.updateNavigationTitle(for: blog)
+                    self.headerViewController?.blogDetailHeaderView.blog = blog
+                }
 
         case .dashboard:
 
             /// The dashboard’s refresh control is intentionally not tied to blog syncing in order to keep
             /// the dashboard updating fast.
-            blogDashboardViewController?.pulledToRefresh { [weak self] in
-                self?.refreshControl.endRefreshing()
-            }
+            blogDashboardViewController?
+                .pulledToRefresh { [weak self] in
+                    self?.refreshControl.endRefreshing()
+                }
 
             syncBlogAndAllMetadata(blog)
 
@@ -452,7 +484,10 @@ final class MySiteViewController: UIViewController, UIScrollViewDelegate, NoSite
             fetchPrompt(for: blog)
         }
 
-        WPAnalytics.track(.mySitePullToRefresh, properties: [WPAppAnalyticsKeyTabSource: currentSection.analyticsDescription])
+        WPAnalytics.track(
+            .mySitePullToRefresh,
+            properties: [WPAppAnalyticsKeyTabSource: currentSection.analyticsDescription]
+        )
     }
 
     private func syncBlogAndAllMetadata(_ blog: Blog) {
@@ -584,12 +619,16 @@ final class MySiteViewController: UIViewController, UIScrollViewDelegate, NoSite
     private func createFABIfNeeded() {
         createButtonCoordinator?.removeCreateButton()
         createButtonCoordinator = makeCreateButtonCoordinator()
-        createButtonCoordinator?.add(to: view,
-                                    trailingAnchor: view.safeAreaLayoutGuide.trailingAnchor,
-                                    bottomAnchor: view.safeAreaLayoutGuide.bottomAnchor)
+        createButtonCoordinator?
+            .add(
+                to: view,
+                trailingAnchor: view.safeAreaLayoutGuide.trailingAnchor,
+                bottomAnchor: view.safeAreaLayoutGuide.bottomAnchor
+            )
 
         if let blog,
-           noSitesViewController.view.superview == nil {
+            noSitesViewController.view.superview == nil
+        {
             createButtonCoordinator?.showCreateButton(for: blog)
         }
     }
@@ -610,20 +649,24 @@ final class MySiteViewController: UIViewController, UIScrollViewDelegate, NoSite
     }
 
     func launchSiteCreation(source: String) {
-        JetpackFeaturesRemovalCoordinator.presentSiteCreationOverlayIfNeeded(in: self, source: source, onDidDismiss: {
-            guard JetpackFeaturesRemovalCoordinator.siteCreationPhase() != .two else {
-                return
-            }
+        JetpackFeaturesRemovalCoordinator.presentSiteCreationOverlayIfNeeded(
+            in: self,
+            source: source,
+            onDidDismiss: {
+                guard JetpackFeaturesRemovalCoordinator.siteCreationPhase() != .two else {
+                    return
+                }
 
-            // Display site creation flow if not in phase two
-            let wizardLauncher = SiteCreationWizardLauncher()
-            guard let wizard = wizardLauncher.ui else {
-                return
+                // Display site creation flow if not in phase two
+                let wizardLauncher = SiteCreationWizardLauncher()
+                guard let wizard = wizardLauncher.ui else {
+                    return
+                }
+                RootViewCoordinator.shared.isSiteCreationActive = true
+                self.present(wizard, animated: true)
+                SiteCreationAnalyticsHelper.trackSiteCreationAccessed(source: source)
             }
-            RootViewCoordinator.shared.isSiteCreationActive = true
-            self.present(wizard, animated: true)
-            SiteCreationAnalyticsHelper.trackSiteCreationAccessed(source: source)
-        })
+        )
     }
 
     @objc
@@ -699,9 +742,13 @@ final class MySiteViewController: UIViewController, UIScrollViewDelegate, NoSite
 
             if self.isSidebarModeEnabled {
                 self.dismiss(animated: true)
-                NotificationCenter.default.post(name: MySiteViewController.didPickSiteNotification, object: self, userInfo: [
-                    MySiteViewController.siteUserInfoKey: blog
-                ])
+                NotificationCenter.default.post(
+                    name: MySiteViewController.didPickSiteNotification,
+                    object: self,
+                    userInfo: [
+                        MySiteViewController.siteUserInfoKey: blog
+                    ]
+                )
             } else {
                 self.configure(for: blog)
                 self.updateChildViewController(for: blog)
@@ -752,14 +799,16 @@ final class MySiteViewController: UIViewController, UIScrollViewDelegate, NoSite
     ///         - blog: The blog to show the details of.
     ///
     private func showDashboard(for blog: Blog) {
-        let blogDashboardViewController = self.blogDashboardViewController ?? BlogDashboardViewController(blog: blog, embeddedInScrollView: true)
+        let blogDashboardViewController =
+            self.blogDashboardViewController ?? BlogDashboardViewController(blog: blog, embeddedInScrollView: true)
         blogDashboardViewController.update(blog: blog)
         embedChildInStackView(blogDashboardViewController)
         self.blogDashboardViewController = blogDashboardViewController
         stackView.sendSubviewToBack(blogDashboardViewController.view)
 
         if isReaderAppModeEnabled, let account = blog.account,
-           !stackView.subviews.contains(where: { $0 is MeHeaderView }) {
+            !stackView.subviews.contains(where: { $0 is MeHeaderView })
+        {
             let headerView = MeHeaderView()
             headerView.update(with: .init(account: account))
             headerView.configureReaderMode()
@@ -780,7 +829,8 @@ final class MySiteViewController: UIViewController, UIScrollViewDelegate, NoSite
             self,
             selector: #selector(handleDataModelChange(notification:)),
             name: .NSManagedObjectContextObjectsDidChange,
-            object: ContextManager.shared.mainContext)
+            object: ContextManager.shared.mainContext
+        )
     }
 
     @objc
@@ -799,7 +849,8 @@ final class MySiteViewController: UIViewController, UIScrollViewDelegate, NoSite
     ///
     private func handlePossibleDeletion(of selectedBlog: Blog, notification: NSNotification) {
         guard let deletedObjects = notification.userInfo?[NSDeletedObjectsKey] as? Set<NSManagedObject>,
-           deletedObjects.contains(selectedBlog) else {
+            deletedObjects.contains(selectedBlog)
+        else {
             return
         }
 
@@ -821,7 +872,8 @@ final class MySiteViewController: UIViewController, UIScrollViewDelegate, NoSite
     ///
     private func verifyThatBlogsWereInserted(in notification: NSNotification) -> Bool {
         guard let insertedObjects = notification.userInfo?[NSInsertedObjectsKey] as? Set<NSManagedObject>,
-              insertedObjects.contains(where: { $0 as? Blog != nil }) else {
+            insertedObjects.contains(where: { $0 as? Blog != nil })
+        else {
             return false
         }
 
@@ -853,10 +905,11 @@ final class MySiteViewController: UIViewController, UIScrollViewDelegate, NoSite
 
     func fetchPrompt(for blog: Blog?) {
         guard FeatureFlag.bloggingPrompts.enabled,
-              let blog,
-              blog.isAccessibleThroughWPCom,
-              let promptsService = BloggingPromptsService(blog: blog),
-              let siteID = blog.dotComID?.intValue else {
+            let blog,
+            blog.isAccessibleThroughWPCom,
+            let promptsService = BloggingPromptsService(blog: blog),
+            let siteID = blog.dotComID?.intValue
+        else {
             return
         }
 
@@ -878,7 +931,11 @@ final class MySiteViewController: UIViewController, UIScrollViewDelegate, NoSite
 // MARK: - UIViewControllerTransitioningDelegate
 //
 extension MySiteViewController: UIViewControllerTransitioningDelegate {
-    func presentationController(forPresented presented: UIViewController, presenting: UIViewController?, source: UIViewController) -> UIPresentationController? {
+    func presentationController(
+        forPresented presented: UIViewController,
+        presenting: UIViewController?,
+        source: UIViewController
+    ) -> UIPresentationController? {
         guard presented is FancyAlertViewController else {
             return nil
         }
@@ -925,7 +982,8 @@ private extension MySiteViewController {
             let didReloadUI = RootViewCoordinator.shared.reloadUIIfNeeded(blog: self.blog)
             if !didReloadUI {
                 let phase = JetpackFeaturesRemovalCoordinator.generalPhase()
-                let source: JetpackFeaturesRemovalCoordinator.JetpackOverlaySource = phase == .four ? .phaseFourOverlay : .appOpen
+                let source: JetpackFeaturesRemovalCoordinator.JetpackOverlaySource =
+                    phase == .four ? .phaseFourOverlay : .appOpen
                 JetpackFeaturesRemovalCoordinator.presentOverlayIfNeeded(in: self, source: source, blog: self.blog)
             }
         }
@@ -961,6 +1019,8 @@ extension MySiteViewController: JetpackRemoteInstallDelegate {
 }
 
 extension MySiteViewController {
-    static var didPickSiteNotification = Foundation.Notification.Name("org.wordpress.mySiteViewController.didPickSiteNotification")
+    static var didPickSiteNotification = Foundation.Notification.Name(
+        "org.wordpress.mySiteViewController.didPickSiteNotification"
+    )
     static var siteUserInfoKey = "siteUserInfoKey"
 }

--- a/WordPress/Classes/ViewRelated/NUX/Helpers/WordPressAuthenticationManager.swift
+++ b/WordPress/Classes/ViewRelated/NUX/Helpers/WordPressAuthenticationManager.swift
@@ -62,7 +62,10 @@ extension WordPressAuthenticationManager {
         wpcomSecret: String = BuildSettings.current.secrets.oauth.secret
     ) {
         let displayStrings = WordPressAuthenticatorDisplayStrings(
-            continueWithWPButtonTitle: NSLocalizedString("Continue With WordPress.com", comment: "Button title. Takes the user to the login with WordPress.com flow.")
+            continueWithWPButtonTitle: NSLocalizedString(
+                "Continue With WordPress.com",
+                comment: "Button title. Takes the user to the login with WordPress.com flow."
+            )
         )
 
         WordPressAuthenticator.initialize(
@@ -87,7 +90,9 @@ extension WordPressAuthenticationManager {
             .debounce(for: .milliseconds(100), scheduler: DispatchQueue.main)
             .sink {
                 guard let blogId = $0.object as? TaggedManagedObjectID<Blog> else {
-                    wpAssertionFailure("No blog ID found in the requestedWithInvalidAuthenticationNotification notification")
+                    wpAssertionFailure(
+                        "No blog ID found in the requestedWithInvalidAuthenticationNotification notification"
+                    )
                     return
                 }
 
@@ -243,7 +248,11 @@ extension WordPressAuthenticationManager {
         let context = ContextManager.shared.mainContext
         let account = try? WPAccount.lookupDefaultWordPressComAccount(in: context)
 
-        return WordPressAuthenticator.signinForWPCom(dotcomEmailAddress: account?.email, dotcomUsername: account?.username, onDismissed: onDismissed)
+        return WordPressAuthenticator.signinForWPCom(
+            dotcomEmailAddress: account?.email,
+            dotcomUsername: account?.username,
+            onDismissed: onDismissed
+        )
     }
 
     /// Presents the WordPress Authentication UI from the rootViewController (configured to allow only WordPress.com).
@@ -263,26 +272,51 @@ extension WordPressAuthenticationManager {
 
         let signedInAccount = try? WPAccount.lookupDefaultWordPressComAccount(in: ContextManager.shared.mainContext)
         Task { @MainActor in
-            let title = NSLocalizedString("wpcom.token.fix.signin", value: "Sign in to WordPress.com", comment: "Message title to be displayed when the user needs to re-authenticate their WordPress.com account.")
-            let message = NSLocalizedString("wpcom.token.fix.signin.message", value: "You need to sign in to WordPress.com to access your account.", comment: "Detailed message to be displayed when the user needs to re-authenticate their WordPress.com account.")
+            let title = NSLocalizedString(
+                "wpcom.token.fix.signin",
+                value: "Sign in to WordPress.com",
+                comment:
+                    "Message title to be displayed when the user needs to re-authenticate their WordPress.com account."
+            )
+            let message = NSLocalizedString(
+                "wpcom.token.fix.signin.message",
+                value: "You need to sign in to WordPress.com to access your account.",
+                comment:
+                    "Detailed message to be displayed when the user needs to re-authenticate their WordPress.com account."
+            )
 
             if showNotice {
                 Notice(title: title, message: message).post()
             }
 
-            let account = await WordPressDotComAuthenticator().signIn(
-                from: presenter,
-                context: signedInAccount?.email
-                    .flatMap { .reauthentication(accountEmail: $0) }
-                    ?? .default
-            )
+            let account = await WordPressDotComAuthenticator()
+                .signIn(
+                    from: presenter,
+                    context: signedInAccount?.email
+                        .flatMap { .reauthentication(accountEmail: $0) }
+                        ?? .default
+                )
 
             if account == nil {
                 let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
-                alert.addActionWithTitle(NSLocalizedString("wpcom.token.alert.button.logout", value: "Log out", comment: "Button title to log out the current WordPress.com account"), style: .destructive) { _ in
+                alert.addActionWithTitle(
+                    NSLocalizedString(
+                        "wpcom.token.alert.button.logout",
+                        value: "Log out",
+                        comment: "Button title to log out the current WordPress.com account"
+                    ),
+                    style: .destructive
+                ) { _ in
                     AccountHelper.logOutDefaultWordPressComAccount()
                 }
-                alert.addActionWithTitle(NSLocalizedString("wpcom.token.alert.button.signin", value: "Sign In", comment: "Button title to Sign In to WordPress.com"), style: .default) { _ in
+                alert.addActionWithTitle(
+                    NSLocalizedString(
+                        "wpcom.token.alert.button.signin",
+                        value: "Sign In",
+                        comment: "Button title to Sign In to WordPress.com"
+                    ),
+                    style: .default
+                ) { _ in
                     WordPressAuthenticationManager.showSigninForWPComFixingAuthToken(showNotice: false)
                 }
                 presenter.present(alert, animated: true)
@@ -292,14 +326,20 @@ extension WordPressAuthenticationManager {
         }
     }
 
-    static func showSigninForSelfHostedSiteFixingApplicationPassword(blogId: TaggedManagedObjectID<Blog>, showNotice: Bool = true) {
+    static func showSigninForSelfHostedSiteFixingApplicationPassword(
+        blogId: TaggedManagedObjectID<Blog>,
+        showNotice: Bool = true
+    ) {
         guard let presenter = UIViewController.topViewController,
-              !presenter.isApplicationReauthentication else {
+            !presenter.isApplicationReauthentication
+        else {
             assertionFailure()
             return
         }
 
-        guard let currentBlog = RootViewCoordinator.sharedPresenter.currentlyVisibleBlog(), currentBlog.objectID == blogId.objectID else {
+        guard let currentBlog = RootViewCoordinator.sharedPresenter.currentlyVisibleBlog(),
+            currentBlog.objectID == blogId.objectID
+        else {
             DDLogWarn("Requested sign in to a site that is not the currently visible one")
             return
         }
@@ -340,19 +380,19 @@ extension WordPressAuthenticationManager: WordPressAuthenticatorDelegate {
     /// Indicates whether if the Support Action should be enabled, or not.
     ///
     var supportActionEnabled: Bool {
-        return true
+        true
     }
 
     /// Indicates whether a link to WP.com TOS should be available, or not.
     ///
     var wpcomTermsOfServiceEnabled: Bool {
-        return true
+        true
     }
 
     /// Indicates if Support is Enabled.
     ///
     var supportEnabled: Bool {
-        return ZendeskUtils.zendeskEnabled
+        ZendeskUtils.zendeskEnabled
     }
 
     private var tracker: AuthenticatorAnalyticsTracker {
@@ -366,9 +406,12 @@ extension WordPressAuthenticationManager: WordPressAuthenticatorDelegate {
 
     /// Returns an instance of a SupportView, configured to be displayed from a specified Support Source.
     ///
-    func presentSupport(from sourceViewController: UIViewController, sourceTag: WordPressSupportSourceTag,
-                        lastStep: AuthenticatorAnalyticsTracker.Step,
-                        lastFlow: AuthenticatorAnalyticsTracker.Flow) {
+    func presentSupport(
+        from sourceViewController: UIViewController,
+        sourceTag: WordPressSupportSourceTag,
+        lastStep: AuthenticatorAnalyticsTracker.Step,
+        lastFlow: AuthenticatorAnalyticsTracker.Flow
+    ) {
         presentSupport(from: sourceViewController, sourceTag: sourceTag)
     }
 
@@ -385,7 +428,10 @@ extension WordPressAuthenticationManager: WordPressAuthenticatorDelegate {
     ///     - site: passes in the site information to the delegate method.
     ///     - onCompletion: Closure to be executed on completion.
     ///
-    func shouldPresentUsernamePasswordController(for siteInfo: WordPressComSiteInfo?, onCompletion: @escaping (WordPressAuthenticatorResult) -> Void) {
+    func shouldPresentUsernamePasswordController(
+        for siteInfo: WordPressComSiteInfo?,
+        onCompletion: @escaping (WordPressAuthenticatorResult) -> Void
+    ) {
 
         let result: WordPressAuthenticatorResult = .presentPasswordController(value: true)
         onCompletion(result)
@@ -393,7 +439,12 @@ extension WordPressAuthenticationManager: WordPressAuthenticatorDelegate {
 
     /// Presents the Login Epilogue, in the specified NavigationController.
     ///
-    func presentLoginEpilogue(in navigationController: UINavigationController, for credentials: AuthenticatorCredentials, source: SignInSource?, onDismiss: @escaping () -> Void) {
+    func presentLoginEpilogue(
+        in navigationController: UINavigationController,
+        for credentials: AuthenticatorCredentials,
+        source: SignInSource?,
+        onDismiss: @escaping () -> Void
+    ) {
         let mainContext = ContextManager.shared.mainContext
         let blog = credentials.wporg.flatMap { wporg in
             Blog.lookup(username: wporg.username, xmlrpc: wporg.xmlrpc, in: mainContext)
@@ -402,7 +453,12 @@ extension WordPressAuthenticationManager: WordPressAuthenticatorDelegate {
         presentLoginEpilogue(in: navigationController, forSelfHostedSite: blog, source: source, onDismiss: onDismiss)
     }
 
-    func presentLoginEpilogue(in navigationController: UINavigationController, forSelfHostedSite blog: Blog?, source: SignInSource?, onDismiss: @escaping () -> Void) {
+    func presentLoginEpilogue(
+        in navigationController: UINavigationController,
+        forSelfHostedSite blog: Blog?,
+        source: SignInSource?,
+        onDismiss: @escaping () -> Void
+    ) {
         // If adding a self-hosted site, skip the Epilogue
         if let blog {
             if self.windowManager.isShowingFullscreenSignIn {
@@ -437,7 +493,8 @@ extension WordPressAuthenticationManager: WordPressAuthenticatorDelegate {
         }
 
         if let primarySiteID = account.primaryBlogID,
-           let site = sites.first(where: { $0.dotComID == primarySiteID }) {
+            let site = sites.first(where: { $0.dotComID == primarySiteID })
+        {
             selectedBlog = site
         }
 
@@ -450,10 +507,16 @@ extension WordPressAuthenticationManager: WordPressAuthenticatorDelegate {
 
     /// Presents the Signup Epilogue, in the specified NavigationController.
     ///
-    func presentSignupEpilogue(in navigationController: UINavigationController, for credentials: AuthenticatorCredentials, socialUser: SocialUser?) {
+    func presentSignupEpilogue(
+        in navigationController: UINavigationController,
+        for credentials: AuthenticatorCredentials,
+        socialUser: SocialUser?
+    ) {
 
         let storyboard = UIStoryboard(name: "SignupEpilogue", bundle: .keystone)
-        guard let epilogueViewController = storyboard.instantiateInitialViewController() as? SignupEpilogueViewController else {
+        guard
+            let epilogueViewController = storyboard.instantiateInitialViewController() as? SignupEpilogueViewController
+        else {
             fatalError()
         }
 
@@ -470,7 +533,8 @@ extension WordPressAuthenticationManager: WordPressAuthenticatorDelegate {
                 navigationController.dismiss(animated: true)
             }
 
-            UserPersistentStoreFactory.instance().set(false, forKey: UserPersistentStoreFactory.instance().welcomeNotificationSeenKey)
+            UserPersistentStoreFactory.instance()
+                .set(false, forKey: UserPersistentStoreFactory.instance().welcomeNotificationSeenKey)
         }
 
         navigationController.pushViewController(epilogueViewController, animated: true)
@@ -490,7 +554,7 @@ extension WordPressAuthenticationManager: WordPressAuthenticatorDelegate {
     /// Indicates if the Signup Epilogue should be displayed.
     ///
     func shouldPresentSignupEpilogue() -> Bool {
-        return true
+        true
     }
 
     /// Whenever a WordPress.com account has been created during the Auth flow, we'll add a new local WPCOM Account, and set it as
@@ -512,10 +576,12 @@ extension WordPressAuthenticationManager: WordPressAuthenticatorDelegate {
     ///
     func userAuthenticatedWithAppleUserID(_ appleUserID: String) {
         do {
-            try SFHFKeychainUtils.storeUsername(WPAppleIDKeychainUsernameKey,
-                                                andPassword: appleUserID,
-                                                forServiceName: WPAppleIDKeychainServiceName,
-                                                updateExisting: true)
+            try SFHFKeychainUtils.storeUsername(
+                WPAppleIDKeychainUsernameKey,
+                andPassword: appleUserID,
+                forServiceName: WPAppleIDKeychainServiceName,
+                updateExisting: true
+            )
         } catch {
             DDLogInfo("Error while saving Apple User ID: \(error)")
         }
@@ -527,7 +593,13 @@ extension WordPressAuthenticationManager: WordPressAuthenticatorDelegate {
         if let wpcom = credentials.wpcom {
             syncWPCom(authToken: wpcom.authToken, isJetpackLogin: wpcom.isJetpackLogin, onCompletion: onCompletion)
         } else if let wporg = credentials.wporg {
-            syncWPOrg(username: wporg.username, password: wporg.password, xmlrpc: wporg.xmlrpc, options: wporg.options, onCompletion: onCompletion)
+            syncWPOrg(
+                username: wporg.username,
+                password: wporg.password,
+                xmlrpc: wporg.xmlrpc,
+                options: wporg.options,
+                onCompletion: onCompletion
+            )
         }
     }
 
@@ -535,7 +607,7 @@ extension WordPressAuthenticationManager: WordPressAuthenticatorDelegate {
     ///
     func shouldHandleError(_ error: Error) -> Bool {
         // Here for protocol compliance.
-        return false
+        false
     }
 
     /// Handles the given error.
@@ -578,12 +650,17 @@ private extension WordPressAuthenticationManager {
 
 // MARK: - Onboarding Questions Prompt
 private extension WordPressAuthenticationManager {
-    private func presentEnableNotificationsPrompt(in navigationController: UINavigationController, blog: Blog, onDismiss: (() -> Void)? = nil) {
+    private func presentEnableNotificationsPrompt(
+        in navigationController: UINavigationController,
+        blog: Blog,
+        onDismiss: (() -> Void)? = nil
+    ) {
         let windowManager = self.windowManager
 
         guard JetpackFeaturesRemovalCoordinator.jetpackFeaturesEnabled(),
-              !UserPersistentStoreFactory.instance().onboardingNotificationsPromptDisplayed,
-              !UITestConfigurator.isEnabled(.disablePrompts) else {
+            !UserPersistentStoreFactory.instance().onboardingNotificationsPromptDisplayed,
+            !UITestConfigurator.isEnabled(.disablePrompts)
+        else {
             if self.windowManager.isShowingFullscreenSignIn {
                 self.windowManager.dismissFullscreenSignIn(blogToShow: blog)
             } else {
@@ -629,24 +706,38 @@ private extension WordPressAuthenticationManager {
 
         // Sync account and blog
         syncGroup.enter()
-        service.syncWPCom(authToken: authToken, isJetpackLogin: isJetpackLogin, onSuccess: { account in
+        service.syncWPCom(
+            authToken: authToken,
+            isJetpackLogin: isJetpackLogin,
+            onSuccess: { account in
 
-            /// HACK: An alternative notification to LoginFinished. Observe this instead of `WPSigninDidFinishNotification` for Jetpack logins.
-            /// When WPTabViewController no longer destroy's and rebuilds the view hierarchy this alternate notification can be removed.
-            ///
-            let notification = isJetpackLogin == true ? .wordpressLoginFinishedJetpackLogin : Foundation.Notification.Name(rawValue: WordPressAuthenticationManager.WPSigninDidFinishNotification)
-            NotificationCenter.default.post(name: notification, object: account)
+                /// HACK: An alternative notification to LoginFinished. Observe this instead of `WPSigninDidFinishNotification` for Jetpack logins.
+                /// When WPTabViewController no longer destroy's and rebuilds the view hierarchy this alternate notification can be removed.
+                ///
+                let notification =
+                    isJetpackLogin == true
+                    ? .wordpressLoginFinishedJetpackLogin
+                    : Foundation.Notification.Name(
+                        rawValue: WordPressAuthenticationManager.WPSigninDidFinishNotification
+                    )
+                NotificationCenter.default.post(name: notification, object: account)
 
-            syncGroup.leave()
-        }, onFailure: { _ in
-            syncGroup.leave()
-        })
+                syncGroup.leave()
+            },
+            onFailure: { _ in
+                syncGroup.leave()
+            }
+        )
 
         // Refresh Remote Feature Flags
         syncGroup.enter()
-        WordPressAppDelegate.shared?.updateFeatureFlags(authToken: authToken, completion: {
-            syncGroup.leave()
-        })
+        WordPressAppDelegate.shared?
+            .updateFeatureFlags(
+                authToken: authToken,
+                completion: {
+                    syncGroup.leave()
+                }
+            )
 
         // Sync done
         syncGroup.notify(queue: .main) {
@@ -656,7 +747,13 @@ private extension WordPressAuthenticationManager {
 
     /// Synchronizes a WordPress.org account with the specified credentials.
     ///
-    private func syncWPOrg(username: String, password: String, xmlrpc: String, options: [AnyHashable: Any], onCompletion: @escaping () -> ()) {
+    private func syncWPOrg(
+        username: String,
+        password: String,
+        xmlrpc: String,
+        options: [AnyHashable: Any],
+        onCompletion: @escaping () -> ()
+    ) {
         let service = BlogSyncFacade()
 
         service.syncBlog(withUsername: username, password: password, xmlrpc: xmlrpc, options: options) { blog in
@@ -696,7 +793,12 @@ private extension UIViewController {
 
     var isApplicationReauthentication: Bool {
         set {
-            objc_setAssociatedObject(self, &isApplicationReauthenticationKey, NSNumber(value: newValue), objc_AssociationPolicy.OBJC_ASSOCIATION_RETAIN)
+            objc_setAssociatedObject(
+                self,
+                &isApplicationReauthenticationKey,
+                NSNumber(value: newValue),
+                objc_AssociationPolicy.OBJC_ASSOCIATION_RETAIN
+            )
         }
         get {
             (objc_getAssociatedObject(self, &isApplicationReauthenticationKey) as? NSNumber)?.boolValue ?? false

--- a/WordPress/Classes/ViewRelated/NUX/Helpers/WordPressAuthenticationManager.swift
+++ b/WordPress/Classes/ViewRelated/NUX/Helpers/WordPressAuthenticationManager.swift
@@ -239,22 +239,6 @@ extension WordPressAuthenticationManager {
 //
 extension WordPressAuthenticationManager {
 
-    /// Returns an Authentication ViewController (configured to allow only WordPress.com). This method pre-populates the Email + Username
-    /// with the values returned by the default WordPress.com account (if any).
-    ///
-    /// - Parameter onDismissed: Closure to be executed whenever the returned ViewController is dismissed.
-    ///
-    static func signinForWPComFixingAuthToken(_ onDismissed: ((_ cancelled: Bool) -> Void)? = nil) -> UIViewController {
-        let context = ContextManager.shared.mainContext
-        let account = try? WPAccount.lookupDefaultWordPressComAccount(in: context)
-
-        return WordPressAuthenticator.signinForWPCom(
-            dotcomEmailAddress: account?.email,
-            dotcomUsername: account?.username,
-            onDismissed: onDismissed
-        )
-    }
-
     /// Presents the WordPress Authentication UI from the rootViewController (configured to allow only WordPress.com).
     /// This method pre-populates the Email + Username with the values returned by the default WordPress.com account (if any).
     ///


### PR DESCRIPTION
> [!Note]
> This first commit is pure code format changes.

## Description

The "magic link" is related to the native WP.com sign-in, which has been disabled for a while.

The account password sign-in entry is the only one left. We now move it over to the application password sign-in.