### PR TITLE
Defer the notice presenter's window until the first presentation

### DIFF
--- a/WordPress/Classes/System/WordPressAppDelegate.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate.swift
@@ -141,6 +141,9 @@ public class WordPressAppDelegate: UIResponder, UIApplicationDelegate {
         InteractiveNotificationsManager.shared.registerForUserNotifications()
         setupPingHub()
         setupBackgroundRefresh(application)
+        // The notice presenter must exist from process launch: background launches
+        // (e.g. the share extension's background URL session) post notices that it
+        // delivers as local notifications, with no UI visible.
         setupNoticePresenter()
         DebugMenuViewController.configure(in: window)
         AppTips.initialize()

--- a/WordPress/Classes/ViewRelated/System/Notices/NoticePresenter.swift
+++ b/WordPress/Classes/ViewRelated/System/Notices/NoticePresenter.swift
@@ -51,12 +51,6 @@ class NoticePresenter {
     /// when no scene (and hence no window to attach to) may exist yet, e.g. on a
     /// background launch. Background notices don't need a window at all.
     private var window: UntouchableWindow?
-    private var view: UIView {
-        guard let view = window?.rootViewController?.view else {
-            fatalError("The notice window doesn't exist or has no root view controller")
-        }
-        return view
-    }
 
     private let generator = UINotificationFeedbackGenerator()
     private var storeReceipt: Receipt?
@@ -124,7 +118,7 @@ class NoticePresenter {
                     animations: {
                         currentContainer.bottomConstraint?.constant =
                             self.onScreenNoticeContainerBottomConstraintConstant
-                        self.view.layoutIfNeeded()
+                        currentContainer.superview?.layoutIfNeeded()
                     }
                 )
             }
@@ -148,7 +142,7 @@ class NoticePresenter {
                     animations: {
                         currentContainer.bottomConstraint?.constant =
                             self.onScreenNoticeContainerBottomConstraintConstant
-                        self.view.layoutIfNeeded()
+                        currentContainer.superview?.layoutIfNeeded()
                     }
                 )
             }
@@ -264,15 +258,17 @@ class NoticePresenter {
             return nil
         }
 
+        let view: UIView = window.untouchableViewController.view
+
         generator.prepare()
 
         let noticeView = NoticeView(notice: notice)
         noticeView.translatesAutoresizingMaskIntoConstraints = false
 
         let noticeContainerView = NoticeContainerView(noticeView: noticeView)
-        addNoticeContainerToPresentingViewController(noticeContainerView)
-        addBottomConstraintToNoticeContainer(noticeContainerView)
-        addTopConstraintToNoticeContainer(noticeContainerView)
+        view.addSubview(noticeContainerView)
+        addBottomConstraintToNoticeContainer(noticeContainerView, in: view)
+        addTopConstraintToNoticeContainer(noticeContainerView, in: view)
 
         // At regular width, the notice shouldn't be any wider than 1/2 the app's width
         noticeContainerView.noticeWidthConstraint = noticeView.widthAnchor.constraint(
@@ -362,17 +358,13 @@ class NoticePresenter {
         return window
     }
 
-    private func addNoticeContainerToPresentingViewController(_ noticeContainer: UIView) {
-        view.addSubview(noticeContainer)
-    }
-
-    private func addBottomConstraintToNoticeContainer(_ container: NoticeContainerView) {
+    private func addBottomConstraintToNoticeContainer(_ container: NoticeContainerView, in view: UIView) {
         let constraint = container.bottomAnchor.constraint(equalTo: view.bottomAnchor)
         container.bottomConstraint = constraint
         constraint.isActive = false
     }
 
-    private func addTopConstraintToNoticeContainer(_ container: NoticeContainerView) {
+    private func addTopConstraintToNoticeContainer(_ container: NoticeContainerView, in view: UIView) {
         let constraint = container.topAnchor.constraint(equalTo: view.bottomAnchor)
         container.topConstraint = constraint
         constraint.priority = UILayoutPriority.defaultHigh
@@ -401,12 +393,17 @@ class NoticePresenter {
 
     private func dismissForegroundNotice() {
         guard let container = currentNoticePresentation?.containerView,
-            container.superview != nil
+            let containerSuperview = container.superview
         else {
             return
         }
         let bottomOffset = offScreenNoticeContainerBottomOffset(for: container)
-        let toState = animator.state(for: container, in: view, withTransition: .offscreen, bottomOffset: bottomOffset)
+        let toState = animator.state(
+            for: container,
+            in: containerSuperview,
+            withTransition: .offscreen,
+            bottomOffset: bottomOffset
+        )
         animator.animatePresentation(
             fromState: {},
             toState: toState,

--- a/WordPress/Classes/ViewRelated/System/Notices/NoticePresenter.swift
+++ b/WordPress/Classes/ViewRelated/System/Notices/NoticePresenter.swift
@@ -62,8 +62,14 @@ class NoticePresenter {
 
     private var notificationObservers = Set<AnyCancellable>()
 
-    init(store: NoticeStore = StoreContainer.shared.notice,
-         animator: NoticeAnimator = NoticeAnimator(duration: Animations.appearanceDuration, springDampening: Animations.appearanceSpringDamping, springVelocity: NoticePresenter.Animations.appearanceSpringVelocity)) {
+    init(
+        store: NoticeStore = StoreContainer.shared.notice,
+        animator: NoticeAnimator = NoticeAnimator(
+            duration: Animations.appearanceDuration,
+            springDampening: Animations.appearanceSpringDamping,
+            springVelocity: NoticePresenter.Animations.appearanceSpringVelocity
+        )
+    ) {
         self.store = store
         self.animator = animator
 
@@ -99,8 +105,9 @@ class NoticePresenter {
                 guard let self,
                     let userInfo = notification.userInfo,
                     let keyboardFrameValue = userInfo[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue,
-                    let durationValue = userInfo[UIResponder.keyboardAnimationDurationUserInfoKey] as? NSNumber else {
-                        return
+                    let durationValue = userInfo[UIResponder.keyboardAnimationDurationUserInfoKey] as? NSNumber
+                else {
+                    return
                 }
 
                 self.currentKeyboardPresentation = .present(height: keyboardFrameValue.cgRectValue.size.height)
@@ -109,10 +116,14 @@ class NoticePresenter {
                     return
                 }
 
-                UIView.animate(withDuration: durationValue.doubleValue, animations: {
-                    currentContainer.bottomConstraint?.constant = self.onScreenNoticeContainerBottomConstraintConstant
-                    self.view.layoutIfNeeded()
-                })
+                UIView.animate(
+                    withDuration: durationValue.doubleValue,
+                    animations: {
+                        currentContainer.bottomConstraint?.constant =
+                            self.onScreenNoticeContainerBottomConstraintConstant
+                        self.view.layoutIfNeeded()
+                    }
+                )
             }
             .store(in: &notificationObservers)
 
@@ -124,14 +135,19 @@ class NoticePresenter {
                 guard let self,
                     let currentContainer = self.currentNoticePresentation?.containerView,
                     let userInfo = notification.userInfo,
-                    let durationValue = userInfo[UIResponder.keyboardAnimationDurationUserInfoKey] as? NSNumber else {
-                        return
+                    let durationValue = userInfo[UIResponder.keyboardAnimationDurationUserInfoKey] as? NSNumber
+                else {
+                    return
                 }
 
-                UIView.animate(withDuration: durationValue.doubleValue, animations: {
-                    currentContainer.bottomConstraint?.constant = self.onScreenNoticeContainerBottomConstraintConstant
-                    self.view.layoutIfNeeded()
-                })
+                UIView.animate(
+                    withDuration: durationValue.doubleValue,
+                    animations: {
+                        currentContainer.bottomConstraint?.constant =
+                            self.onScreenNoticeContainerBottomConstraintConstant
+                        self.view.layoutIfNeeded()
+                    }
+                )
             }
             .store(in: &notificationObservers)
     }
@@ -142,8 +158,9 @@ class NoticePresenter {
         NotificationCenter.default.publisher(for: .WPTabBarHeightChanged)
             .sink { [weak self] _ in
                 guard let self,
-                    let containerView = self.currentNoticePresentation?.containerView else {
-                        return
+                    let containerView = self.currentNoticePresentation?.containerView
+                else {
+                    return
                 }
 
                 containerView.bottomConstraint?.constant = -self.window.untouchableViewController.offsetOnscreen
@@ -197,15 +214,21 @@ class NoticePresenter {
         }
 
         let content = UNMutableNotificationContent(notice: notice)
-        let request = UNNotificationRequest(identifier: notificationInfo.identifier,
-                                            content: content,
-                                            trigger: nil)
+        let request = UNNotificationRequest(
+            identifier: notificationInfo.identifier,
+            content: content,
+            trigger: nil
+        )
 
-        UNUserNotificationCenter.current().add(request, withCompletionHandler: { _ in
-            DispatchQueue.main.async {
-                ActionDispatcher.dispatch(NoticeAction.clear(notice))
-            }
-        })
+        UNUserNotificationCenter.current()
+            .add(
+                request,
+                withCompletionHandler: { _ in
+                    DispatchQueue.main.async {
+                        ActionDispatcher.dispatch(NoticeAction.clear(notice))
+                    }
+                }
+            )
 
         return NoticePresentation(notice: notice, containerView: nil)
     }
@@ -222,13 +245,18 @@ class NoticePresenter {
         addTopConstraintToNoticeContainer(noticeContainerView)
 
         // At regular width, the notice shouldn't be any wider than 1/2 the app's width
-        noticeContainerView.noticeWidthConstraint = noticeView.widthAnchor.constraint(equalTo: noticeContainerView.widthAnchor, multiplier: 0.5)
-        let isRegularWidth = noticeContainerView.traitCollection.containsTraits(in: UITraitCollection(horizontalSizeClass: .regular))
+        noticeContainerView.noticeWidthConstraint = noticeView.widthAnchor.constraint(
+            equalTo: noticeContainerView.widthAnchor,
+            multiplier: 0.5
+        )
+        let isRegularWidth = noticeContainerView.traitCollection.containsTraits(
+            in: UITraitCollection(horizontalSizeClass: .regular)
+        )
         noticeContainerView.noticeWidthConstraint?.isActive = isRegularWidth
 
         NSLayoutConstraint.activate([
             noticeContainerView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            noticeContainerView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            noticeContainerView.trailingAnchor.constraint(equalTo: view.trailingAnchor)
         ])
 
         let dismiss = {
@@ -246,17 +274,29 @@ class NoticePresenter {
         view.mask = MaskView(parent: view, untouchableViewController: self.window.untouchableViewController)
 
         let offScreenBottomOffset = offScreenNoticeContainerBottomOffset(for: noticeContainerView)
-        let fromState = animator.state(for: noticeContainerView, in: view, withTransition: .offscreen,
-                                          bottomOffset: offScreenBottomOffset)
-        let toState = animator.state(for: noticeContainerView, in: view, withTransition: .onscreen,
-                                        bottomOffset: onScreenNoticeContainerBottomConstraintConstant)
-        animator.animatePresentation(fromState: fromState, toState: toState, completion: {
-            guard notice.style.isDismissable else {
-                return
-            }
+        let fromState = animator.state(
+            for: noticeContainerView,
+            in: view,
+            withTransition: .offscreen,
+            bottomOffset: offScreenBottomOffset
+        )
+        let toState = animator.state(
+            for: noticeContainerView,
+            in: view,
+            withTransition: .onscreen,
+            bottomOffset: onScreenNoticeContainerBottomConstraintConstant
+        )
+        animator.animatePresentation(
+            fromState: fromState,
+            toState: toState,
+            completion: {
+                guard notice.style.isDismissable else {
+                    return
+                }
 
-            DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + Animations.dismissDelay, execute: dismiss)
-        })
+                DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + Animations.dismissDelay, execute: dismiss)
+            }
+        )
 
         UIAccessibility.post(notification: .layoutChanged, argument: noticeContainerView)
 
@@ -284,38 +324,45 @@ class NoticePresenter {
 
     public class func dismiss(container: NoticeContainerView) {
         DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + .nanoseconds(1)) {
-            UIView.animate(withDuration: Animations.appearanceDuration,
-                           delay: 0,
-                           usingSpringWithDamping: Animations.appearanceSpringDamping,
-                           initialSpringVelocity: Animations.appearanceSpringVelocity,
-                           options: [],
-                           animations: {
+            UIView.animate(
+                withDuration: Animations.appearanceDuration,
+                delay: 0,
+                usingSpringWithDamping: Animations.appearanceSpringDamping,
+                initialSpringVelocity: Animations.appearanceSpringVelocity,
+                options: [],
+                animations: {
                     container.noticeView.alpha = 0
-            },
-                           completion: { _ in
+                },
+                completion: { _ in
                     container.removeFromSuperview()
-            })
+                }
+            )
         }
     }
 
     private func dismissForegroundNotice() {
         guard let container = currentNoticePresentation?.containerView,
-            container.superview != nil else {
-                return
+            container.superview != nil
+        else {
+            return
         }
         let bottomOffset = offScreenNoticeContainerBottomOffset(for: container)
         let toState = animator.state(for: container, in: view, withTransition: .offscreen, bottomOffset: bottomOffset)
-        animator.animatePresentation(fromState: {}, toState: toState, completion: { [weak self] in
-            container.removeFromSuperview()
+        animator.animatePresentation(
+            fromState: {},
+            toState: toState,
+            completion: { [weak self] in
+                container.removeFromSuperview()
 
-            // It is possible that when the dismiss animation finished, another Notice was already
-            // being shown. Hiding the window would cause that new Notice to be invisible.
-            if self?.currentNoticePresentation == nil {
-                UIAccessibility.post(notification: .layoutChanged, argument: nil)
+                // It is possible that when the dismiss animation finished, another Notice was already
+                // being shown. Hiding the window would cause that new Notice to be invisible.
+                if self?.currentNoticePresentation == nil {
+                    UIAccessibility.post(notification: .layoutChanged, argument: nil)
 
-                self?.window.isHidden = true
+                    self?.window.isHidden = true
+                }
             }
-        })
+        )
     }
 
     // MARK: - Animations
@@ -353,7 +400,7 @@ private extension UIWindow {
     /// - Returns: CGRect based on this window's frame
     /// - Note: Turns out that a small alteration to the frame is enough to accomplish this.
     func offsetToAvoidStatusBar() -> CGRect {
-        return self.frame.insetBy(dx: Offsets.minimalEdgeOffset, dy: Offsets.minimalEdgeOffset)
+        self.frame.insetBy(dx: Offsets.minimalEdgeOffset, dy: Offsets.minimalEdgeOffset)
     }
 
     private enum Offsets {
@@ -422,7 +469,7 @@ class NoticeContainerView: UIView {
     }
 
     override func point(inside point: CGPoint, with event: UIEvent?) -> Bool {
-        return noticeView.point(inside: convert(point, to: noticeView), with: event)
+        noticeView.point(inside: convert(point, to: noticeView), with: event)
     }
 }
 
@@ -450,8 +497,12 @@ private extension NoticePresenter {
             backgroundColor = .blue
 
             let nc = NotificationCenter.default
-            nc.addObserver(self, selector: #selector(updateFrame(notification:)),
-                           name: UIDevice.orientationDidChangeNotification, object: nil)
+            nc.addObserver(
+                self,
+                selector: #selector(updateFrame(notification:)),
+                name: UIDevice.orientationDidChangeNotification,
+                object: nil
+            )
         }
 
         required init?(coder aDecoder: NSCoder) {
@@ -462,9 +513,11 @@ private extension NoticePresenter {
             setNeedsLayout()
         }
 
-        private static func calculateFrame(parent: UIView,
-                                           untouchableVC: UntouchableViewController) -> CGRect {
-            return CGRect(
+        private static func calculateFrame(
+            parent: UIView,
+            untouchableVC: UntouchableViewController
+        ) -> CGRect {
+            CGRect(
                 x: 0,
                 y: 0,
                 width: parent.bounds.width,

--- a/WordPress/Classes/ViewRelated/System/Notices/NoticePresenter.swift
+++ b/WordPress/Classes/ViewRelated/System/Notices/NoticePresenter.swift
@@ -46,10 +46,14 @@ class NoticePresenter {
 
     private let store: NoticeStore
     private let animator: NoticeAnimator
-    private let window: UntouchableWindow
+    /// The overlay window hosting foreground notices. Created lazily on the first
+    /// foreground presentation: the presenter itself is created at process launch,
+    /// when no scene (and hence no window to attach to) may exist yet, e.g. on a
+    /// background launch. Background notices don't need a window at all.
+    private var window: UntouchableWindow?
     private var view: UIView {
-        guard let view = window.rootViewController?.view else {
-            fatalError("Root view controller shouldn't be nil")
+        guard let view = window?.rootViewController?.view else {
+            fatalError("The notice window doesn't exist or has no root view controller")
         }
         return view
     }
@@ -62,6 +66,11 @@ class NoticePresenter {
 
     private var notificationObservers = Set<AnyCancellable>()
 
+    /// Set when a foreground notice could not be presented because no scene was
+    /// connected (e.g. during launch). The notice stays at the head of the queue
+    /// and presentation is retried when the app becomes active.
+    private var retriesPresentationOnActivation = false
+
     init(
         store: NoticeStore = StoreContainer.shared.notice,
         animator: NoticeAnimator = NoticeAnimator(
@@ -73,20 +82,6 @@ class NoticePresenter {
         self.store = store
         self.animator = animator
 
-        let windowFrame: CGRect
-        if let mainWindow = UIApplication.shared.mainWindow {
-            windowFrame = mainWindow.offsetToAvoidStatusBar()
-        } else {
-            windowFrame = .zero
-        }
-        window = UntouchableWindow(frame: windowFrame)
-
-        // this window level may affect some UI elements like share sheets.
-        // however, since the alerts aren't permanently on screen, this isn't
-        // often a problem.
-        window.windowLevel = .alert
-        window.isHidden = true
-
         // Keep the storeReceipt to prevent the `onChange` subscription from being deactivated.
         storeReceipt = store.onChange { [weak self] in
             self?.onStoreChange()
@@ -94,6 +89,14 @@ class NoticePresenter {
 
         listenToKeyboardEvents()
         listenToOrientationChangeEvents()
+        listenToApplicationActivation()
+
+        // `onChange` doesn't replay the current state to a new subscriber. Process any
+        // notice that was posted before this presenter existed so it doesn't block the
+        // queue forever.
+        if store.currentNotice != nil {
+            onStoreChange()
+        }
     }
 
     // MARK: - Events
@@ -163,7 +166,23 @@ class NoticePresenter {
                     return
                 }
 
-                containerView.bottomConstraint?.constant = -self.window.untouchableViewController.offsetOnscreen
+                guard let window = self.window else {
+                    return
+                }
+                containerView.bottomConstraint?.constant = -window.untouchableViewController.offsetOnscreen
+            }
+            .store(in: &notificationObservers)
+    }
+
+    private func listenToApplicationActivation() {
+        NotificationCenter.default
+            .publisher(for: UIApplication.didBecomeActiveNotification)
+            .sink { [weak self] _ in
+                guard let self, self.retriesPresentationOnActivation else {
+                    return
+                }
+                self.retriesPresentationOnActivation = false
+                self.onStoreChange()
             }
             .store(in: &notificationObservers)
     }
@@ -187,6 +206,9 @@ class NoticePresenter {
 
         if let presentation = present(notice) {
             currentNoticePresentation = presentation
+        } else if retriesPresentationOnActivation {
+            // The notice stays at the head of the queue; the activation observer
+            // re-runs this method once a scene is available.
         } else {
             // We were not able to show the `notice` so we will dispatch a .clear action. This
             // should prevent us from getting in a stuck state where `NoticeStore` thinks its
@@ -234,6 +256,14 @@ class NoticePresenter {
     }
 
     private func presentNoticeInForeground(_ notice: Notice) -> NoticePresentation? {
+        // No scene is connected yet (e.g. the launch sequence posted this notice
+        // before UIKit connected the scene). Keep the notice queued and retry when
+        // the app becomes active, when a scene is guaranteed to exist.
+        guard let window = ensureWindow() else {
+            retriesPresentationOnActivation = true
+            return nil
+        }
+
         generator.prepare()
 
         let noticeView = NoticeView(notice: notice)
@@ -271,7 +301,7 @@ class NoticePresenter {
         window.isHidden = false
 
         // Mask must be initialized after the window is shown or the view.frame will be zero
-        view.mask = MaskView(parent: view, untouchableViewController: self.window.untouchableViewController)
+        view.mask = MaskView(parent: view, untouchableViewController: window.untouchableViewController)
 
         let offScreenBottomOffset = offScreenNoticeContainerBottomOffset(for: noticeContainerView)
         let fromState = animator.state(
@@ -301,6 +331,35 @@ class NoticePresenter {
         UIAccessibility.post(notification: .layoutChanged, argument: noticeContainerView)
 
         return NoticePresentation(notice: notice, containerView: noticeContainerView)
+    }
+
+    /// Returns the overlay window, creating it on first use. Returns nil when no
+    /// scene is connected: a window not attached to a scene would never display.
+    private func ensureWindow() -> UntouchableWindow? {
+        if let window {
+            // The scene can disconnect and reconnect while the process lives.
+            // Reattach the cached window so it isn't bound to a dead scene.
+            if let scene = UIApplication.shared.mainWindow?.windowScene, window.windowScene !== scene {
+                window.windowScene = scene
+            }
+            return window
+        }
+        guard let mainWindow = UIApplication.shared.mainWindow,
+            let windowScene = mainWindow.windowScene
+        else {
+            return nil
+        }
+        let window = UntouchableWindow(windowScene: windowScene)
+        window.frame = mainWindow.offsetToAvoidStatusBar()
+
+        // this window level may affect some UI elements like share sheets.
+        // however, since the alerts aren't permanently on screen, this isn't
+        // often a problem.
+        window.windowLevel = .alert
+        window.isHidden = true
+
+        self.window = window
+        return window
     }
 
     private func addNoticeContainerToPresentingViewController(_ noticeContainer: UIView) {
@@ -359,7 +418,7 @@ class NoticePresenter {
                 if self?.currentNoticePresentation == nil {
                     UIAccessibility.post(notification: .layoutChanged, argument: nil)
 
-                    self?.window.isHidden = true
+                    self?.window?.isHidden = true
                 }
             }
         )
@@ -372,7 +431,7 @@ class NoticePresenter {
         case .present(let keyboardHeight):
             return -keyboardHeight
         case .notPresent:
-            return -window.untouchableViewController.offsetOnscreen
+            return -(window?.untouchableViewController.offsetOnscreen ?? 0)
         }
     }
 
@@ -381,7 +440,7 @@ class NoticePresenter {
         case .present(let keyboardHeight):
             return -keyboardHeight + container.bounds.height
         case .notPresent:
-            return window.untouchableViewController.offsetOffscreen
+            return window?.untouchableViewController.offsetOffscreen ?? 0
         }
     }
 

--- a/WordPress/Classes/ViewRelated/System/Notices/UntouchableWindow.swift
+++ b/WordPress/Classes/ViewRelated/System/Notices/UntouchableWindow.swift
@@ -37,7 +37,8 @@ class UntouchableViewController: UIViewController {
         // this causes the check for the presentedViewController to return nil
         // thus placing the notice incorrectly, without the proper space for the tabBar
         guard let mainWindow = UIApplication.shared.delegate?.window,
-            let tabBarController = mainWindow?.rootViewController as? WPTabBarController else {
+            let tabBarController = mainWindow?.rootViewController as? WPTabBarController
+        else {
             return 0
         }
 
@@ -48,8 +49,9 @@ class UntouchableViewController: UIViewController {
         // we want 0 unless the tab bar has presented a VC
         guard let mainWindow = UIApplication.shared.delegate?.window,
             let tabBarController = mainWindow?.rootViewController as? WPTabBarController,
-            tabBarController.presentedViewController != nil else {
-                return 0
+            tabBarController.presentedViewController != nil
+        else {
+            return 0
         }
 
         return Constants.offsetWithoutTabbar
@@ -62,8 +64,9 @@ class UntouchableViewController: UIViewController {
     override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
         get {
             guard let mainWindow = UIApplication.shared.delegate?.window,
-                let rootController = mainWindow?.rootViewController else {
-                    return .all
+                let rootController = mainWindow?.rootViewController
+            else {
+                return .all
             }
 
             return rootController.topmostPresentedViewController.supportedInterfaceOrientations
@@ -79,7 +82,7 @@ private class UntouchableView: UIView {
 
     override func point(inside point: CGPoint, with event: UIEvent?) -> Bool {
         let visibleViews = subviews.filter { view -> Bool in
-            return view.alpha >= 0.01 && !view.isHidden && view.isUserInteractionEnabled
+            view.alpha >= 0.01 && !view.isHidden && view.isUserInteractionEnabled
         }
         for view in visibleViews {
             let relativePoint = convert(point, to: view)

--- a/WordPress/Classes/ViewRelated/System/Notices/UntouchableWindow.swift
+++ b/WordPress/Classes/ViewRelated/System/Notices/UntouchableWindow.swift
@@ -3,8 +3,8 @@ import UIKit
 @objc class UntouchableWindow: UIWindow {
     let untouchableViewController = UntouchableViewController()
 
-    override init(frame: CGRect) {
-        super.init(frame: frame)
+    override init(windowScene: UIWindowScene) {
+        super.init(windowScene: windowScene)
         rootViewController = untouchableViewController
     }
 


### PR DESCRIPTION
> [!Note]
> I recommend reviewing this PR commit by commit. The first commit is swift-format only.

## Description

Second PR in the UIScene life cycle preparation series, after https://github.com/wordpress-mobile/WordPress-iOS/pull/25636.

`NoticePresenter` created its `UntouchableWindow` eagerly at setup via `init(frame:)`, which leaves the window without a `windowScene`; such a window silently never displays once the app adopts the scene life cycle.

1. The window is now created on the first foreground presentation, attached to the active scene, and reattached if the scene has changed since creation.
2. A notice posted before any scene is connected (e.g. during launch) stays at the head of the queue and presentation is retried when the app becomes active, instead of being dropped.
3. Since the window can no longer be assumed to exist, the `fatalError`-backed `view` accessor is removed; presentation reads the view from the window it just ensured, and the keyboard and dismissal paths reach it through the container's superview.

## Testing instructions

Regression-test notices: trigger a few (e.g. save a draft, publish a post), and check a notice posted right before backgrounding is delivered as a local notification.