### PR TITLE
Attach auxiliary windows to the window scene

### DIFF
--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -115,7 +115,8 @@ let package = Package(
             name: "JetpackStats",
             dependencies: [
                 "WordPressUI",
-                "WordPressKit"
+                "WordPressKit",
+                "WordPressShared"
             ],
             resources: [.process("Resources")]
         ),

--- a/Modules/Sources/JetpackStats/StatsRouter.swift
+++ b/Modules/Sources/JetpackStats/StatsRouter.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 import UIKit
 import SafariServices
+import WordPressShared
 
 @MainActor
 public protocol StatsRouterScreenFactory: AnyObject {
@@ -64,14 +65,6 @@ public final class StatsRouter: @unchecked Sendable {
         let safariViewController = SFSafariViewController(url: url)
         let vc = viewController ?? findTopViewController()
         vc?.present(safariViewController, animated: true)
-    }
-}
-
-private extension UIApplication {
-    @objc var mainWindow: UIWindow? {
-        connectedScenes
-            .compactMap { ($0 as? UIWindowScene)?.keyWindow }
-            .first
     }
 }
 

--- a/Modules/Sources/WordPressShared/Utility/UIApplication+MainWindow.swift
+++ b/Modules/Sources/WordPressShared/Utility/UIApplication+MainWindow.swift
@@ -2,9 +2,13 @@ import UIKit
 
 public extension UIApplication {
     @objc var mainWindow: UIWindow? {
+        // The delegate-window fallback covers the moments when no scene key window
+        // exists: early in scene connection (before makeKeyAndVisible) and in the unit
+        // test host, which never connects a window scene.
         connectedScenes
             .compactMap { ($0 as? UIWindowScene)?.keyWindow }
             .first
+            ?? (delegate?.window).flatMap { $0 }
     }
 
     @objc var currentStatusBarFrame: CGRect {

--- a/Modules/Sources/WordPressShared/Utility/UIApplication+MainWindow.swift
+++ b/Modules/Sources/WordPressShared/Utility/UIApplication+MainWindow.swift
@@ -8,11 +8,11 @@ public extension UIApplication {
     }
 
     @objc var currentStatusBarFrame: CGRect {
-        return mainWindow?.windowScene?.statusBarManager?.statusBarFrame ?? CGRect.zero
+        mainWindow?.windowScene?.statusBarManager?.statusBarFrame ?? CGRect.zero
     }
 
     @objc var currentStatusBarOrientation: UIInterfaceOrientation {
-        return mainWindow?.windowScene?.interfaceOrientation ?? .unknown
+        mainWindow?.windowScene?.interfaceOrientation ?? .unknown
     }
 }
 
@@ -22,7 +22,9 @@ public extension UIApplication {
             return nil
         }
         var leafViewController = rootViewController
-        while leafViewController.presentedViewController != nil && !leafViewController.presentedViewController!.isBeingDismissed {
+        while leafViewController.presentedViewController != nil
+            && !leafViewController.presentedViewController!.isBeingDismissed
+        {
             leafViewController = leafViewController.presentedViewController!
         }
         return leafViewController

--- a/Tests/KeystoneTests/Tests/Features/Misc/Compliance/CompliancePopoverCoordinatorTests.swift
+++ b/Tests/KeystoneTests/Tests/Features/Misc/Compliance/CompliancePopoverCoordinatorTests.swift
@@ -1,4 +1,3 @@
-
 import XCTest
 
 @testable import WordPress
@@ -17,6 +16,8 @@ final class CompliancePopoverCoordinatorTests: XCTestCase {
             complianceService: service,
             isFeatureFlagEnabled: true
         )
+        // The test host has no connected scene for the default factory to attach to.
+        self.coordinator.makeWindow = { UIWindow() }
     }
 
     // MARK: - Tests

--- a/Tests/KeystoneTests/Tests/Misc/WP3DTouchShortcutCreatorTests.swift
+++ b/Tests/KeystoneTests/Tests/Misc/WP3DTouchShortcutCreatorTests.swift
@@ -26,11 +26,3 @@ class WP3DTouchShortcutCreatorTests: XCTestCase {
         XCTAssertEqual(UIApplication.shared.shortcutItems!.count, is3DTouchAvailable() ? 1 : 0)
     }
 }
-
-extension UIApplication {
-    @objc var mainWindow: UIWindow? {
-        connectedScenes
-            .compactMap { ($0 as? UIWindowScene)?.keyWindow }
-            .first
-    }
-}

--- a/WordPress/Classes/System/WindowManager.swift
+++ b/WordPress/Classes/System/WindowManager.swift
@@ -24,7 +24,7 @@ class WindowManager: NSObject {
     /// The root view controller for the window.
     ///
     var rootViewController: UIViewController? {
-        return window.rootViewController
+        window.rootViewController
     }
 
     init(window: UIWindow) {
@@ -103,7 +103,8 @@ class WindowManager: NSObject {
             animations: nil,
             completion: { _ in
                 completion?()
-            })
+            }
+        )
     }
 
     // MARK: Temporary Overlaying Window
@@ -113,8 +114,13 @@ class WindowManager: NSObject {
     ///
     func displayOverlayingWindow(with rootViewController: UIViewController) {
         clearOverlayingWindow()
-        let windowFrame = window.frame
-        let window = UIWindow(frame: windowFrame)
+        let window: UIWindow
+        if let windowScene = self.window.windowScene {
+            window = UIWindow(windowScene: windowScene)
+        } else {
+            // Unreachable in practice: the app's main window is always scene-attached.
+            window = UIWindow(frame: self.window.frame)
+        }
         window.rootViewController = rootViewController
         window.windowLevel = .alert
         window.isHidden = false

--- a/WordPress/Classes/System/WindowManager.swift
+++ b/WordPress/Classes/System/WindowManager.swift
@@ -113,14 +113,15 @@ class WindowManager: NSObject {
     /// - Parameter rootViewController: View controller to be used as the root view controller for the newly created window.
     ///
     func displayOverlayingWindow(with rootViewController: UIViewController) {
-        clearOverlayingWindow()
-        let window: UIWindow
-        if let windowScene = self.window.windowScene {
-            window = UIWindow(windowScene: windowScene)
-        } else {
-            // Unreachable in practice: the app's main window is always scene-attached.
-            window = UIWindow(frame: self.window.frame)
+        // A window without a scene never displays, so fail loudly instead of
+        // creating an invisible overlay. The main window is always scene-attached
+        // while UI is on screen. Bail before tearing down any existing overlay.
+        guard let windowScene = self.window.windowScene else {
+            assertionFailure("displayOverlayingWindow requires a scene-attached main window")
+            return
         }
+        clearOverlayingWindow()
+        let window = UIWindow(windowScene: windowScene)
         window.rootViewController = rootViewController
         window.windowLevel = .alert
         window.isHidden = false

--- a/WordPress/Classes/ViewRelated/EEUUSCompliance/CompliancePopoverCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/EEUUSCompliance/CompliancePopoverCoordinator.swift
@@ -1,5 +1,6 @@
 import UIKit
 import WordPressData
+import WordPressShared
 import WordPressUI
 
 protocol CompliancePopoverCoordinatorProtocol: AnyObject {
@@ -89,10 +90,26 @@ final class CompliancePopoverCoordinator: CompliancePopoverCoordinatorProtocol {
         Self.window = nil
     }
 
+    /// Creates the popover's host window. The default requires a connected scene:
+    /// a window without one never displays under the scene life cycle. The unit
+    /// test host has no scene, so tests inject a plain window instead.
+    var makeWindow: () -> UIWindow? = {
+        guard let windowScene = UIApplication.shared.mainWindow?.windowScene else {
+            return nil
+        }
+        return UIWindow(windowScene: windowScene)
+    }
+
     private func presentPopover() {
+        // Resolve the new window before tearing down a visible popover: when no
+        // scene is available, an existing popover stays up. `Self.window` staying
+        // nil (when there is none) makes `presentIfNeeded` report the popover as
+        // not shown.
+        guard let window = makeWindow() else {
+            return
+        }
         self.removeWindow()
 
-        let window = UIWindow()
         window.windowLevel = .alert
         window.backgroundColor = .clear
         window.rootViewController = presentingViewController

--- a/WordPress/Classes/ViewRelated/EEUUSCompliance/CompliancePopoverCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/EEUUSCompliance/CompliancePopoverCoordinator.swift
@@ -43,7 +43,9 @@ final class CompliancePopoverCoordinator: CompliancePopoverCoordinatorProtocol {
         }
         return await withCheckedContinuation { continuation in
             self.complianceService.getIPCountryCode { [weak self] result in
-                guard let self, case .success(let countryCode) = result, self.shouldShowPrivacyBanner(countryCode: countryCode) else {
+                guard let self, case .success(let countryCode) = result,
+                    self.shouldShowPrivacyBanner(countryCode: countryCode)
+                else {
                     continuation.resume(returning: false)
                     return
                 }
@@ -68,7 +70,7 @@ final class CompliancePopoverCoordinator: CompliancePopoverCoordinatorProtocol {
     // MARK: - Helpers
 
     private func shouldShowPrivacyBanner(countryCode: String) -> Bool {
-        return Self.gdprCountryCodes.contains(countryCode)
+        Self.gdprCountryCodes.contains(countryCode)
     }
 
     private func dismiss(completion: (() -> Void)? = nil) {
@@ -142,7 +144,7 @@ private extension CompliancePopoverCoordinator {
         "CH", "CHE", // Switzerland
         "IS",
         "LI",
-        "GB",
+        "GB"
         // *Although the UK has departed from the EU as of January 2021,
         // the GDPR was enacted before its withdrawal and is therefore considered a valid UK law.*
     ]
@@ -154,7 +156,8 @@ extension UserDefaults {
     var didShowCompliancePopup: Bool {
         get {
             bool(forKey: Self.didShowCompliancePopupKey)
-        } set {
+        }
+        set {
             set(newValue, forKey: Self.didShowCompliancePopupKey)
         }
     }


### PR DESCRIPTION
> [!Note]
> I recommend reviewing this PR commit by commit. The first commit is swift-format only.

## Description

This is the first of a series of PRs preparing the app for adopting the UIScene life cycle. A `UIWindow` created without a window scene displays fine under the current app-delegate life cycle, but silently never displays once the app declares a scene manifest.

This PR attaches the auxiliary windows to the scene, which behaves the same today and keeps them working after the switch:

1. `WindowManager`'s overlaying window and `CompliancePopoverCoordinator`'s window are now created from the active scene. When no scene is available, `WindowManager` fails loudly with an assertion, and `CompliancePopoverCoordinator.presentIfNeeded` reports the popover as not shown so the presentation can be retried, instead of faking success.
2. `UIApplication.mainWindow` is consolidated into WordPressShared: it now falls back to the app delegate's window (which covers the unit test host, where no scene ever connects), the duplicate helper in the unit test bundle is deleted, and JetpackStats uses the shared helper instead of its private copy.