### PR TITLE
Route the Claude Code SwiftLint hook through rake lint

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -28,7 +28,7 @@
           {
             "type": "command",
             "command": "\"$CLAUDE_PROJECT_DIR\"/Scripts/claude-hooks/swiftlint.sh",
-            "timeout": 30,
+            "timeout": 60,
             "statusMessage": "Linting Swift..."
           }
         ]

--- a/Rakefile
+++ b/Rakefile
@@ -120,14 +120,14 @@ task :mocks do
   sh "#{File.join(PROJECT_DIR, 'API-Mocks', 'scripts', 'start.sh')} 8282"
 end
 
-desc 'Checks the source for style errors'
-task :lint do
-  sh 'pushd BuildTools; export SDKROOT=$(xcrun --sdk macosx --show-sdk-path); swift package plugin --allow-writing-to-directory .. --allow-writing-to-package-directory swiftlint --working-directory .. --quiet; popd'
+desc 'Checks the source for style errors. Lints the whole project, or only the given paths: rake lint[path1,path2]'
+task :lint, [:paths] do |_task, args|
+  run_swiftlint(paths: [args[:paths], *args.extras].compact)
 end
 
-desc 'Automatically fix linting errors where possible'
-task :lintfix do
-  sh 'pushd BuildTools; export SDKROOT=$(xcrun --sdk macosx --show-sdk-path); swift package plugin --allow-writing-to-directory .. --allow-writing-to-package-directory swiftlint --fix --working-directory .. --quiet; popd'
+desc 'Automatically fix linting errors where possible. Fixes the whole project, or only the given paths: rake lintfix[path1,path2]'
+task :lintfix, [:paths] do |_task, args|
+  run_swiftlint(paths: [args[:paths], *args.extras].compact, extra_args: ['--fix'])
 end
 
 namespace :git do
@@ -572,4 +572,16 @@ def check_dependencies_hook
     puts e.message
     exit 1
   end
+end
+
+# Runs SwiftLint via the BuildTools package plugin, which pins the SwiftLint version
+# to `swiftlint_version` in .swiftlint.yml. With no paths, lints the whole project.
+# SDKROOT is pinned to the macOS SDK so the plugin builds even when invoked from an
+# environment that targets iOS (e.g. an Xcode run script phase).
+def run_swiftlint(paths: [], extra_args: [])
+  sh({ 'SDKROOT' => `xcrun --sdk macosx --show-sdk-path`.strip },
+     'swift', 'package', '--package-path', 'BuildTools', 'plugin',
+     '--allow-writing-to-directory', PROJECT_DIR, '--allow-writing-to-package-directory',
+     'swiftlint', '--working-directory', PROJECT_DIR, '--quiet',
+     *extra_args, *paths.map { |path| File.expand_path(path) })
 end

--- a/Scripts/claude-hooks/swiftlint.sh
+++ b/Scripts/claude-hooks/swiftlint.sh
@@ -1,8 +1,9 @@
 #!/bin/sh
 # Claude Code PostToolUse hook: lint the just-edited Swift file with SwiftLint.
-# Reads the hook payload (JSON) on stdin, extracts the file path, and runs `swiftlint`
-# when the file is Swift and the binary is available. On violations, prints them to
-# stderr and exits 2 so Claude Code feeds them back to the model for self-correction.
+# Reads the hook payload (JSON) on stdin, extracts the file path, and runs it through
+# `rake lint` so the hook uses the exact same SwiftLint binary and configuration as
+# the project lint command. On violations, prints them to stderr and exits 2 so
+# Claude Code feeds them back to the model for self-correction.
 
 f=$(jq -r '.tool_input.file_path')
 case "$f" in
@@ -10,9 +11,10 @@ case "$f" in
     *) exit 0 ;;
 esac
 
-command -v swiftlint >/dev/null 2>&1 || exit 0
+cd "${CLAUDE_PROJECT_DIR:-.}" || exit 0
+command -v rake >/dev/null 2>&1 || exit 0
 
-out=$(swiftlint lint --quiet "$f" 2>&1)
+out=$(rake -s "lint[$f]" 2>&1)
 if [ -n "$out" ]; then
     echo "$out" >&2
     exit 2


### PR DESCRIPTION
## Description

The Claude Code swiftlint hook runs whatever `swiftlint` binary is on `PATH`, which can drift from the version pinned in `.swiftlint.yml`. This PR makes `rake lint` and `rake lintfix` accept optional paths (`rake lint[path1,path2]`), and changes the hook to run the edited file through `rake lint`, so the hook always uses the same plugin-pinned SwiftLint binary and configuration as the `rake lint` command.

A warm single-file `rake lint` run takes about one to three seconds. The first run after a SwiftLint version bump re-resolves the BuildTools package, which is why the hook timeout is raised to 60 seconds.