### PR TITLE
Add keychain types for per-app access groups

### DIFF
--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -237,6 +237,7 @@ let package = Package(
         .target(
             name: "WordPressShared",
             dependencies: [
+                "BuildSettingsKit",
                 .product(name: "SwiftSoup", package: "SwiftSoup"),
                 .target(name: "SFHFKeychainUtils"),
                 .target(name: "WordPressSharedObjC")

--- a/Modules/Sources/BuildSettingsKit/BuildSettings+Live.swift
+++ b/Modules/Sources/BuildSettingsKit/BuildSettings+Live.swift
@@ -10,6 +10,7 @@ extension BuildSettings {
         pushNotificationAppID = bundle.infoValue(forKey: "WPPushNotificationAppID")
         appGroupName = bundle.infoValue(forKey: "WPAppGroupName")
         appKeychainAccessGroup = bundle.infoValue(forKey: "WPAppKeychainAccessGroup")
+        sharedKeychainAccessGroup = bundle.object(forInfoDictionaryKey: "WPSharedKeychainAccessGroup") as? String
         eventNamePrefix = bundle.infoValue(forKey: "WPEventNamePrefix")
         explatPlatform = bundle.infoValue(forKey: "WPExplatPlatform")
         itunesAppID = bundle.infoValue(forKey: "WPItunesAppID")

--- a/Modules/Sources/BuildSettingsKit/BuildSettings+Preview.swift
+++ b/Modules/Sources/BuildSettingsKit/BuildSettings+Preview.swift
@@ -9,6 +9,7 @@ extension BuildSettings {
         pushNotificationAppID: "xcpreview_push_notification_id",
         appGroupName: "xcpreview_app_group_name",
         appKeychainAccessGroup: "xcpreview_app_keychain_access_group",
+        sharedKeychainAccessGroup: "xcpreview_shared_keychain_access_group",
         eventNamePrefix: "xcpreview",
         explatPlatform: "xcpreview",
         itunesAppID: "1234567890",

--- a/Modules/Sources/BuildSettingsKit/BuildSettings.swift
+++ b/Modules/Sources/BuildSettingsKit/BuildSettings.swift
@@ -25,6 +25,10 @@ public struct BuildSettings: Sendable {
     public var pushNotificationAppID: String
     public var appGroupName: String
     public var appKeychainAccessGroup: String
+    /// The legacy cross-app keychain group shared by the WordPress and
+    /// Jetpack apps. nil where the app has no shared-group entitlement
+    /// (Reader): the key is simply absent from that app's Info.plist.
+    public var sharedKeychainAccessGroup: String?
     public var eventNamePrefix: String
     public var explatPlatform: String
     public var itunesAppID: String

--- a/Modules/Sources/ShareExtensionCore/ShareExtensionService.swift
+++ b/Modules/Sources/ShareExtensionCore/ShareExtensionService.swift
@@ -153,11 +153,13 @@ public final class ShareExtensionService {
     /// Retrieves the WordPress.com OAuth Token, meant for Extension usage.
     ///
     public func retrieveShareExtensionToken() -> String? {
-        guard let oauth2Token = try? SFHFKeychainUtils.getPasswordForUsername(
-            configuration.keychainTokenKey,
-            andServiceName: configuration.keychainServiceName,
-            accessGroup: appKeychainAccessGroup
-        ) else {
+        guard
+            let oauth2Token = try? SFHFKeychainUtils.getPasswordForUsername(
+                configuration.keychainTokenKey,
+                andServiceName: configuration.keychainServiceName,
+                accessGroup: appKeychainAccessGroup
+            )
+        else {
             return nil
         }
 
@@ -167,11 +169,13 @@ public final class ShareExtensionService {
     /// Retrieves the WordPress.com Username, meant for Extension usage.
     ///
     public func retrieveShareExtensionUsername() -> String? {
-        guard let oauth2Token = try? SFHFKeychainUtils.getPasswordForUsername(
-            configuration.keychainUsernameKey,
-            andServiceName: configuration.keychainServiceName,
-            accessGroup: appKeychainAccessGroup
-        ) else {
+        guard
+            let oauth2Token = try? SFHFKeychainUtils.getPasswordForUsername(
+                configuration.keychainUsernameKey,
+                andServiceName: configuration.keychainServiceName,
+                accessGroup: appKeychainAccessGroup
+            )
+        else {
             return nil
         }
 
@@ -186,7 +190,8 @@ public final class ShareExtensionService {
         }
 
         if let siteID = userDefaults.object(forKey: configuration.userDefaultsPrimarySiteID) as? Int,
-            let siteName = userDefaults.object(forKey: configuration.userDefaultsPrimarySiteName) as? String {
+            let siteName = userDefaults.object(forKey: configuration.userDefaultsPrimarySiteName) as? String
+        {
             return (siteID, siteName)
         }
 
@@ -202,12 +207,14 @@ public final class ShareExtensionService {
         }
 
         if let siteID = userDefaults.object(forKey: configuration.userDefaultsLastUsedSiteID) as? Int,
-            let siteName = userDefaults.object(forKey: configuration.userDefaultsLastUsedSiteName) as? String {
+            let siteName = userDefaults.object(forKey: configuration.userDefaultsLastUsedSiteName) as? String
+        {
             return (siteID, siteName)
         }
 
         if let siteID = userDefaults.object(forKey: configuration.userDefaultsPrimarySiteID) as? Int,
-            let siteName = userDefaults.object(forKey: configuration.userDefaultsPrimarySiteName) as? String {
+            let siteName = userDefaults.object(forKey: configuration.userDefaultsPrimarySiteName) as? String
+        {
             return (siteID, siteName)
         }
 

--- a/Modules/Sources/WordPressShared/Keychain/AppKeychain.swift
+++ b/Modules/Sources/WordPressShared/Keychain/AppKeychain.swift
@@ -1,0 +1,96 @@
+import BuildSettingsKit
+import Foundation
+import Security
+import SFHFKeychainUtils
+
+/// Keychain access scoped to this app family's private access group (the
+/// app and its extensions, e.g. "3TMU3BH3NK.org.wordpress.jetpack").
+///
+/// Routing rules:
+///   - reads:   private group first, then a read-only fallback to the legacy
+///              shared group (transition only; removed once pre-change app
+///              versions are negligible)
+///   - writes:  private group, always
+///   - deletes: both groups, so a logout cannot resurrect a credential
+///              through the fallback read
+///
+/// Use `SharedKeychain` instead for the WordPress-to-Jetpack migration
+/// contract, the only data deliberately shared across apps.
+public final class AppKeychain: KeychainAccessible {
+    private let privateGroup: String
+    private let sharedGroup: String?
+    private let keychainUtils: SFHFKeychainUtils.Type
+
+    public convenience init() {
+        let settings = BuildSettings.current
+        self.init(
+            privateGroup: settings.appKeychainAccessGroup,
+            sharedGroup: settings.sharedKeychainAccessGroup
+        )
+    }
+
+    init(
+        privateGroup: String,
+        sharedGroup: String?,
+        keychainUtils: SFHFKeychainUtils.Type = SFHFKeychainUtils.self
+    ) {
+        self.privateGroup = privateGroup
+        self.sharedGroup = sharedGroup
+        self.keychainUtils = keychainUtils
+    }
+
+    public func getPassword(for username: String, serviceName: String) throws -> String {
+        do {
+            return try keychainUtils.getPasswordForUsername(
+                username,
+                andServiceName: serviceName,
+                accessGroup: privateGroup
+            )
+        } catch {
+            // The item may predate the one-time copy into the private group,
+            // including in extensions that wake before the host app copied.
+            // SFHFKeychainUtils cannot distinguish not-found from other
+            // failures in Swift, so any error falls through; a missing
+            // shared-group entitlement also lands here and is rethrown.
+            guard let sharedGroup else { throw error }
+            return try keychainUtils.getPasswordForUsername(
+                username,
+                andServiceName: serviceName,
+                accessGroup: sharedGroup
+            )
+        }
+    }
+
+    public func setPassword(for username: String, to newValue: String?, serviceName: String) throws {
+        guard let newValue else {
+            try deleteIgnoringNotFound(username, serviceName: serviceName, accessGroup: privateGroup)
+            if let sharedGroup {
+                try deleteIgnoringNotFound(username, serviceName: serviceName, accessGroup: sharedGroup)
+            }
+            return
+        }
+        try keychainUtils.storeUsername(
+            username,
+            andPassword: newValue,
+            forServiceName: serviceName,
+            accessGroup: privateGroup,
+            updateExisting: true
+        )
+    }
+
+    private func deleteIgnoringNotFound(_ username: String, serviceName: String, accessGroup: String) throws {
+        do {
+            try keychainUtils.deleteItem(
+                forUsername: username,
+                andServiceName: serviceName,
+                accessGroup: accessGroup
+            )
+        } catch {
+            // Deleting a missing item is expected: the item usually exists
+            // in only one of the two groups. Anything else (for example
+            // errSecInteractionNotAllowed while the device is locked) must
+            // surface, or a logout could silently leave a credential behind.
+            guard (error as NSError).code == Int(errSecItemNotFound) else { throw error }
+        }
+    }
+}

--- a/Modules/Sources/WordPressShared/Keychain/AuthTokenServiceNames.swift
+++ b/Modules/Sources/WordPressShared/Keychain/AuthTokenServiceNames.swift
@@ -1,0 +1,9 @@
+/// Keychain service names for the WP.com OAuth tokens. These form a
+/// cross-app contract (see `SharedKeychain`): the WordPress app publishes
+/// its token under `wordPress` for the Jetpack app to import, the group
+/// sweep preserves that item, and each app's copy skips the other's token.
+/// Old app versions hardcode both values, so they must never change.
+public enum AuthTokenServiceNames {
+    public static let wordPress = "public-api.wordpress.com"
+    public static let jetpack = "jetpack.public-api.wordpress.com"
+}

--- a/Modules/Sources/WordPressShared/Keychain/KeychainGroupMigrator.swift
+++ b/Modules/Sources/WordPressShared/Keychain/KeychainGroupMigrator.swift
@@ -1,0 +1,203 @@
+import BuildSettingsKit
+import Foundation
+import Security
+import SFHFKeychainUtils
+
+/// Minimal key-value needs of the keychain group migration.
+/// UserDefaults satisfies it natively.
+public protocol KeychainMigrationFlagStore: AnyObject {
+    func bool(forKey defaultName: String) -> Bool
+    func integer(forKey defaultName: String) -> Int
+    func set(_ value: Bool, forKey defaultName: String)
+    func set(_ value: Int, forKey defaultName: String)
+}
+
+extension UserDefaults: KeychainMigrationFlagStore {}
+
+/// One-time blanket copy of the legacy shared-group keychain items into this
+/// app's private group, plus a coordinated sweep that deletes the shared
+/// group's leftovers once every installed app has copied.
+///
+/// Runs at launch in the WordPress and Jetpack apps. Reader never runs this
+/// (no shared group; the initializer fails).
+/// The protocol assumes exactly two group members, WordPress and Jetpack.
+public final class KeychainGroupMigrator {
+
+    /// Bump to re-run the copy in a future release.
+    public static let migrationVersion = 1
+
+    static let localMarkerKey = "keychain_access_group_migration_version"
+    static let copyDoneKeyPrefix = "keychain_private_copy_done."
+    /// Deliberately unversioned, unlike the copy flags: a `migrationVersion`
+    /// bump re-runs the copy but not the sweep. If a future bump needs a
+    /// re-sweep (e.g. items landed in the shared group after the first
+    /// sweep), version this key at that point.
+    static let sweepDoneKey = "keychain_shared_sweep_done"
+
+    /// The migration handoff item is owned by the export/import flow
+    /// (DataMigrator), not by this sweep. Deleting it here would break a
+    /// pending export whose Jetpack import has not run yet.
+    static let preservedServices: Set<String> = [AuthTokenServiceNames.wordPress]
+
+    private let brand: AppBrand
+    private let privateGroup: String
+    private let sharedGroup: String
+    private let localDefaults: KeychainMigrationFlagStore
+    private let sharedDefaults: KeychainMigrationFlagStore
+    private let keychainUtils: SFHFKeychainUtils.Type
+    private let excludedFromCopy: Set<String>
+
+    public init?(
+        brand: AppBrand,
+        privateGroup: String,
+        sharedGroup: String?,
+        localDefaults: KeychainMigrationFlagStore,
+        sharedDefaults: KeychainMigrationFlagStore?,
+        keychainUtils: SFHFKeychainUtils.Type = SFHFKeychainUtils.self
+    ) {
+        guard brand == .wordpress || brand == .jetpack,
+            let sharedGroup,
+            let sharedDefaults
+        else {
+            return nil
+        }
+        self.brand = brand
+        self.privateGroup = privateGroup
+        self.sharedGroup = sharedGroup
+        self.localDefaults = localDefaults
+        self.sharedDefaults = sharedDefaults
+        self.keychainUtils = keychainUtils
+        // Never import the counterpart's WP.com token into this app's
+        // private group: it would outlive the counterpart's logout there,
+        // unreachable by either app's delete path.
+        self.excludedFromCopy =
+            brand == .wordpress
+            ? [AuthTokenServiceNames.jetpack]
+            : [AuthTokenServiceNames.wordPress]
+    }
+
+    public func migrateIfNeeded() {
+        #if targetEnvironment(simulator)
+        // The simulator keychain has no access groups: getAllPasswords would
+        // return every item regardless of group and the sweep would delete
+        // the app's only copies. There is nothing to migrate there.
+        return
+        #else
+        copyIfNeeded()
+        sweepIfSafe()
+        #endif
+    }
+
+    func copyIfNeeded() {
+        guard localDefaults.integer(forKey: Self.localMarkerKey) < Self.migrationVersion else {
+            return
+        }
+        // Snapshot first, then store. getAllPasswords fails while the device
+        // is locked before first unlock (errSecInteractionNotAllowed); the
+        // marker stays unset and the copy retries on the next launch.
+        // updateExisting makes retries idempotent.
+        let items: [[String: String]]
+        do {
+            items = try keychainUtils.getAllPasswords(forAccessGroup: sharedGroup)
+        } catch {
+            // An empty group surfaces as errSecItemNotFound: that is a
+            // successful zero-item copy (fresh installs, or a re-run after
+            // the sweep emptied the group). Anything else (for example
+            // errSecInteractionNotAllowed before first unlock) retries on
+            // the next launch.
+            guard (error as NSError).code == Int(errSecItemNotFound) else { return }
+            items = []
+        }
+        for item in items {
+            guard let username = item["username"],
+                let password = item["password"],
+                let serviceName = item["serviceName"],
+                excludedFromCopy.contains(serviceName) == false
+            else {
+                continue
+            }
+            // Insert-only: never overwrite an item that already exists in
+            // the private group. A retried copy (after a partial failure)
+            // must not revert credentials the app wrote after the update;
+            // the shared-group snapshot is older by definition.
+            if let _ = try? keychainUtils.getPasswordForUsername(
+                username,
+                andServiceName: serviceName,
+                accessGroup: privateGroup
+            ) {
+                continue
+            }
+            do {
+                try keychainUtils.storeUsername(
+                    username,
+                    andPassword: password,
+                    forServiceName: serviceName,
+                    accessGroup: privateGroup,
+                    updateExisting: true
+                )
+            } catch {
+                // Partial copy: leave the marker unset and retry next launch.
+                return
+            }
+        }
+        localDefaults.set(Self.migrationVersion, forKey: Self.localMarkerKey)
+        sharedDefaults.set(Self.migrationVersion, forKey: Self.copyDoneKeyPrefix + brand.rawValue)
+    }
+
+    /// Deletes the shared group's contents once it is safe: both apps have
+    /// copied at the current migration version. There is deliberately no
+    /// "counterpart not installed" shortcut: keychain items survive app
+    /// uninstalls and iCloud restores re-download apps lazily, and scheme
+    /// probing is unreliable outside production builds, so absence cannot
+    /// be distinguished from "not yet copied". If the counterpart is never
+    /// installed or never updates, the leftovers simply remain for a later
+    /// cleanup.
+    ///
+    /// Safety property: a pre-change app version never sets its copy flag,
+    /// so an installed old version always blocks the sweep.
+    func sweepIfSafe() {
+        guard sharedDefaults.bool(forKey: Self.sweepDoneKey) == false,
+            sharedDefaults.integer(forKey: Self.copyDoneKeyPrefix + brand.rawValue) >= Self.migrationVersion
+        else {
+            return
+        }
+        let counterpart: AppBrand = brand == .wordpress ? .jetpack : .wordpress
+        guard sharedDefaults.integer(forKey: Self.copyDoneKeyPrefix + counterpart.rawValue) >= Self.migrationVersion
+        else {
+            return
+        }
+        let items: [[String: String]]
+        do {
+            items = try keychainUtils.getAllPasswords(forAccessGroup: sharedGroup)
+        } catch {
+            // Empty group: nothing left to sweep, mark it done. Any other
+            // error retries on the next launch.
+            guard (error as NSError).code == Int(errSecItemNotFound) else { return }
+            items = []
+        }
+        var allDeletesSucceeded = true
+        for item in items {
+            guard let username = item["username"],
+                let serviceName = item["serviceName"],
+                Self.preservedServices.contains(serviceName) == false
+            else {
+                continue
+            }
+            do {
+                try keychainUtils.deleteItem(
+                    forUsername: username,
+                    andServiceName: serviceName,
+                    accessGroup: sharedGroup
+                )
+            } catch {
+                if (error as NSError).code != Int(errSecItemNotFound) {
+                    allDeletesSucceeded = false
+                }
+            }
+        }
+        // A failed delete means leftovers remain; keep the done flag unset
+        // so the next launch retries instead of abandoning them silently.
+        guard allDeletesSucceeded else { return }
+        sharedDefaults.set(true, forKey: Self.sweepDoneKey)
+    }
+}

--- a/Modules/Sources/WordPressShared/Keychain/KeychainUtils.swift
+++ b/Modules/Sources/WordPressShared/Keychain/KeychainUtils.swift
@@ -9,19 +9,28 @@ public class KeychainUtils: NSObject {
         self.keychainUtils = keychainUtils
     }
 
-    func copyKeychain(from sourceAccessGroup: String?,
-                      to destinationAccessGroup: String?,
-                      updateExisting: Bool = true) throws {
+    func copyKeychain(
+        from sourceAccessGroup: String?,
+        to destinationAccessGroup: String?,
+        updateExisting: Bool = true
+    ) throws {
         let sourceItems = try keychainUtils.getAllPasswords(forAccessGroup: sourceAccessGroup)
 
         for item in sourceItems {
             guard let username = item["username"],
-                  let password = item["password"],
-                  let serviceName = item["serviceName"] else {
+                let password = item["password"],
+                let serviceName = item["serviceName"]
+            else {
                 continue
             }
 
-            try keychainUtils.storeUsername(username, andPassword: password, forServiceName: serviceName, accessGroup: destinationAccessGroup, updateExisting: updateExisting)
+            try keychainUtils.storeUsername(
+                username,
+                andPassword: password,
+                forServiceName: serviceName,
+                accessGroup: destinationAccessGroup,
+                updateExisting: updateExisting
+            )
         }
     }
 }
@@ -33,7 +42,12 @@ extension KeychainUtils: KeychainAccessible {
 
     public func setPassword(for username: String, to newValue: String?, serviceName: String) throws {
         if let newValue {
-            try keychainUtils.storeUsername(username, andPassword: newValue, forServiceName: serviceName, updateExisting: true)
+            try keychainUtils.storeUsername(
+                username,
+                andPassword: newValue,
+                forServiceName: serviceName,
+                updateExisting: true
+            )
         } else {
             try keychainUtils.deleteItem(forUsername: username, andServiceName: serviceName)
         }

--- a/Modules/Sources/WordPressShared/Keychain/SharedKeychain.swift
+++ b/Modules/Sources/WordPressShared/Keychain/SharedKeychain.swift
@@ -1,0 +1,63 @@
+import BuildSettingsKit
+import Foundation
+import Security
+import SFHFKeychainUtils
+
+/// Keychain access scoped to the legacy cross-app shared access group
+/// ("3TMU3BH3NK.org.wordpress").
+///
+/// The ONLY permitted users are the WordPress-to-Jetpack migration contract:
+///   1. DataMigrator.exportData          (WordPress: publish the WP.com token)
+///   2. DataMigrator.deleteExportedData  (WordPress: remove it on logout)
+///   3. SharedDataIssueSolver.migrateAuthKey (Jetpack: read the token)
+///
+/// Anything else belongs in `AppKeychain`. A new SharedKeychain call site
+/// means a new cross-app data flow; treat it as a design change.
+public final class SharedKeychain: KeychainAccessible {
+    private let group: String
+    private let keychainUtils: SFHFKeychainUtils.Type
+
+    /// Fails where the app has no shared-group entitlement (Reader).
+    public convenience init?() {
+        self.init(group: BuildSettings.current.sharedKeychainAccessGroup)
+    }
+
+    init?(group: String?, keychainUtils: SFHFKeychainUtils.Type = SFHFKeychainUtils.self) {
+        guard let group else { return nil }
+        self.group = group
+        self.keychainUtils = keychainUtils
+    }
+
+    public func getPassword(for username: String, serviceName: String) throws -> String {
+        try keychainUtils.getPasswordForUsername(
+            username,
+            andServiceName: serviceName,
+            accessGroup: group
+        )
+    }
+
+    public func setPassword(for username: String, to newValue: String?, serviceName: String) throws {
+        if let newValue {
+            try keychainUtils.storeUsername(
+                username,
+                andPassword: newValue,
+                forServiceName: serviceName,
+                accessGroup: group,
+                updateExisting: true
+            )
+        } else {
+            do {
+                try keychainUtils.deleteItem(
+                    forUsername: username,
+                    andServiceName: serviceName,
+                    accessGroup: group
+                )
+            } catch {
+                // Deleting an already-absent item is success: the migration
+                // cleanup path removes a token that may legitimately be gone.
+                // Real failures must surface, same as AppKeychain.
+                guard (error as NSError).code == Int(errSecItemNotFound) else { throw error }
+            }
+        }
+    }
+}

--- a/Modules/Tests/WordPressSharedTests/AppKeychainTests.swift
+++ b/Modules/Tests/WordPressSharedTests/AppKeychainTests.swift
@@ -1,0 +1,80 @@
+import Security
+import Testing
+@testable import WordPressShared
+
+@Suite(.serialized)
+struct AppKeychainTests {
+    private let privateGroup = "team.private"
+    private let sharedGroup = "team.shared"
+
+    private func makeKeychain(sharedGroup: String? = "team.shared") -> AppKeychain {
+        AppKeychain(privateGroup: privateGroup, sharedGroup: sharedGroup, keychainUtils: KeychainStub.self)
+    }
+
+    init() {
+        KeychainStub.reset()
+    }
+
+    @Test func readPrefersPrivateGroup() throws {
+        KeychainStub.seed(group: privateGroup, service: "svc", username: "user", password: "private-pw")
+        KeychainStub.seed(group: sharedGroup, service: "svc", username: "user", password: "shared-pw")
+
+        let value = try makeKeychain().getPassword(for: "user", serviceName: "svc")
+        #expect(value == "private-pw")
+    }
+
+    @Test func readFallsBackToSharedGroup() throws {
+        KeychainStub.seed(group: sharedGroup, service: "svc", username: "user", password: "shared-pw")
+
+        let value = try makeKeychain().getPassword(for: "user", serviceName: "svc")
+        #expect(value == "shared-pw")
+    }
+
+    @Test func readThrowsWhenMissingEverywhere() {
+        #expect(throws: (any Error).self) {
+            try makeKeychain().getPassword(for: "user", serviceName: "svc")
+        }
+    }
+
+    @Test func readDoesNotFallBackWithoutSharedGroup() {
+        KeychainStub.seed(group: sharedGroup, service: "svc", username: "user", password: "shared-pw")
+
+        #expect(throws: (any Error).self) {
+            try makeKeychain(sharedGroup: nil).getPassword(for: "user", serviceName: "svc")
+        }
+    }
+
+    @Test func writeTargetsPrivateGroupOnly() throws {
+        try makeKeychain().setPassword(for: "user", to: "new-pw", serviceName: "svc")
+
+        #expect(KeychainStub.password(group: privateGroup, service: "svc", username: "user") == "new-pw")
+        #expect(KeychainStub.password(group: sharedGroup, service: "svc", username: "user") == nil)
+    }
+
+    @Test func deleteRemovesFromBothGroups() throws {
+        KeychainStub.seed(group: privateGroup, service: "svc", username: "user", password: "pw")
+        KeychainStub.seed(group: sharedGroup, service: "svc", username: "user", password: "pw")
+
+        try makeKeychain().setPassword(for: "user", to: nil, serviceName: "svc")
+
+        #expect(KeychainStub.password(group: privateGroup, service: "svc", username: "user") == nil)
+        #expect(KeychainStub.password(group: sharedGroup, service: "svc", username: "user") == nil)
+    }
+
+    @Test func deleteSucceedsWhenItemOnlyInSharedGroup() throws {
+        KeychainStub.seed(group: sharedGroup, service: "svc", username: "user", password: "pw")
+
+        try makeKeychain().setPassword(for: "user", to: nil, serviceName: "svc")
+
+        #expect(KeychainStub.password(group: sharedGroup, service: "svc", username: "user") == nil)
+    }
+
+    @Test func deleteRethrowsRealFailures() {
+        KeychainStub.seed(group: privateGroup, service: "svc", username: "user", password: "pw")
+        KeychainStub.deleteError = NSError(domain: "KeychainStub", code: Int(errSecInteractionNotAllowed))
+
+        #expect(throws: (any Error).self) {
+            try makeKeychain().setPassword(for: "user", to: nil, serviceName: "svc")
+        }
+    }
+}

--- a/Modules/Tests/WordPressSharedTests/AppKeychainTests.swift
+++ b/Modules/Tests/WordPressSharedTests/AppKeychainTests.swift
@@ -2,79 +2,81 @@ import Security
 import Testing
 @testable import WordPressShared
 
-@Suite(.serialized)
-struct AppKeychainTests {
-    private let privateGroup = "team.private"
-    private let sharedGroup = "team.shared"
+extension KeychainStubSuites {
+    @Suite(.serialized)
+    struct AppKeychainTests {
+        private let privateGroup = "team.private"
+        private let sharedGroup = "team.shared"
 
-    private func makeKeychain(sharedGroup: String? = "team.shared") -> AppKeychain {
-        AppKeychain(privateGroup: privateGroup, sharedGroup: sharedGroup, keychainUtils: KeychainStub.self)
-    }
-
-    init() {
-        KeychainStub.reset()
-    }
-
-    @Test func readPrefersPrivateGroup() throws {
-        KeychainStub.seed(group: privateGroup, service: "svc", username: "user", password: "private-pw")
-        KeychainStub.seed(group: sharedGroup, service: "svc", username: "user", password: "shared-pw")
-
-        let value = try makeKeychain().getPassword(for: "user", serviceName: "svc")
-        #expect(value == "private-pw")
-    }
-
-    @Test func readFallsBackToSharedGroup() throws {
-        KeychainStub.seed(group: sharedGroup, service: "svc", username: "user", password: "shared-pw")
-
-        let value = try makeKeychain().getPassword(for: "user", serviceName: "svc")
-        #expect(value == "shared-pw")
-    }
-
-    @Test func readThrowsWhenMissingEverywhere() {
-        #expect(throws: (any Error).self) {
-            try makeKeychain().getPassword(for: "user", serviceName: "svc")
+        private func makeKeychain(sharedGroup: String? = "team.shared") -> AppKeychain {
+            AppKeychain(privateGroup: privateGroup, sharedGroup: sharedGroup, keychainUtils: KeychainStub.self)
         }
-    }
 
-    @Test func readDoesNotFallBackWithoutSharedGroup() {
-        KeychainStub.seed(group: sharedGroup, service: "svc", username: "user", password: "shared-pw")
-
-        #expect(throws: (any Error).self) {
-            try makeKeychain(sharedGroup: nil).getPassword(for: "user", serviceName: "svc")
+        init() {
+            KeychainStub.reset()
         }
-    }
 
-    @Test func writeTargetsPrivateGroupOnly() throws {
-        try makeKeychain().setPassword(for: "user", to: "new-pw", serviceName: "svc")
+        @Test func readPrefersPrivateGroup() throws {
+            KeychainStub.seed(group: privateGroup, service: "svc", username: "user", password: "private-pw")
+            KeychainStub.seed(group: sharedGroup, service: "svc", username: "user", password: "shared-pw")
 
-        #expect(KeychainStub.password(group: privateGroup, service: "svc", username: "user") == "new-pw")
-        #expect(KeychainStub.password(group: sharedGroup, service: "svc", username: "user") == nil)
-    }
+            let value = try makeKeychain().getPassword(for: "user", serviceName: "svc")
+            #expect(value == "private-pw")
+        }
 
-    @Test func deleteRemovesFromBothGroups() throws {
-        KeychainStub.seed(group: privateGroup, service: "svc", username: "user", password: "pw")
-        KeychainStub.seed(group: sharedGroup, service: "svc", username: "user", password: "pw")
+        @Test func readFallsBackToSharedGroup() throws {
+            KeychainStub.seed(group: sharedGroup, service: "svc", username: "user", password: "shared-pw")
 
-        try makeKeychain().setPassword(for: "user", to: nil, serviceName: "svc")
+            let value = try makeKeychain().getPassword(for: "user", serviceName: "svc")
+            #expect(value == "shared-pw")
+        }
 
-        #expect(KeychainStub.password(group: privateGroup, service: "svc", username: "user") == nil)
-        #expect(KeychainStub.password(group: sharedGroup, service: "svc", username: "user") == nil)
-    }
+        @Test func readThrowsWhenMissingEverywhere() {
+            #expect(throws: (any Error).self) {
+                try makeKeychain().getPassword(for: "user", serviceName: "svc")
+            }
+        }
 
-    @Test func deleteSucceedsWhenItemOnlyInSharedGroup() throws {
-        KeychainStub.seed(group: sharedGroup, service: "svc", username: "user", password: "pw")
+        @Test func readDoesNotFallBackWithoutSharedGroup() {
+            KeychainStub.seed(group: sharedGroup, service: "svc", username: "user", password: "shared-pw")
 
-        try makeKeychain().setPassword(for: "user", to: nil, serviceName: "svc")
+            #expect(throws: (any Error).self) {
+                try makeKeychain(sharedGroup: nil).getPassword(for: "user", serviceName: "svc")
+            }
+        }
 
-        #expect(KeychainStub.password(group: sharedGroup, service: "svc", username: "user") == nil)
-    }
+        @Test func writeTargetsPrivateGroupOnly() throws {
+            try makeKeychain().setPassword(for: "user", to: "new-pw", serviceName: "svc")
 
-    @Test func deleteRethrowsRealFailures() {
-        KeychainStub.seed(group: privateGroup, service: "svc", username: "user", password: "pw")
-        KeychainStub.deleteError = NSError(domain: "KeychainStub", code: Int(errSecInteractionNotAllowed))
+            #expect(KeychainStub.password(group: privateGroup, service: "svc", username: "user") == "new-pw")
+            #expect(KeychainStub.password(group: sharedGroup, service: "svc", username: "user") == nil)
+        }
 
-        #expect(throws: (any Error).self) {
+        @Test func deleteRemovesFromBothGroups() throws {
+            KeychainStub.seed(group: privateGroup, service: "svc", username: "user", password: "pw")
+            KeychainStub.seed(group: sharedGroup, service: "svc", username: "user", password: "pw")
+
             try makeKeychain().setPassword(for: "user", to: nil, serviceName: "svc")
+
+            #expect(KeychainStub.password(group: privateGroup, service: "svc", username: "user") == nil)
+            #expect(KeychainStub.password(group: sharedGroup, service: "svc", username: "user") == nil)
+        }
+
+        @Test func deleteSucceedsWhenItemOnlyInSharedGroup() throws {
+            KeychainStub.seed(group: sharedGroup, service: "svc", username: "user", password: "pw")
+
+            try makeKeychain().setPassword(for: "user", to: nil, serviceName: "svc")
+
+            #expect(KeychainStub.password(group: sharedGroup, service: "svc", username: "user") == nil)
+        }
+
+        @Test func deleteRethrowsRealFailures() {
+            KeychainStub.seed(group: privateGroup, service: "svc", username: "user", password: "pw")
+            KeychainStub.deleteError = NSError(domain: "KeychainStub", code: Int(errSecInteractionNotAllowed))
+
+            #expect(throws: (any Error).self) {
+                try makeKeychain().setPassword(for: "user", to: nil, serviceName: "svc")
+            }
         }
     }
 }

--- a/Modules/Tests/WordPressSharedTests/KeychainGroupMigratorTests.swift
+++ b/Modules/Tests/WordPressSharedTests/KeychainGroupMigratorTests.swift
@@ -1,0 +1,255 @@
+import BuildSettingsKit
+import Foundation
+import Security
+import Testing
+@testable import WordPressShared
+
+private final class FlagStoreFake: KeychainMigrationFlagStore {
+    var storage: [String: Any] = [:]
+
+    func bool(forKey defaultName: String) -> Bool { storage[defaultName] as? Bool ?? false }
+    func integer(forKey defaultName: String) -> Int { storage[defaultName] as? Int ?? 0 }
+    func set(_ value: Bool, forKey defaultName: String) { storage[defaultName] = value }
+    func set(_ value: Int, forKey defaultName: String) { storage[defaultName] = value }
+}
+
+extension KeychainStubSuites {
+    @Suite(.serialized)
+    struct KeychainGroupMigratorTests {
+        private let privateGroup = "team.private.wordpress"
+        private let sharedGroup = "team.shared"
+        private let localDefaults = FlagStoreFake()
+        private let sharedDefaults = FlagStoreFake()
+
+        init() {
+            KeychainStub.reset()
+        }
+
+        private func makeMigrator(
+            brand: AppBrand = .wordpress
+        ) -> KeychainGroupMigrator {
+            KeychainGroupMigrator(
+                brand: brand,
+                privateGroup: privateGroup,
+                sharedGroup: sharedGroup,
+                localDefaults: localDefaults,
+                sharedDefaults: sharedDefaults,
+                keychainUtils: KeychainStub.self
+            )!
+        }
+
+        @Test func initFailsForReaderOrMissingSharedGroup() {
+            #expect(
+                KeychainGroupMigrator(
+                    brand: .reader,
+                    privateGroup: privateGroup,
+                    sharedGroup: sharedGroup,
+                    localDefaults: localDefaults,
+                    sharedDefaults: sharedDefaults,
+                    keychainUtils: KeychainStub.self
+                ) == nil
+            )
+            #expect(
+                KeychainGroupMigrator(
+                    brand: .wordpress,
+                    privateGroup: privateGroup,
+                    sharedGroup: nil,
+                    localDefaults: localDefaults,
+                    sharedDefaults: sharedDefaults,
+                    keychainUtils: KeychainStub.self
+                ) == nil
+            )
+        }
+
+        @Test func copyMovesItemsAndSetsFlags() {
+            KeychainStub.seed(group: sharedGroup, service: "svc1", username: "u1", password: "p1")
+            KeychainStub.seed(group: sharedGroup, service: "svc2", username: "u2", password: "p2")
+
+            makeMigrator().copyIfNeeded()
+
+            #expect(KeychainStub.password(group: privateGroup, service: "svc1", username: "u1") == "p1")
+            #expect(KeychainStub.password(group: privateGroup, service: "svc2", username: "u2") == "p2")
+            // Originals stay; the sweep removes them later.
+            #expect(KeychainStub.password(group: sharedGroup, service: "svc1", username: "u1") == "p1")
+            #expect(localDefaults.integer(forKey: "keychain_access_group_migration_version") == 1)
+            #expect(
+                sharedDefaults.integer(forKey: "keychain_private_copy_done.wordpress")
+                    == KeychainGroupMigrator.migrationVersion
+            )
+        }
+
+        @Test func copySkippedWhenMarkerCurrent() {
+            localDefaults.set(KeychainGroupMigrator.migrationVersion, forKey: "keychain_access_group_migration_version")
+            KeychainStub.seed(group: sharedGroup, service: "svc", username: "u", password: "p")
+
+            makeMigrator().copyIfNeeded()
+
+            #expect(KeychainStub.password(group: privateGroup, service: "svc", username: "u") == nil)
+        }
+
+        @Test func copyFailureLeavesMarkerUnset() {
+            KeychainStub.getAllPasswordsError = NSError(domain: "KeychainStub", code: Int(errSecInteractionNotAllowed))
+
+            makeMigrator().copyIfNeeded()
+
+            #expect(localDefaults.integer(forKey: "keychain_access_group_migration_version") == 0)
+            #expect(sharedDefaults.integer(forKey: "keychain_private_copy_done.wordpress") == 0)
+        }
+
+        @Test func sweepBlockedWithoutCounterpartFlag() {
+            sharedDefaults.set(KeychainGroupMigrator.migrationVersion, forKey: "keychain_private_copy_done.wordpress")
+            KeychainStub.seed(group: sharedGroup, service: "svc", username: "u", password: "p")
+
+            makeMigrator().sweepIfSafe()
+
+            #expect(KeychainStub.password(group: sharedGroup, service: "svc", username: "u") == "p")
+            #expect(!sharedDefaults.bool(forKey: "keychain_shared_sweep_done"))
+        }
+
+        @Test func sweepBlockedBeforeOwnCopy() {
+            KeychainStub.seed(group: sharedGroup, service: "svc", username: "u", password: "p")
+
+            makeMigrator().sweepIfSafe()
+
+            #expect(KeychainStub.password(group: sharedGroup, service: "svc", username: "u") == "p")
+        }
+
+        @Test func sweepPreservesHandoffItem() {
+            sharedDefaults.set(KeychainGroupMigrator.migrationVersion, forKey: "keychain_private_copy_done.wordpress")
+            sharedDefaults.set(KeychainGroupMigrator.migrationVersion, forKey: "keychain_private_copy_done.jetpack")
+            KeychainStub.seed(group: sharedGroup, service: "svc", username: "u", password: "p")
+            KeychainStub.seed(
+                group: sharedGroup,
+                service: "public-api.wordpress.com",
+                username: "acct",
+                password: "token"
+            )
+
+            makeMigrator().sweepIfSafe()
+
+            #expect(KeychainStub.password(group: sharedGroup, service: "svc", username: "u") == nil)
+            #expect(
+                KeychainStub.password(group: sharedGroup, service: "public-api.wordpress.com", username: "acct")
+                    == "token"
+            )
+            #expect(sharedDefaults.bool(forKey: "keychain_shared_sweep_done"))
+        }
+
+        @Test func sweepRunsWhenCounterpartCopied() {
+            sharedDefaults.set(KeychainGroupMigrator.migrationVersion, forKey: "keychain_private_copy_done.wordpress")
+            sharedDefaults.set(KeychainGroupMigrator.migrationVersion, forKey: "keychain_private_copy_done.jetpack")
+            KeychainStub.seed(group: sharedGroup, service: "svc", username: "u", password: "p")
+
+            makeMigrator().sweepIfSafe()
+
+            #expect(KeychainStub.password(group: sharedGroup, service: "svc", username: "u") == nil)
+            #expect(sharedDefaults.bool(forKey: "keychain_shared_sweep_done"))
+        }
+
+        @Test func sweepSkippedWhenAlreadyDone() {
+            sharedDefaults.set(KeychainGroupMigrator.migrationVersion, forKey: "keychain_private_copy_done.wordpress")
+            sharedDefaults.set(true, forKey: "keychain_shared_sweep_done")
+            KeychainStub.seed(group: sharedGroup, service: "svc", username: "u", password: "p")
+
+            makeMigrator().sweepIfSafe()
+
+            #expect(KeychainStub.password(group: sharedGroup, service: "svc", username: "u") == "p")
+        }
+
+        @Test func copyWithEmptyGroupSetsMarkerAndFlag() {
+            KeychainStub.getAllPasswordsError = NSError(domain: "KeychainStub", code: Int(errSecItemNotFound))
+
+            makeMigrator().copyIfNeeded()
+
+            #expect(
+                localDefaults.integer(forKey: "keychain_access_group_migration_version")
+                    == KeychainGroupMigrator.migrationVersion
+            )
+            #expect(
+                sharedDefaults.integer(forKey: "keychain_private_copy_done.wordpress")
+                    == KeychainGroupMigrator.migrationVersion
+            )
+        }
+
+        @Test func sweepBlockedWhenCounterpartCopiedAtOlderVersion() {
+            sharedDefaults.set(KeychainGroupMigrator.migrationVersion, forKey: "keychain_private_copy_done.wordpress")
+            sharedDefaults.set(KeychainGroupMigrator.migrationVersion - 1, forKey: "keychain_private_copy_done.jetpack")
+            KeychainStub.seed(group: sharedGroup, service: "svc", username: "u", password: "p")
+
+            makeMigrator().sweepIfSafe()
+
+            #expect(KeychainStub.password(group: sharedGroup, service: "svc", username: "u") == "p")
+            #expect(!sharedDefaults.bool(forKey: "keychain_shared_sweep_done"))
+        }
+
+        @Test func sweepRetriesWhenDeleteFails() {
+            sharedDefaults.set(KeychainGroupMigrator.migrationVersion, forKey: "keychain_private_copy_done.wordpress")
+            sharedDefaults.set(KeychainGroupMigrator.migrationVersion, forKey: "keychain_private_copy_done.jetpack")
+            KeychainStub.seed(group: sharedGroup, service: "svc", username: "u", password: "p")
+            KeychainStub.deleteError = NSError(domain: "KeychainStub", code: Int(errSecInteractionNotAllowed))
+
+            makeMigrator().sweepIfSafe()
+
+            #expect(!sharedDefaults.bool(forKey: "keychain_shared_sweep_done"))
+        }
+
+        @Test func sweepWithEmptyGroupMarksDone() {
+            sharedDefaults.set(KeychainGroupMigrator.migrationVersion, forKey: "keychain_private_copy_done.wordpress")
+            sharedDefaults.set(KeychainGroupMigrator.migrationVersion, forKey: "keychain_private_copy_done.jetpack")
+            KeychainStub.getAllPasswordsError = NSError(domain: "KeychainStub", code: Int(errSecItemNotFound))
+
+            makeMigrator().sweepIfSafe()
+
+            #expect(sharedDefaults.bool(forKey: "keychain_shared_sweep_done"))
+        }
+
+        @Test func copySkipsCounterpartAuthToken() {
+            KeychainStub.seed(
+                group: sharedGroup,
+                service: "jetpack.public-api.wordpress.com",
+                username: "u",
+                password: "jp-token"
+            )
+            KeychainStub.seed(group: sharedGroup, service: "svc", username: "u", password: "p")
+
+            makeMigrator(brand: .wordpress).copyIfNeeded()
+
+            #expect(
+                KeychainStub.password(group: privateGroup, service: "jetpack.public-api.wordpress.com", username: "u")
+                    == nil
+            )
+            #expect(KeychainStub.password(group: privateGroup, service: "svc", username: "u") == "p")
+        }
+
+        @Test func copyKeepsOwnAuthToken() {
+            KeychainStub.seed(
+                group: sharedGroup,
+                service: "jetpack.public-api.wordpress.com",
+                username: "u",
+                password: "jp-token"
+            )
+
+            makeMigrator(brand: .jetpack).copyIfNeeded()
+
+            #expect(
+                KeychainStub.password(group: privateGroup, service: "jetpack.public-api.wordpress.com", username: "u")
+                    == "jp-token"
+            )
+        }
+
+        @Test func retriedCopyDoesNotOverwriteNewerPrivateItem() {
+            KeychainStub.seed(group: privateGroup, service: "svc", username: "u", password: "newer-pw")
+            KeychainStub.seed(group: sharedGroup, service: "svc", username: "u", password: "older-pw")
+            KeychainStub.seed(group: sharedGroup, service: "svc2", username: "u2", password: "p2")
+
+            makeMigrator().copyIfNeeded()
+
+            #expect(KeychainStub.password(group: privateGroup, service: "svc", username: "u") == "newer-pw")
+            #expect(KeychainStub.password(group: privateGroup, service: "svc2", username: "u2") == "p2")
+            #expect(
+                localDefaults.integer(forKey: "keychain_access_group_migration_version")
+                    == KeychainGroupMigrator.migrationVersion
+            )
+        }
+    }
+}

--- a/Modules/Tests/WordPressSharedTests/KeychainStub.swift
+++ b/Modules/Tests/WordPressSharedTests/KeychainStub.swift
@@ -1,9 +1,17 @@
 import Foundation
 import Security
 import SFHFKeychainUtils
+import Testing
+
+/// Parent suite that serializes every keychain suite against the others.
+/// They all share `KeychainStub`'s class-level state, and `.serialized` on
+/// an individual suite only orders the tests inside it; without a common
+/// serialized ancestor, separate suites still run in parallel and race on
+/// the stub.
+@Suite(.serialized) enum KeychainStubSuites {}
 
 /// In-memory SFHFKeychainUtils replacement keyed by access group.
-/// Class-level state: any suite using it must be `.serialized`.
+/// Class-level state: any suite using it must nest in `KeychainStubSuites`.
 final class KeychainStub: SFHFKeychainUtils {
     /// group -> service -> username -> password.
     /// nil access groups are stored under `defaultGroup`.

--- a/Modules/Tests/WordPressSharedTests/KeychainStub.swift
+++ b/Modules/Tests/WordPressSharedTests/KeychainStub.swift
@@ -1,0 +1,81 @@
+import Foundation
+import Security
+import SFHFKeychainUtils
+
+/// In-memory SFHFKeychainUtils replacement keyed by access group.
+/// Class-level state: any suite using it must be `.serialized`.
+final class KeychainStub: SFHFKeychainUtils {
+    /// group -> service -> username -> password.
+    /// nil access groups are stored under `defaultGroup`.
+    nonisolated(unsafe) static var groups: [String: [String: [String: String]]] = [:]
+    nonisolated(unsafe) static var getAllPasswordsError: Error?
+    nonisolated(unsafe) static var storeError: Error?
+    nonisolated(unsafe) static var deleteError: Error?
+
+    static let defaultGroup = "<default>"
+
+    enum StubError: Error {
+        case notFound
+    }
+
+    static func reset() {
+        groups = [:]
+        getAllPasswordsError = nil
+        storeError = nil
+        deleteError = nil
+    }
+
+    static func seed(group: String, service: String, username: String, password: String) {
+        groups[group, default: [:]][service, default: [:]][username] = password
+    }
+
+    static func password(group: String, service: String, username: String) -> String? {
+        groups[group]?[service]?[username]
+    }
+
+    override class func getPasswordForUsername(
+        _ username: String!,
+        andServiceName serviceName: String!,
+        accessGroup: String!
+    ) throws -> String {
+        guard let value = groups[accessGroup ?? defaultGroup]?[serviceName]?[username] else {
+            throw StubError.notFound
+        }
+        return value
+    }
+
+    override class func storeUsername(
+        _ username: String!,
+        andPassword password: String!,
+        forServiceName serviceName: String!,
+        accessGroup: String!,
+        updateExisting: Bool
+    ) throws {
+        if let storeError { throw storeError }
+        groups[accessGroup ?? defaultGroup, default: [:]][serviceName, default: [:]][username] = password
+    }
+
+    override class func deleteItem(
+        forUsername username: String!,
+        andServiceName serviceName: String!,
+        accessGroup: String!
+    ) throws {
+        if let deleteError { throw deleteError }
+        let group = accessGroup ?? defaultGroup
+        guard groups[group]?[serviceName]?[username] != nil else {
+            throw NSError(domain: "KeychainStub", code: Int(errSecItemNotFound))
+        }
+        groups[group]?[serviceName]?[username] = nil
+    }
+
+    override class func getAllPasswords(forAccessGroup accessGroup: String!) throws -> [[String: String]] {
+        if let getAllPasswordsError { throw getAllPasswordsError }
+        var result = [[String: String]]()
+        for (service, users) in groups[accessGroup ?? defaultGroup] ?? [:] {
+            for (username, password) in users {
+                result.append(["username": username, "password": password, "serviceName": service])
+            }
+        }
+        return result
+    }
+}

--- a/Modules/Tests/WordPressSharedTests/SharedKeychainTests.swift
+++ b/Modules/Tests/WordPressSharedTests/SharedKeychainTests.swift
@@ -1,0 +1,45 @@
+import Testing
+@testable import WordPressShared
+
+@Suite(.serialized)
+struct SharedKeychainTests {
+    private let sharedGroup = "team.shared"
+
+    init() {
+        KeychainStub.reset()
+    }
+
+    @Test func initFailsWithoutGroup() {
+        #expect(SharedKeychain(group: nil, keychainUtils: KeychainStub.self) == nil)
+    }
+
+    @Test func readTargetsSharedGroup() throws {
+        KeychainStub.seed(group: sharedGroup, service: "svc", username: "user", password: "pw")
+        let keychain = try #require(SharedKeychain(group: sharedGroup, keychainUtils: KeychainStub.self))
+
+        let value = try keychain.getPassword(for: "user", serviceName: "svc")
+        #expect(value == "pw")
+    }
+
+    @Test func writeTargetsSharedGroup() throws {
+        let keychain = try #require(SharedKeychain(group: sharedGroup, keychainUtils: KeychainStub.self))
+
+        try keychain.setPassword(for: "user", to: "pw", serviceName: "svc")
+        #expect(KeychainStub.password(group: sharedGroup, service: "svc", username: "user") == "pw")
+    }
+
+    @Test func nilValueDeletesFromSharedGroup() throws {
+        KeychainStub.seed(group: sharedGroup, service: "svc", username: "user", password: "pw")
+        let keychain = try #require(SharedKeychain(group: sharedGroup, keychainUtils: KeychainStub.self))
+
+        try keychain.setPassword(for: "user", to: nil, serviceName: "svc")
+        #expect(KeychainStub.password(group: sharedGroup, service: "svc", username: "user") == nil)
+    }
+
+    @Test func nilValueSucceedsWhenItemMissing() throws {
+        let keychain = try #require(SharedKeychain(group: sharedGroup, keychainUtils: KeychainStub.self))
+
+        try keychain.setPassword(for: "user", to: nil, serviceName: "svc")
+        #expect(KeychainStub.password(group: sharedGroup, service: "svc", username: "user") == nil)
+    }
+}

--- a/Modules/Tests/WordPressSharedTests/SharedKeychainTests.swift
+++ b/Modules/Tests/WordPressSharedTests/SharedKeychainTests.swift
@@ -1,45 +1,47 @@
 import Testing
 @testable import WordPressShared
 
-@Suite(.serialized)
-struct SharedKeychainTests {
-    private let sharedGroup = "team.shared"
+extension KeychainStubSuites {
+    @Suite(.serialized)
+    struct SharedKeychainTests {
+        private let sharedGroup = "team.shared"
 
-    init() {
-        KeychainStub.reset()
-    }
+        init() {
+            KeychainStub.reset()
+        }
 
-    @Test func initFailsWithoutGroup() {
-        #expect(SharedKeychain(group: nil, keychainUtils: KeychainStub.self) == nil)
-    }
+        @Test func initFailsWithoutGroup() {
+            #expect(SharedKeychain(group: nil, keychainUtils: KeychainStub.self) == nil)
+        }
 
-    @Test func readTargetsSharedGroup() throws {
-        KeychainStub.seed(group: sharedGroup, service: "svc", username: "user", password: "pw")
-        let keychain = try #require(SharedKeychain(group: sharedGroup, keychainUtils: KeychainStub.self))
+        @Test func readTargetsSharedGroup() throws {
+            KeychainStub.seed(group: sharedGroup, service: "svc", username: "user", password: "pw")
+            let keychain = try #require(SharedKeychain(group: sharedGroup, keychainUtils: KeychainStub.self))
 
-        let value = try keychain.getPassword(for: "user", serviceName: "svc")
-        #expect(value == "pw")
-    }
+            let value = try keychain.getPassword(for: "user", serviceName: "svc")
+            #expect(value == "pw")
+        }
 
-    @Test func writeTargetsSharedGroup() throws {
-        let keychain = try #require(SharedKeychain(group: sharedGroup, keychainUtils: KeychainStub.self))
+        @Test func writeTargetsSharedGroup() throws {
+            let keychain = try #require(SharedKeychain(group: sharedGroup, keychainUtils: KeychainStub.self))
 
-        try keychain.setPassword(for: "user", to: "pw", serviceName: "svc")
-        #expect(KeychainStub.password(group: sharedGroup, service: "svc", username: "user") == "pw")
-    }
+            try keychain.setPassword(for: "user", to: "pw", serviceName: "svc")
+            #expect(KeychainStub.password(group: sharedGroup, service: "svc", username: "user") == "pw")
+        }
 
-    @Test func nilValueDeletesFromSharedGroup() throws {
-        KeychainStub.seed(group: sharedGroup, service: "svc", username: "user", password: "pw")
-        let keychain = try #require(SharedKeychain(group: sharedGroup, keychainUtils: KeychainStub.self))
+        @Test func nilValueDeletesFromSharedGroup() throws {
+            KeychainStub.seed(group: sharedGroup, service: "svc", username: "user", password: "pw")
+            let keychain = try #require(SharedKeychain(group: sharedGroup, keychainUtils: KeychainStub.self))
 
-        try keychain.setPassword(for: "user", to: nil, serviceName: "svc")
-        #expect(KeychainStub.password(group: sharedGroup, service: "svc", username: "user") == nil)
-    }
+            try keychain.setPassword(for: "user", to: nil, serviceName: "svc")
+            #expect(KeychainStub.password(group: sharedGroup, service: "svc", username: "user") == nil)
+        }
 
-    @Test func nilValueSucceedsWhenItemMissing() throws {
-        let keychain = try #require(SharedKeychain(group: sharedGroup, keychainUtils: KeychainStub.self))
+        @Test func nilValueSucceedsWhenItemMissing() throws {
+            let keychain = try #require(SharedKeychain(group: sharedGroup, keychainUtils: KeychainStub.self))
 
-        try keychain.setPassword(for: "user", to: nil, serviceName: "svc")
-        #expect(KeychainStub.password(group: sharedGroup, service: "svc", username: "user") == nil)
+            try keychain.setPassword(for: "user", to: nil, serviceName: "svc")
+            #expect(KeychainStub.password(group: sharedGroup, service: "svc", username: "user") == nil)
+        }
     }
 }

--- a/Sources/JetpackStatsWidgets/Sources/Services/StatsWidgetsService.swift
+++ b/Sources/JetpackStatsWidgets/Sources/Services/StatsWidgetsService.swift
@@ -29,8 +29,10 @@ class StatsWidgetsService {
 
     private var state: State = .ready
 
-    func fetchStats(for widgetData: HomeWidgetData,
-                    completion: @escaping (Result<ResultType, Error>) -> Void) {
+    func fetchStats(
+        for widgetData: HomeWidgetData,
+        completion: @escaping (Result<ResultType, Error>) -> Void
+    ) {
 
         guard !state.isLoading else {
             return
@@ -48,8 +50,10 @@ class StatsWidgetsService {
         }
     }
 
-    private func fetchTodayStats(widgetData: HomeWidgetTodayData,
-                                 completion: @escaping (Result<ResultType, Error>) -> Void) {
+    private func fetchTodayStats(
+        widgetData: HomeWidgetTodayData,
+        completion: @escaping (Result<ResultType, Error>) -> Void
+    ) {
 
         getInsight(widgetData: widgetData) { [weak self] (insight: StatsTodayInsight?, error) in
             guard let self else {
@@ -68,15 +72,19 @@ class StatsWidgetsService {
                 return
             }
 
-            let newWidgetData = HomeWidgetTodayData(siteID: widgetData.siteID,
-                                                    siteName: widgetData.siteName,
-                                                    url: widgetData.url,
-                                                    timeZone: widgetData.timeZone,
-                                                    date: Date(),
-                                                    stats: TodayWidgetStats(views: insight.viewsCount,
-                                                                            visitors: insight.visitorsCount,
-                                                                            likes: insight.likesCount,
-                                                                            comments: insight.commentsCount))
+            let newWidgetData = HomeWidgetTodayData(
+                siteID: widgetData.siteID,
+                siteName: widgetData.siteName,
+                url: widgetData.url,
+                timeZone: widgetData.timeZone,
+                date: Date(),
+                stats: TodayWidgetStats(
+                    views: insight.viewsCount,
+                    visitors: insight.visitorsCount,
+                    likes: insight.likesCount,
+                    comments: insight.commentsCount
+                )
+            )
             completion(.success(newWidgetData))
             DispatchQueue.main.async {
                 // update the item in the local cache
@@ -86,8 +94,10 @@ class StatsWidgetsService {
         }
     }
 
-    private func fetchAllTimeStats(widgetData: HomeWidgetAllTimeData,
-                                   completion: @escaping (Result<ResultType, Error>) -> Void) {
+    private func fetchAllTimeStats(
+        widgetData: HomeWidgetAllTimeData,
+        completion: @escaping (Result<ResultType, Error>) -> Void
+    ) {
 
         getInsight(widgetData: widgetData) { [weak self] (insight: StatsAllTimesInsight?, error) in
 
@@ -101,16 +111,20 @@ class StatsWidgetsService {
                 return
             }
 
-            let newWidgetData = HomeWidgetAllTimeData(siteID: widgetData.siteID,
-                                                      siteName: widgetData.siteName,
-                                                      url: widgetData.url,
-                                                      timeZone: widgetData.timeZone,
-                                                      date: Date(),
-                                                      stats: AllTimeWidgetStats(views:
-                                                                                    insight?.viewsCount,
-                                                                                visitors: insight?.visitorsCount,
-                                                                                posts: insight?.postsCount,
-                                                                                bestViews: insight?.bestViewsPerDayCount))
+            let newWidgetData = HomeWidgetAllTimeData(
+                siteID: widgetData.siteID,
+                siteName: widgetData.siteName,
+                url: widgetData.url,
+                timeZone: widgetData.timeZone,
+                date: Date(),
+                stats: AllTimeWidgetStats(
+                    views:
+                        insight?.viewsCount,
+                    visitors: insight?.visitorsCount,
+                    posts: insight?.postsCount,
+                    bestViews: insight?.bestViewsPerDayCount
+                )
+            )
             completion(.success(newWidgetData))
             DispatchQueue.main.async {
                 // update the item in the local cache
@@ -120,25 +134,31 @@ class StatsWidgetsService {
         }
     }
 
-    private func fetchThisWeekStats(widgetData: HomeWidgetThisWeekData,
-                                    completion: @escaping (Result<ResultType, Error>) -> Void) {
+    private func fetchThisWeekStats(
+        widgetData: HomeWidgetThisWeekData,
+        completion: @escaping (Result<ResultType, Error>) -> Void
+    ) {
 
         // Get the current date in the site's time zone.
         let siteTimeZone = widgetData.timeZone
         let weekEndingDate = Date().convert(from: siteTimeZone).normalizedDate()
 
         // Include an extra day. It's needed to get the dailyChange for the last day.
-        getData(widgetData: widgetData,
-                for: .day,
-                endingOn: weekEndingDate,
-                limit: ThisWeekWidgetStats.maxDaysToDisplay + 1) { [weak self] (summary: StatsSummaryTimeIntervalData?, error: Error?) in
+        getData(
+            widgetData: widgetData,
+            for: .day,
+            endingOn: weekEndingDate,
+            limit: ThisWeekWidgetStats.maxDaysToDisplay + 1
+        ) { [weak self] (summary: StatsSummaryTimeIntervalData?, error: Error?) in
 
             guard let self else {
                 return
             }
 
             if let error {
-                DDLogError("This Week Widget: Error fetching summary: \(String(describing: error.localizedDescription))")
+                DDLogError(
+                    "This Week Widget: Error fetching summary: \(String(describing: error.localizedDescription))"
+                )
                 completion(.failure(error))
                 self.state = .error
                 return
@@ -156,16 +176,18 @@ class StatsWidgetsService {
                         summaryData: summaryData.map {
                             ThisWeekWidgetStats.Input(
                                 periodStartDate: $0.periodStartDate,
-                                viewsCount: $0.viewsCount)
+                                viewsCount: $0.viewsCount
+                            )
                         }
                     )
                 )
             )
             completion(.success(newWidgetData))
 
-            DispatchQueue.global().async {
-                HomeWidgetThisWeekData.setItem(item: newWidgetData)
-            }
+            DispatchQueue.global()
+                .async {
+                    HomeWidgetThisWeekData.setItem(item: newWidgetData)
+                }
             self.state = .ready
         }
     }
@@ -190,10 +212,14 @@ private extension StatsWidgetsService {
     ) {
         do {
             self.service = try createStatsService(for: widgetData)
-            self.service?.getInsight(limit: limit, completion: { [weak self] in
-                completion($0, $1)
-                self?.service = nil
-            })
+            self.service?
+                .getInsight(
+                    limit: limit,
+                    completion: { [weak self] in
+                        completion($0, $1)
+                        self?.service = nil
+                    }
+                )
         } catch {
             completion(nil, error)
             self.state = .error
@@ -210,10 +236,17 @@ private extension StatsWidgetsService {
     ) {
         do {
             self.service = try createStatsService(for: widgetData)
-            self.service?.getData(for: period, unit: unit, endingOn: endingOn, limit: limit, completion: { [weak self] in
-                completion($0, $1)
-                self?.service = nil
-            })
+            self.service?
+                .getData(
+                    for: period,
+                    unit: unit,
+                    endingOn: endingOn,
+                    limit: limit,
+                    completion: { [weak self] in
+                        completion($0, $1)
+                        self?.service = nil
+                    }
+                )
         } catch {
             completion(nil, error)
             self.state = .error
@@ -227,6 +260,10 @@ private extension StatsWidgetsService {
             accessGroup: BuildSettings.current.appKeychainAccessGroup
         )
         let wpApi = WordPressComRestApi(oAuthToken: token)
-        return StatsServiceRemoteV2(wordPressComRestApi: wpApi, siteID: widgetData.siteID, siteTimezone: widgetData.timeZone)
+        return StatsServiceRemoteV2(
+            wordPressComRestApi: wpApi,
+            siteID: widgetData.siteID,
+            siteTimezone: widgetData.timeZone
+        )
     }
 }

--- a/Sources/WordPressData/Swift/Blog+Swift.swift
+++ b/Sources/WordPressData/Swift/Blog+Swift.swift
@@ -66,7 +66,8 @@ extension Blog {
     @objc public var password: String? {
         get {
             guard let username, !username.isEmpty,
-                  let xmlrpc, !xmlrpc.isEmpty else {
+                let xmlrpc, !xmlrpc.isEmpty
+            else {
                 return nil
             }
             if let password = try? keychain.getPassword(for: username, serviceName: xmlrpc) {
@@ -181,11 +182,13 @@ extension Blog {
     @objc public var timeZone: TimeZone? {
         let oneHourInSeconds: Double = 3600
         if let name = getOptionString(name: "timezone"), !name.isEmpty,
-           let timeZone = TimeZone(identifier: name) {
+            let timeZone = TimeZone(identifier: name)
+        {
             return timeZone
         }
         if let gmtOffset = getOptionValue("gmt_offset") as? NSNumber,
-           let timeZone = TimeZone(secondsFromGMT: Int(gmtOffset.doubleValue * oneHourInSeconds)) {
+            let timeZone = TimeZone(secondsFromGMT: Int(gmtOffset.doubleValue * oneHourInSeconds))
+        {
             return timeZone
         }
         if let value = getOptionValue("time_zone") {
@@ -205,7 +208,8 @@ extension Blog {
         for protectionSpace in storage.allCredentials.keys {
             if protectionSpace.host == url.host
                 && protectionSpace.port == (url.port ?? 80)
-                && protectionSpace.authenticationMethod == NSURLAuthenticationMethodHTTPBasic {
+                && protectionSpace.authenticationMethod == NSURLAuthenticationMethodHTTPBasic
+            {
                 return true
             }
         }
@@ -217,13 +221,15 @@ extension Blog {
     @objc public var logDescription: String {
         let extra: String
         if let account {
-            extra = " wp.com account: \(account.username) blogId: \(dotComID?.intValue ?? 0) plan: \(planTitle ?? "") (\(planID?.intValue ?? 0))"
+            extra =
+                " wp.com account: \(account.username) blogId: \(dotComID?.intValue ?? 0) plan: \(planTitle ?? "") (\(planID?.intValue ?? 0))"
         } else if let jetpack {
             extra = " jetpack: \(jetpack)"
         } else {
             extra = ""
         }
-        return "<Blog Name: \(settings?.name ?? "") URL: \(url ?? "") XML-RPC: \(xmlrpc ?? "")\(extra) ObjectID: \(objectID.uriRepresentation())>"
+        return
+            "<Blog Name: \(settings?.name ?? "") URL: \(url ?? "") XML-RPC: \(xmlrpc ?? "")\(extra) ObjectID: \(objectID.uriRepresentation())>"
     }
 
     // MARK: - Misc
@@ -266,9 +272,10 @@ extension Blog {
 
     /// The blog's categories sorted alphabetically by name (case-insensitive).
     @objc public var sortedCategories: [PostCategory] {
-        (categories ?? []).sorted {
-            $0.categoryName.caseInsensitiveCompare($1.categoryName) == .orderedAscending
-        }
+        (categories ?? [])
+            .sorted {
+                $0.categoryName.caseInsensitiveCompare($1.categoryName) == .orderedAscending
+            }
     }
 
     /// The set of allowed file types for uploads, derived from blog options.
@@ -286,7 +293,8 @@ extension Blog {
     public var siteVisibility: SiteVisibility {
         get {
             guard let rawValue = settings?.privacy?.intValue,
-                  let visibility = SiteVisibility(rawValue: rawValue) else {
+                let visibility = SiteVisibility(rawValue: rawValue)
+            else {
                 return .unknown
             }
             return visibility

--- a/Sources/WordPressData/Swift/SharedDataIssueSolver.swift
+++ b/Sources/WordPressData/Swift/SharedDataIssueSolver.swift
@@ -9,11 +9,13 @@ public final class SharedDataIssueSolver {
     private let localFileStore: LocalFileStore
     private let appGroupName: String
 
-    public init(contextManager: CoreDataStack = ContextManager.shared,
-         keychainUtils: KeychainAccessible = KeychainUtils(),
-         sharedDefaults: UserPersistentRepository? = UserDefaults(suiteName: BuildSettings.current.appGroupName),
-         localFileStore: LocalFileStore = FileManager.default,
-         appGroupName: String = BuildSettings.current.appGroupName) {
+    public init(
+        contextManager: CoreDataStack = ContextManager.shared,
+        keychainUtils: KeychainAccessible = KeychainUtils(),
+        sharedDefaults: UserPersistentRepository? = UserDefaults(suiteName: BuildSettings.current.appGroupName),
+        localFileStore: LocalFileStore = FileManager.default,
+        appGroupName: String = BuildSettings.current.appGroupName
+    ) {
         self.contextManager = contextManager
         self.keychainUtils = keychainUtils
         self.sharedDefaults = sharedDefaults
@@ -34,18 +36,29 @@ public final class SharedDataIssueSolver {
     ///
     public func migrateAuthKey(for username: String) {
         guard BuildSettings.current.brand == .jetpack,
-              let token = try? keychainUtils.getPassword(for: username, serviceName: WPAccountConstants.authToken.rawValue) else {
+            let token = try? keychainUtils.getPassword(
+                for: username,
+                serviceName: WPAccountConstants.authToken.rawValue
+            )
+        else {
             return
         }
 
         // If the token has already been migrated, no need to resolve the issue again.
         // There might also be a possibility that the user logged in to JP by themselves. In which, we won't need to migrate.
-        if let _ = try? keychainUtils.getPassword(for: username, serviceName: WPAccountConstants.authToken.valueForJetpack) {
+        if let _ = try? keychainUtils.getPassword(
+            for: username,
+            serviceName: WPAccountConstants.authToken.valueForJetpack
+        ) {
             return
         }
 
         // if authToken for the account username exists, move it to the authToken location for JP.
-        try? keychainUtils.setPassword(for: username, to: token, serviceName: WPAccountConstants.authToken.valueForJetpack)
+        try? keychainUtils.setPassword(
+            for: username,
+            to: token,
+            serviceName: WPAccountConstants.authToken.valueForJetpack
+        )
     }
 
     public func migrateExtensionsData() {
@@ -137,9 +150,13 @@ private extension SharedDataIssueSolver {
         ]
 
         fileNames.forEach { fileName in
-            guard let sourceURL = localFileStore.containerURL(forAppGroup: appGroupName)?.appendingPathComponent(fileName.rawValue),
-                  let targetURL = localFileStore.containerURL(forAppGroup: appGroupName)?.appendingPathComponent(fileName.valueForJetpack),
-                  localFileStore.fileExists(at: sourceURL) else {
+            guard
+                let sourceURL = localFileStore.containerURL(forAppGroup: appGroupName)?
+                    .appendingPathComponent(fileName.rawValue),
+                let targetURL = localFileStore.containerURL(forAppGroup: appGroupName)?
+                    .appendingPathComponent(fileName.valueForJetpack),
+                localFileStore.fileExists(at: sourceURL)
+            else {
                 return
             }
 

--- a/Sources/WordPressData/Swift/WPAccount.swift
+++ b/Sources/WordPressData/Swift/WPAccount.swift
@@ -86,7 +86,7 @@ public class WPAccount: NSManagedObject {
     // MARK: - Entity Name
 
     @objc public override class func entityName() -> String {
-        return "Account"
+        "Account"
     }
 
     // MARK: - Lifecycle
@@ -139,7 +139,10 @@ public class WPAccount: NSManagedObject {
         do {
             try keychain.setPassword(for: username, to: authToken, serviceName: keychainServiceName)
         } catch {
-            WPLogError("Error while updating or deleting WordPressComOAuthKeychainServiceName token: %@", error.localizedDescription)
+            WPLogError(
+                "Error while updating or deleting WordPressComOAuthKeychainServiceName token: %@",
+                error.localizedDescription
+            )
         }
     }
 
@@ -163,7 +166,10 @@ public class WPAccount: NSManagedObject {
         do {
             return try keychain.getPassword(for: username, serviceName: serviceName)
         } catch {
-            WPLogError("Error while retrieving WordPressComOAuthKeychainServiceName token: %@", error.localizedDescription)
+            WPLogError(
+                "Error while retrieving WordPressComOAuthKeychainServiceName token: %@",
+                error.localizedDescription
+            )
             throw error
         }
     }

--- a/Tests/KeystoneTests/Tests/Jetpack/DataMigratorTests.swift
+++ b/Tests/KeystoneTests/Tests/Jetpack/DataMigratorTests.swift
@@ -83,7 +83,10 @@ class DataMigratorTests: XCTestCase {
         let migratorError = getExportDataMigratorError(migrator)
 
         // Then
-        XCTAssertEqual(migratorError, DataMigrationError.databaseExportError(underlyingError: DataMigrationError.sharedUserDefaultsNil))
+        XCTAssertEqual(
+            migratorError,
+            DataMigrationError.databaseExportError(underlyingError: DataMigrationError.sharedUserDefaultsNil)
+        )
     }
 
     func test_importData_givenDataIsNotExported_shouldFail() {
@@ -239,7 +242,7 @@ private final class CoreDataStackMock: CoreDataStack {
     }
 
     func newDerivedContext() -> NSManagedObjectContext {
-        return mainContext
+        mainContext
     }
 
     func saveContextAndWait(_ context: NSManagedObjectContext) {}
@@ -247,7 +250,11 @@ private final class CoreDataStackMock: CoreDataStack {
     func save(_ context: NSManagedObjectContext, completion completionBlock: (() -> Void)?, on queue: DispatchQueue) {}
 
     func performAndSave(_ aBlock: @escaping (NSManagedObjectContext) -> Void) {}
-    func performAndSave(_ aBlock: @escaping (NSManagedObjectContext) -> Void, completion: (() -> Void)?, on queue: DispatchQueue) {}
+    func performAndSave(
+        _ aBlock: @escaping (NSManagedObjectContext) -> Void,
+        completion: (() -> Void)?,
+        on queue: DispatchQueue
+    ) {}
 }
 
 // MARK: - Helpers
@@ -259,11 +266,18 @@ private extension DataMigratorTests {
         static let defaultsWrapperKey = "defaults_staging_dictionary"
     }
 
-    func createContext(for model: NSManagedObjectModel = NSManagedObjectModel.mergedModel(from: [Bundle.wordPressData])!,
-                       type: String = NSInMemoryStoreType,
-                       at location: URL? = nil) throws -> NSManagedObjectContext {
+    func createContext(
+        for model: NSManagedObjectModel = NSManagedObjectModel.mergedModel(from: [Bundle.wordPressData])!,
+        type: String = NSInMemoryStoreType,
+        at location: URL? = nil
+    ) throws -> NSManagedObjectContext {
         let persistentStoreCoordinator = NSPersistentStoreCoordinator(managedObjectModel: model)
-        try persistentStoreCoordinator.addPersistentStore(ofType: type, configurationName: nil, at: location, options: nil)
+        try persistentStoreCoordinator.addPersistentStore(
+            ofType: type,
+            configurationName: nil,
+            at: location,
+            options: nil
+        )
         let managedObjectContext = NSManagedObjectContext(concurrencyType: .mainQueueConcurrencyType)
         managedObjectContext.persistentStoreCoordinator = persistentStoreCoordinator
 
@@ -271,7 +285,7 @@ private extension DataMigratorTests {
     }
 
     func createFileContext(for model: NSManagedObjectModel, at location: URL) throws -> NSManagedObjectContext {
-        return try createContext(for: model, type: NSSQLiteStoreType, at: location)
+        try createContext(for: model, type: NSSQLiteStoreType, at: location)
     }
 
     func getExportDataMigratorError(_ migrator: DataMigrator) -> DataMigrationError? {
@@ -289,8 +303,9 @@ private extension DataMigratorTests {
 
     func getModelNames() -> [String] {
         guard let modelFileURL = Bundle.wordPressData.url(forResource: "WordPress", withExtension: "momd"),
-              let versionInfo = NSDictionary(contentsOf: modelFileURL.appendingPathComponent("VersionInfo.plist")),
-              let modelNames = (versionInfo["NSManagedObjectModel_VersionHashes"] as? [String: AnyObject])?.keys else {
+            let versionInfo = NSDictionary(contentsOf: modelFileURL.appendingPathComponent("VersionInfo.plist")),
+            let modelNames = (versionInfo["NSManagedObjectModel_VersionHashes"] as? [String: AnyObject])?.keys
+        else {
             return []
         }
         let sortedModelNames = modelNames.sorted { $0.compare($1, options: .numeric) == .orderedAscending }
@@ -311,7 +326,11 @@ private extension DataMigratorTests {
 
         let momdPaths = Bundle.wordPressData.paths(forResourcesOfType: "momd", inDirectory: nil)
         for path in momdPaths {
-            if let url = Bundle.wordPressData.url(forResource: name, withExtension: "mom", subdirectory: URL(fileURLWithPath: path).lastPathComponent) {
+            if let url = Bundle.wordPressData.url(
+                forResource: name,
+                withExtension: "mom",
+                subdirectory: URL(fileURLWithPath: path).lastPathComponent
+            ) {
                 return url
             }
         }
@@ -322,8 +341,9 @@ private extension DataMigratorTests {
     func getRecentObjectModels() -> (current: NSManagedObjectModel?, previous: NSManagedObjectModel?) {
         let models = getModelNames()
         guard models.count > 1,
-              let currentModel = getModelObject(for: models[models.count - 1]),
-              let previousModel = getModelObject(for: models[models.count - 2]) else {
+            let currentModel = getModelObject(for: models[models.count - 1]),
+            let previousModel = getModelObject(for: models[models.count - 2])
+        else {
             return (current: nil, previous: nil)
         }
         return (current: currentModel, previous: previousModel)

--- a/Tests/KeystoneTests/Tests/Jetpack/SharedDataIssueSolverTests.swift
+++ b/Tests/KeystoneTests/Tests/Jetpack/SharedDataIssueSolverTests.swift
@@ -120,7 +120,12 @@ private extension SharedDataIssueSolverTests {
     func createInMemoryContext() throws -> NSManagedObjectContext {
         let managedObjectModel = NSManagedObjectModel.mergedModel(from: [Bundle.main])!
         let persistentStoreCoordinator = NSPersistentStoreCoordinator(managedObjectModel: managedObjectModel)
-        try persistentStoreCoordinator.addPersistentStore(ofType: NSInMemoryStoreType, configurationName: nil, at: nil, options: nil)
+        try persistentStoreCoordinator.addPersistentStore(
+            ofType: NSInMemoryStoreType,
+            configurationName: nil,
+            at: nil,
+            options: nil
+        )
         let managedObjectContext = NSManagedObjectContext(concurrencyType: .mainQueueConcurrencyType)
         managedObjectContext.persistentStoreCoordinator = persistentStoreCoordinator
 
@@ -138,7 +143,7 @@ private final class CoreDataStackMock: CoreDataStack {
     }
 
     func newDerivedContext() -> NSManagedObjectContext {
-        return mainContext
+        mainContext
     }
 
     func saveContextAndWait(_ context: NSManagedObjectContext) {}
@@ -146,13 +151,17 @@ private final class CoreDataStackMock: CoreDataStack {
     func save(_ context: NSManagedObjectContext, completion completionBlock: (() -> Void)?, on queue: DispatchQueue) {}
 
     func performAndSave(_ aBlock: @escaping (NSManagedObjectContext) -> Void) {}
-    func performAndSave(_ aBlock: @escaping (NSManagedObjectContext) -> Void, completion: (() -> Void)?, on queue: DispatchQueue) {}
+    func performAndSave(
+        _ aBlock: @escaping (NSManagedObjectContext) -> Void,
+        completion: (() -> Void)?,
+        on queue: DispatchQueue
+    ) {}
 }
 
 // MARK: - Mock Local File Store
 
 private final class MockLocalFileStore: LocalFileStore {
-    var fileShouldExistClosure: (URL?) -> Bool = { _ in return false }
+    var fileShouldExistClosure: (URL?) -> Bool = { _ in false }
     var removeItemCallCount: Int = 0
     var copyItemCallCount: Int = 0
 
@@ -160,15 +169,15 @@ private final class MockLocalFileStore: LocalFileStore {
     var copyShouldThrowError: Bool = false
 
     func fileExists(at url: URL) -> Bool {
-        return fileShouldExistClosure(url)
+        fileShouldExistClosure(url)
     }
 
     func save(contents: Data, at url: URL) -> Bool {
-        return true
+        true
     }
 
     func containerURL(forAppGroup appGroup: String) -> URL? {
-        return URL(string: "/dev/null")
+        URL(string: "/dev/null")
     }
 
     func removeItem(at url: URL) throws {

--- a/WordPress/Classes/Jetpack/Utility/DataMigrator.swift
+++ b/WordPress/Classes/Jetpack/Utility/DataMigrator.swift
@@ -28,13 +28,18 @@ final class DataMigrator {
     private let crashLogger: CrashLogging?
     private let appGroupName: String
 
-    init(coreDataStack: CoreDataStack = ContextManager.shared,
-         backupLocation: URL? = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: BuildSettings.current.appGroupName)?.appendingPathComponent("WordPress.sqlite"),
-         keychainUtils: KeychainAccessible = KeychainUtils(),
-         localDefaults: UserPersistentRepository = UserDefaults.standard,
-         sharedDefaults: UserPersistentRepository? = UserDefaults(suiteName: BuildSettings.current.appGroupName),
-         crashLogger: CrashLogging? = .main,
-         appGroupName: String = BuildSettings.current.appGroupName) {
+    init(
+        coreDataStack: CoreDataStack = ContextManager.shared,
+        backupLocation: URL? = FileManager.default.containerURL(
+            forSecurityApplicationGroupIdentifier: BuildSettings.current.appGroupName
+        )?
+        .appendingPathComponent("WordPress.sqlite"),
+        keychainUtils: KeychainAccessible = KeychainUtils(),
+        localDefaults: UserPersistentRepository = UserDefaults.standard,
+        sharedDefaults: UserPersistentRepository? = UserDefaults(suiteName: BuildSettings.current.appGroupName),
+        crashLogger: CrashLogging? = .main,
+        appGroupName: String = BuildSettings.current.appGroupName
+    ) {
         self.coreDataStack = coreDataStack
         self.backupLocation = backupLocation
         self.keychainUtils = keychainUtils
@@ -101,7 +106,8 @@ extension DataMigrator: ContentDataMigrating {
 
     func deleteExportedData() {
         guard let backupLocation,
-              let sharedDefaults else {
+            let sharedDefaults
+        else {
             return
         }
 
@@ -168,7 +174,8 @@ private extension DataMigrator {
 
     func populateFromSharedDefaults() throws {
         guard let sharedDefaults,
-              let temporaryDictionary = sharedDefaults.dictionary(forKey: DefaultsWrapper.dictKey) else {
+            let temporaryDictionary = sharedDefaults.dictionary(forKey: DefaultsWrapper.dictKey)
+        else {
             throw DataMigrationError.sharedUserDefaultsNil
         }
         for (key, value) in temporaryDictionary {

--- a/WordPress/Classes/Services/CredentialsService.swift
+++ b/WordPress/Classes/Services/CredentialsService.swift
@@ -7,7 +7,7 @@ protocol CredentialsProvider {
 
 struct KeychainCredentialsProvider: CredentialsProvider {
     func getPassword(username: String, service: String) -> String? {
-        return try? SFHFKeychainUtils.getPasswordForUsername(username, andServiceName: service)
+        try? SFHFKeychainUtils.getPasswordForUsername(username, andServiceName: service)
     }
 }
 
@@ -19,6 +19,6 @@ class CredentialsService {
     }
 
     func getOAuthToken(site: JetpackSiteRef) -> String? {
-        return provider.getPassword(username: site.username, service: BuildSettings.current.authKeychainServiceName)
+        provider.getPassword(username: site.username, service: BuildSettings.current.authKeychainServiceName)
     }
 }

--- a/WordPress/Classes/Services/NotificationSupportService.swift
+++ b/WordPress/Classes/Services/NotificationSupportService.swift
@@ -15,8 +15,10 @@ final class NotificationSupportService {
         )
     }
 
-    init(appKeychainAccessGroup: String,
-         configuration: NotificationServiceExtensionConfiguration) {
+    init(
+        appKeychainAccessGroup: String,
+        configuration: NotificationServiceExtensionConfiguration
+    ) {
         self.appKeychainAccessGroup = appKeychainAccessGroup
         self.configuration = configuration
     }

--- a/WordPress/Classes/Stores/StatsWidgetsStore.swift
+++ b/WordPress/Classes/Stores/StatsWidgetsStore.swift
@@ -11,9 +11,11 @@ class StatsWidgetsStore {
     private let appGroupName: String
     private let appKeychainAccessGroup: String
 
-    init(coreDataStack: CoreDataStack = ContextManager.shared,
-         appGroupName: String = BuildSettings.current.appGroupName,
-         appKeychainAccessGroup: String = BuildSettings.current.appKeychainAccessGroup) {
+    init(
+        coreDataStack: CoreDataStack = ContextManager.shared,
+        appGroupName: String = BuildSettings.current.appGroupName,
+        appKeychainAccessGroup: String = BuildSettings.current.appKeychainAccessGroup
+    ) {
         self.coreDataStack = coreDataStack
         self.appGroupName = appGroupName
         self.appKeychainAccessGroup = appKeychainAccessGroup
@@ -46,8 +48,10 @@ class StatsWidgetsStore {
 
     /// Initialize the local cache for widgets, if it does not exist
     @objc func initializeStatsWidgetsIfNeeded() {
-        UserDefaults(suiteName: appGroupName)?.setValue(AccountHelper.isLoggedIn, forKey: WidgetStatsConfiguration.userDefaultsLoggedInKey)
-        UserDefaults(suiteName: appGroupName)?.setValue(AccountHelper.defaultSiteId, forKey: WidgetStatsConfiguration.userDefaultsSiteIdKey)
+        UserDefaults(suiteName: appGroupName)?
+            .setValue(AccountHelper.isLoggedIn, forKey: WidgetStatsConfiguration.userDefaultsLoggedInKey)
+        UserDefaults(suiteName: appGroupName)?
+            .setValue(AccountHelper.defaultSiteId, forKey: WidgetStatsConfiguration.userDefaultsSiteIdKey)
 
         storeCredentials()
 
@@ -104,36 +108,39 @@ class StatsWidgetsStore {
         if widgetType == HomeWidgetTodayData.self, let stats = stats as? TodayWidgetStats {
             widgetReload = WidgetCenter.shared.reloadTodayTimelines
 
-            homeWidgetCache[siteID.intValue] = HomeWidgetTodayData(
-                siteID: siteID.intValue,
-                siteName: blog.title ?? oldData.siteName,
-                url: blog.url ?? oldData.url,
-                timeZone: blog.timeZone ?? TimeZone.current,
-                date: Date(),
-                stats: stats
-            ) as? T
+            homeWidgetCache[siteID.intValue] =
+                HomeWidgetTodayData(
+                    siteID: siteID.intValue,
+                    siteName: blog.title ?? oldData.siteName,
+                    url: blog.url ?? oldData.url,
+                    timeZone: blog.timeZone ?? TimeZone.current,
+                    date: Date(),
+                    stats: stats
+                ) as? T
         } else if widgetType == HomeWidgetAllTimeData.self, let stats = stats as? AllTimeWidgetStats {
             widgetReload = WidgetCenter.shared.reloadAllTimeTimelines
 
-            homeWidgetCache[siteID.intValue] = HomeWidgetAllTimeData(
-                siteID: siteID.intValue,
-                siteName: blog.title ?? oldData.siteName,
-                url: blog.url ?? oldData.url,
-                timeZone: blog.timeZone ?? TimeZone.current,
-                date: Date(),
-                stats: stats
-            ) as? T
+            homeWidgetCache[siteID.intValue] =
+                HomeWidgetAllTimeData(
+                    siteID: siteID.intValue,
+                    siteName: blog.title ?? oldData.siteName,
+                    url: blog.url ?? oldData.url,
+                    timeZone: blog.timeZone ?? TimeZone.current,
+                    date: Date(),
+                    stats: stats
+                ) as? T
         } else if widgetType == HomeWidgetThisWeekData.self, let stats = stats as? ThisWeekWidgetStats {
             widgetReload = WidgetCenter.shared.reloadThisWeekTimelines
 
-            homeWidgetCache[siteID.intValue] = HomeWidgetThisWeekData(
-                siteID: siteID.intValue,
-                siteName: blog.title ?? oldData.siteName,
-                url: blog.url ?? oldData.url,
-                timeZone: blog.timeZone ?? TimeZone.current,
-                date: Date(),
-                stats: stats
-            ) as? T
+            homeWidgetCache[siteID.intValue] =
+                HomeWidgetThisWeekData(
+                    siteID: siteID.intValue,
+                    siteName: blog.title ?? oldData.siteName,
+                    url: blog.url ?? oldData.url,
+                    timeZone: blog.timeZone ?? TimeZone.current,
+                    date: Date(),
+                    stats: stats
+                ) as? T
         }
 
         setCachedItems(homeWidgetCache)
@@ -223,38 +230,42 @@ private extension StatsWidgetsStore {
 
                 let stats = (existingSite as? HomeWidgetTodayData)?.stats ?? TodayWidgetStats()
 
-                sitesList[blogID.intValue] = HomeWidgetTodayData(
-                    siteID: blogID.intValue,
-                    siteName: siteName,
-                    url: siteURL,
-                    timeZone: timeZone,
-                    date: date,
-                    stats: stats
-                ) as? T
+                sitesList[blogID.intValue] =
+                    HomeWidgetTodayData(
+                        siteID: blogID.intValue,
+                        siteName: siteName,
+                        url: siteURL,
+                        timeZone: timeZone,
+                        date: date,
+                        stats: stats
+                    ) as? T
             } else if type == HomeWidgetAllTimeData.self {
 
                 let stats = (existingSite as? HomeWidgetAllTimeData)?.stats ?? AllTimeWidgetStats()
 
-                sitesList[blogID.intValue] = HomeWidgetAllTimeData(
-                    siteID: blogID.intValue,
-                    siteName: siteName,
-                    url: siteURL,
-                    timeZone: timeZone,
-                    date: date,
-                    stats: stats
-                ) as? T
+                sitesList[blogID.intValue] =
+                    HomeWidgetAllTimeData(
+                        siteID: blogID.intValue,
+                        siteName: siteName,
+                        url: siteURL,
+                        timeZone: timeZone,
+                        date: date,
+                        stats: stats
+                    ) as? T
             } else if type == HomeWidgetThisWeekData.self {
 
-                let stats = (existingSite as? HomeWidgetThisWeekData)?.stats ?? ThisWeekWidgetStats(days: initializedWeekdays)
+                let stats =
+                    (existingSite as? HomeWidgetThisWeekData)?.stats ?? ThisWeekWidgetStats(days: initializedWeekdays)
 
-                sitesList[blogID.intValue] = HomeWidgetThisWeekData(
-                    siteID: blogID.intValue,
-                    siteName: siteName,
-                    url: siteURL,
-                    timeZone: timeZone,
-                    date: date,
-                    stats: stats
-                ) as? T
+                sitesList[blogID.intValue] =
+                    HomeWidgetThisWeekData(
+                        siteID: blogID.intValue,
+                        siteName: siteName,
+                        url: siteURL,
+                        timeZone: timeZone,
+                        date: date,
+                        stats: stats
+                    ) as? T
             }
         }
         return newData
@@ -264,46 +275,50 @@ private extension StatsWidgetsStore {
         let blogs = (try? BlogQuery().hostedByWPCom(true).blogs(in: coreDataStack.mainContext)) ?? []
         return blogs.reduce(into: [Int: T]()) { result, element in
             if let blogID = element.dotComID,
-               let url = element.url,
-               let blog = Blog.lookup(withID: blogID, in: ContextManager.shared.mainContext) {
+                let url = element.url,
+                let blog = Blog.lookup(withID: blogID, in: ContextManager.shared.mainContext)
+            {
                 // set the title to the site title, if it's not nil and not empty; otherwise use the site url
                 let title = (element.title ?? url).isEmpty ? url : element.title ?? url
                 let timeZone = blog.timeZone
                 if type == HomeWidgetTodayData.self {
-                    result[blogID.intValue] = HomeWidgetTodayData(
-                        siteID: blogID.intValue,
-                        siteName: title,
-                        url: url,
-                        timeZone: timeZone ?? TimeZone.current,
-                        date: Date(
-                            timeIntervalSinceReferenceDate: 0
-                        ),
-                        stats: TodayWidgetStats()
-                    ) as? T
+                    result[blogID.intValue] =
+                        HomeWidgetTodayData(
+                            siteID: blogID.intValue,
+                            siteName: title,
+                            url: url,
+                            timeZone: timeZone ?? TimeZone.current,
+                            date: Date(
+                                timeIntervalSinceReferenceDate: 0
+                            ),
+                            stats: TodayWidgetStats()
+                        ) as? T
                 } else if type == HomeWidgetAllTimeData.self {
-                    result[blogID.intValue] = HomeWidgetAllTimeData(
-                        siteID: blogID.intValue,
-                        siteName: title,
-                        url: url,
-                        timeZone: timeZone ?? TimeZone.current,
-                        date: Date(
-                            timeIntervalSinceReferenceDate: 0
-                        ),
-                        stats: AllTimeWidgetStats()
-                    ) as? T
+                    result[blogID.intValue] =
+                        HomeWidgetAllTimeData(
+                            siteID: blogID.intValue,
+                            siteName: title,
+                            url: url,
+                            timeZone: timeZone ?? TimeZone.current,
+                            date: Date(
+                                timeIntervalSinceReferenceDate: 0
+                            ),
+                            stats: AllTimeWidgetStats()
+                        ) as? T
                 } else if type == HomeWidgetThisWeekData.self {
-                    result[blogID.intValue] = HomeWidgetThisWeekData(
-                        siteID: blogID.intValue,
-                        siteName: title,
-                        url: url,
-                        timeZone: timeZone ?? TimeZone.current,
-                        date: Date(
-                            timeIntervalSinceReferenceDate: 0
-                        ),
-                        stats: ThisWeekWidgetStats(
-                            days: initializedWeekdays
-                        )
-                    ) as? T
+                    result[blogID.intValue] =
+                        HomeWidgetThisWeekData(
+                            siteID: blogID.intValue,
+                            siteName: title,
+                            url: url,
+                            timeZone: timeZone ?? TimeZone.current,
+                            date: Date(
+                                timeIntervalSinceReferenceDate: 0
+                            ),
+                            stats: ThisWeekWidgetStats(
+                                days: initializedWeekdays
+                            )
+                        ) as? T
                 }
             }
         }
@@ -318,10 +333,21 @@ extension StatsWidgetsStore {
             guard summary?.periodEndDate == StatsDataHelper.currentDateForSite().normalizedDate() else {
                 return
             }
-            let summaryData = Array(summary?.summaryData.reversed().prefix(ThisWeekWidgetStats.maxDaysToDisplay + 1) ?? [])
+            let summaryData = Array(
+                summary?.summaryData.reversed().prefix(ThisWeekWidgetStats.maxDaysToDisplay + 1) ?? []
+            )
 
-            let stats = ThisWeekWidgetStats(days: ThisWeekWidgetStats.daysFrom(summaryData: summaryData.map { ThisWeekWidgetStats.Input(periodStartDate: $0.periodStartDate, viewsCount: $0.viewsCount) }))
-            StoreContainer.shared.statsWidgets.storeHomeWidgetData(widgetType: HomeWidgetThisWeekData.self, stats: stats)
+            let stats = ThisWeekWidgetStats(
+                days: ThisWeekWidgetStats.daysFrom(
+                    summaryData: summaryData.map {
+                        ThisWeekWidgetStats.Input(periodStartDate: $0.periodStartDate, viewsCount: $0.viewsCount)
+                    }
+                )
+            )
+            StoreContainer.shared.statsWidgets.storeHomeWidgetData(
+                widgetType: HomeWidgetThisWeekData.self,
+                stats: stats
+            )
         case .week:
             WidgetCenter.shared.reloadThisWeekTimelines()
         default:
@@ -335,7 +361,12 @@ private extension StatsWidgetsStore {
     /// Observes WPAccountDefaultWordPressComAccountChanged notification and reloads widget data based on the state of account.
     /// The site data is not yet loaded after this notification and widget data cannot be cached for newly signed in account.
     func observeAccountChangesForWidgets() {
-        NotificationCenter.default.addObserver(self, selector: #selector(handleAccountChangedNotification), name: .wpAccountDefaultWordPressComAccountChanged, object: nil)
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleAccountChangedNotification),
+            name: .wpAccountDefaultWordPressComAccountChanged,
+            object: nil
+        )
     }
 
     @objc func handleAccountChangedNotification() {
@@ -358,13 +389,28 @@ private extension StatsWidgetsStore {
     /// Observes WPSigninDidFinishNotification and wordpressLoginFinishedJetpackLogin notifications and initializes the widget.
     /// The site data is loaded after this notification and widget data can be cached.
     func observeAccountSignInForWidgets() {
-        NotificationCenter.default.addObserver(self, selector: #selector(initializeStatsWidgetsIfNeeded), name: NSNotification.Name(rawValue: WordPressAuthenticationManager.WPSigninDidFinishNotification), object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(initializeStatsWidgetsIfNeeded), name: .wordpressLoginFinishedJetpackLogin, object: nil)
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(initializeStatsWidgetsIfNeeded),
+            name: NSNotification.Name(rawValue: WordPressAuthenticationManager.WPSigninDidFinishNotification),
+            object: nil
+        )
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(initializeStatsWidgetsIfNeeded),
+            name: .wordpressLoginFinishedJetpackLogin,
+            object: nil
+        )
     }
 
     /// Observes applicationLaunchCompleted notification and runs migration.
     func observeApplicationLaunched() {
-        NotificationCenter.default.addObserver(self, selector: #selector(handleApplicationLaunchCompleted), name: NSNotification.Name.applicationLaunchCompleted, object: nil)
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleApplicationLaunchCompleted),
+            name: NSNotification.Name.applicationLaunchCompleted,
+            object: nil
+        )
     }
 
     @objc private func handleApplicationLaunchCompleted() {
@@ -379,9 +425,10 @@ private extension StatsWidgetsStore {
     func handleJetpackWidgetsMigration() {
         // If user is logged in but defaultSiteIdKey is not set
         guard let account = try? WPAccount.lookupDefaultWordPressComAccount(in: coreDataStack.mainContext),
-              let siteId = account.defaultBlog?.dotComID,
-              let userDefaults = UserDefaults(suiteName: appGroupName),
-              userDefaults.value(forKey: WidgetStatsConfiguration.userDefaultsSiteIdKey) == nil else {
+            let siteId = account.defaultBlog?.dotComID,
+            let userDefaults = UserDefaults(suiteName: appGroupName),
+            userDefaults.value(forKey: WidgetStatsConfiguration.userDefaultsSiteIdKey) == nil
+        else {
             return
         }
 
@@ -391,8 +438,18 @@ private extension StatsWidgetsStore {
     }
 
     func observeSiteUpdatesForWidgets() {
-        NotificationCenter.default.addObserver(self, selector: #selector(refreshStatsWidgetsSiteList), name: .WPSiteCreated, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(refreshStatsWidgetsSiteList), name: .WPSiteDeleted, object: nil)
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(refreshStatsWidgetsSiteList),
+            name: .WPSiteCreated,
+            object: nil
+        )
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(refreshStatsWidgetsSiteList),
+            name: .WPSiteDeleted,
+            object: nil
+        )
     }
 }
 

--- a/WordPress/Classes/System/WordPressAppDelegate.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate.swift
@@ -402,7 +402,7 @@ extension WordPressAppDelegate {
     }
 
     public func application(_ application: UIApplication, didFailToRegisterForRemoteNotificationsWithError error: Error)
-    {
+    { // swiftlint:disable:this opening_brace
         PushNotificationsManager.shared.registrationDidFail(error as NSError)
     }
 

--- a/WordPress/Classes/System/WordPressAppDelegate.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate.swift
@@ -26,9 +26,12 @@ public class WordPressAppDelegate: UIResponder, UIApplicationDelegate {
 
     public var window: UIWindow?
 
-    let backgroundTasksCoordinator = BackgroundTasksCoordinator(tasks: [
-        WeeklyRoundupBackgroundTask()
-    ], eventHandler: WordPressBackgroundTaskEventHandler())
+    let backgroundTasksCoordinator = BackgroundTasksCoordinator(
+        tasks: [
+            WeeklyRoundupBackgroundTask()
+        ],
+        eventHandler: WordPressBackgroundTaskEventHandler()
+    )
 
     @objc
     lazy var windowManager: WindowManager = {
@@ -55,7 +58,7 @@ public class WordPressAppDelegate: UIResponder, UIApplicationDelegate {
     private let remoteConfigStore = RemoteConfigStore()
 
     private var mainContext: NSManagedObjectContext {
-        return ContextManager.shared.mainContext
+        ContextManager.shared.mainContext
     }
 
     private let loggingStack = WPLoggingStack.shared
@@ -77,14 +80,17 @@ public class WordPressAppDelegate: UIResponder, UIApplicationDelegate {
 
     // MARK: - Application lifecycle
 
-    public func application(_ application: UIApplication, willFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
+    public func application(
+        _ application: UIApplication,
+        willFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
+    ) -> Bool {
         // We need to set up the swift-log logging system right after app launch, so that logs can be written
         // into the log handlers configured below.
         LoggingSystem.bootstrap { label in
             let ddLogHandlerFactory: (String) -> LogHandler = DDLogHandler.handlerFactory()
             return MultiplexLogHandler([
                 ddLogHandlerFactory(label),
-                ExtensiveLogger(label: label),
+                ExtensiveLogger(label: label)
             ])
         }
 
@@ -131,7 +137,10 @@ public class WordPressAppDelegate: UIResponder, UIApplicationDelegate {
         return true
     }
 
-    public func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
+    public func application(
+        _ application: UIApplication,
+        didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
+    ) -> Bool {
         Loggers.app.info("didFinishLaunchingWithOptions state: \(application.applicationState)")
 
         ABTest.start()
@@ -147,9 +156,10 @@ public class WordPressAppDelegate: UIResponder, UIApplicationDelegate {
 
         // This was necessary to properly load fonts for the Stories editor. I believe external libraries may require this call to access fonts.
         let fonts = Bundle.main.urls(forResourcesWithExtension: "ttf", subdirectory: nil)
-        fonts?.forEach({ url in
-            CTFontManagerRegisterFontsForURL(url as CFURL, .process, nil)
-        })
+        fonts?
+            .forEach({ url in
+                CTFontManagerRegisterFontsForURL(url as CFURL, .process, nil)
+            })
 
         startObservingAppleIDCredentialRevoked()
 
@@ -159,7 +169,8 @@ public class WordPressAppDelegate: UIResponder, UIApplicationDelegate {
         }
 
         if let account = try? WPAccount.lookupDefaultWordPressComAccount(in: ContextManager.shared.mainContext) {
-            BlogSyncFacade().syncBlogs(for: account, success: { /* Do nothing */ }, failure: { _ in /* Do nothing */ })
+            BlogSyncFacade()
+                .syncBlogs(for: account, success: { /* Do nothing */  }, failure: { _ in /* Do nothing */ })
         }
 
         return true
@@ -224,12 +235,20 @@ public class WordPressAppDelegate: UIResponder, UIApplicationDelegate {
         GutenbergSettings().performGutenbergPhase2MigrationIfNeeded()
     }
 
-    public func application(_ application: UIApplication, performActionFor shortcutItem: UIApplicationShortcutItem, completionHandler: @escaping (Bool) -> Void) {
+    public func application(
+        _ application: UIApplication,
+        performActionFor shortcutItem: UIApplicationShortcutItem,
+        completionHandler: @escaping (Bool) -> Void
+    ) {
         let handler = WP3DTouchShortcutHandler()
         completionHandler(handler.handleShortcutItem(shortcutItem))
     }
 
-    public func application(_ application: UIApplication, handleEventsForBackgroundURLSession identifier: String, completionHandler: @escaping () -> Void) {
+    public func application(
+        _ application: UIApplication,
+        handleEventsForBackgroundURLSession identifier: String,
+        completionHandler: @escaping () -> Void
+    ) {
         // 21-Oct-2017: We are only handling background URLSessions initiated by the share extension so there
         // is no need to inspect the identifier beyond the simple check here.
         let appGroupName = BuildSettings.current.appGroupName
@@ -240,7 +259,11 @@ public class WordPressAppDelegate: UIResponder, UIApplicationDelegate {
         }
     }
 
-    public func application(_ application: UIApplication, continue userActivity: NSUserActivity, restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void) -> Bool {
+    public func application(
+        _ application: UIApplication,
+        continue userActivity: NSUserActivity,
+        restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void
+    ) -> Bool {
         if userActivity.activityType == NSUserActivityTypeBrowsingWeb {
             handleWebActivity(userActivity)
         } else {
@@ -253,9 +276,13 @@ public class WordPressAppDelegate: UIResponder, UIApplicationDelegate {
 
     // Note that this method only appears to be called for iPhone devices, not iPad.
     // This allows individual view controllers to cancel rotation if they need to.
-    public func application(_ application: UIApplication, supportedInterfaceOrientationsFor window: UIWindow?) -> UIInterfaceOrientationMask {
+    public func application(
+        _ application: UIApplication,
+        supportedInterfaceOrientationsFor window: UIWindow?
+    ) -> UIInterfaceOrientationMask {
         if let vc = window?.topmostPresentedViewController,
-           vc is OrientationLimited {
+            vc is OrientationLimited
+        {
             return vc.supportedInterfaceOrientations
         }
 
@@ -281,13 +308,13 @@ public class WordPressAppDelegate: UIResponder, UIApplicationDelegate {
             toggleExtraDebuggingIfNeeded()
         }
 
-#if DEBUG
+        #if DEBUG
         KeychainTools.processKeychainDebugArguments()
 
         // Zendesk Logging
         CoreLogger.enabled = true
         CoreLogger.logLevel = .debug
-#endif
+        #endif
 
         ZendeskUtils.setup()
 
@@ -301,11 +328,12 @@ public class WordPressAppDelegate: UIResponder, UIApplicationDelegate {
         }
 
         // Deferred tasks to speed up app launch
-        DispatchQueue.global(qos: .background).async { [weak self] in
-            self?.mergeDuplicateAccountsIfNeeded()
-            MediaCoordinator.shared.refreshMediaStatus()
-            MediaFileManager.clearUnusedMediaUploadFiles(onCompletion: nil, onError: nil)
-        }
+        DispatchQueue.global(qos: .background)
+            .async { [weak self] in
+                self?.mergeDuplicateAccountsIfNeeded()
+                MediaCoordinator.shared.refreshMediaStatus()
+                MediaFileManager.clearUnusedMediaUploadFiles(onCompletion: nil, onError: nil)
+            }
 
         DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
             PostCoordinator.shared.initializeSync()
@@ -352,29 +380,37 @@ public class WordPressAppDelegate: UIResponder, UIApplicationDelegate {
     // MARK: - Helpers
 
     var runningInBackground: Bool {
-        return UIApplication.shared.applicationState == .background
+        UIApplication.shared.applicationState == .background
     }
 }
 
 /// Declares Notification Names
 extension Foundation.Notification.Name {
     static var applicationLaunchCompleted: Foundation.NSNotification.Name {
-        return Foundation.Notification.Name("org.wordpress.startup.completed")
+        Foundation.Notification.Name("org.wordpress.startup.completed")
     }
 }
 
 // MARK: - Push Notification Delegate
 
 extension WordPressAppDelegate {
-    public func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
+    public func application(
+        _ application: UIApplication,
+        didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data
+    ) {
         PushNotificationsManager.shared.registerDeviceToken(deviceToken)
     }
 
-    public func application(_ application: UIApplication, didFailToRegisterForRemoteNotificationsWithError error: Error) {
+    public func application(_ application: UIApplication, didFailToRegisterForRemoteNotificationsWithError error: Error)
+    {
         PushNotificationsManager.shared.registrationDidFail(error as NSError)
     }
 
-    public func application(_ application: UIApplication, didReceiveRemoteNotification userInfo: [AnyHashable: Any], fetchCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Void) {
+    public func application(
+        _ application: UIApplication,
+        didReceiveRemoteNotification userInfo: [AnyHashable: Any],
+        fetchCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Void
+    ) {
         Loggers.app.info("\(self) \(#function)")
         PushNotificationsManager.shared.application(
             application,
@@ -405,7 +441,12 @@ extension WordPressAppDelegate {
 
     func configureSelfHostedChallengeHandler() {
         WordPressOrgXMLRPCApi.onChallenge = { challenge, completionHandler in
-            guard let alertController = HTTPAuthenticationAlertController.controller(for: challenge, handler: completionHandler) else {
+            guard
+                let alertController = HTTPAuthenticationAlertController.controller(
+                    for: challenge,
+                    handler: completionHandler
+                )
+            else {
                 completionHandler(.performDefaultHandling, nil)
                 return
             }
@@ -433,25 +474,28 @@ extension WordPressAppDelegate {
     }
 
     func present(selfHostedSite blog: Blog, from navigationController: UINavigationController) {
-        self.authManager?.presentLoginEpilogue(in: navigationController, forSelfHostedSite: blog, source: nil) {
-            // Do nothing.
-        }
+        self.authManager?
+            .presentLoginEpilogue(in: navigationController, forSelfHostedSite: blog, source: nil) {
+                // Do nothing.
+            }
     }
 
     func handleWebActivity(_ activity: NSUserActivity) {
         // try to handle unauthenticated routes first.
         if activity.activityType == NSUserActivityTypeBrowsingWeb,
-           let url = activity.webpageURL,
-           UniversalLinkRouter.unauthenticated.canHandle(url: url) {
+            let url = activity.webpageURL,
+            UniversalLinkRouter.unauthenticated.canHandle(url: url)
+        {
             UniversalLinkRouter.unauthenticated.handle(url: url)
             return
         }
 
         guard AccountHelper.isLoggedIn,
             activity.activityType == NSUserActivityTypeBrowsingWeb,
-            let url = activity.webpageURL else {
-                FailureNavigationAction().failAndBounce(activity.webpageURL)
-                return
+            let url = activity.webpageURL
+        else {
+            FailureNavigationAction().failAndBounce(activity.webpageURL)
+            return
         }
 
         if QRLoginCoordinator.didHandle(url: url) {
@@ -468,7 +512,8 @@ extension WordPressAppDelegate {
         ///
         /// Read more: https://github.com/wordpress-mobile/WordPress-iOS/issues/19755
         if MigrationAppDetection.isCounterpartAppInstalled,
-           WPAdminConvertibleRouter.shared.canHandle(url: url) {
+            WPAdminConvertibleRouter.shared.canHandle(url: url)
+        {
             WPAdminConvertibleRouter.shared.handle(url: url)
             return
         }
@@ -477,7 +522,9 @@ extension WordPressAppDelegate {
     }
 
     @objc func configureWordPressComApi() {
-        if let baseUrl = UserPersistentStoreFactory.instance().string(forKey: "wpcom-api-base-url"), let url = URL(string: baseUrl) {
+        if let baseUrl = UserPersistentStoreFactory.instance().string(forKey: "wpcom-api-base-url"),
+            let url = URL(string: baseUrl)
+        {
             AppEnvironment.replaceEnvironment(wordPressComApiBase: url)
         }
     }
@@ -645,20 +692,26 @@ extension WordPressAppDelegate {
     func addNotificationObservers() {
         let nc = NotificationCenter.default
 
-        nc.addObserver(self,
-                       selector: #selector(handleDefaultAccountChangedNotification(_:)),
-                       name: NSNotification.Name.wpAccountDefaultWordPressComAccountChanged,
-                       object: nil)
+        nc.addObserver(
+            self,
+            selector: #selector(handleDefaultAccountChangedNotification(_:)),
+            name: NSNotification.Name.wpAccountDefaultWordPressComAccountChanged,
+            object: nil
+        )
 
-        nc.addObserver(self,
-                       selector: #selector(handleLowMemoryWarningNotification(_:)),
-                       name: UIApplication.didReceiveMemoryWarningNotification,
-                       object: nil)
+        nc.addObserver(
+            self,
+            selector: #selector(handleLowMemoryWarningNotification(_:)),
+            name: UIApplication.didReceiveMemoryWarningNotification,
+            object: nil
+        )
 
-        nc.addObserver(self,
-                       selector: #selector(saveRecentSitesForExtensions),
-                       name: .WPRecentSitesChanged,
-                       object: nil)
+        nc.addObserver(
+            self,
+            selector: #selector(saveRecentSitesForExtensions),
+            name: .WPRecentSitesChanged,
+            object: nil
+        )
     }
 
     @objc fileprivate func handleDefaultAccountChangedNotification(_ notification: NSNotification) {
@@ -726,7 +779,9 @@ extension WordPressAppDelegate {
 
     func configureNotificationExtension() {
 
-        if let account = try? WPAccount.lookupDefaultWordPressComAccount(in: mainContext), let authToken = account.authToken, let userID = account.userID {
+        if let account = try? WPAccount.lookupDefaultWordPressComAccount(in: mainContext),
+            let authToken = account.authToken, let userID = account.userID
+        {
             let service = NotificationSupportService()
             service.storeToken(authToken)
             service.storeUsername(account.username)
@@ -773,8 +828,10 @@ extension WordPressAppDelegate {
         // Get the Apple User ID from the keychain
         let appleUserID: String
         do {
-            appleUserID = try SFHFKeychainUtils.getPasswordForUsername(WPAppleIDKeychainUsernameKey,
-                                                                       andServiceName: WPAppleIDKeychainServiceName)
+            appleUserID = try SFHFKeychainUtils.getPasswordForUsername(
+                WPAppleIDKeychainUsernameKey,
+                andServiceName: WPAppleIDKeychainServiceName
+            )
         } catch {
             Loggers.app.info("checkAppleIDCredentialState: No Apple ID found.")
             return
@@ -793,7 +850,9 @@ extension WordPressAppDelegate {
                 // An error exists only for the notFound state.
                 // notFound is a valid state when logging in with an Apple account for the first time.
                 if let error {
-                    Loggers.app.debug("checkAppleIDCredentialState: Apple ID state not found: \(error.localizedDescription)")
+                    Loggers.app.debug(
+                        "checkAppleIDCredentialState: Apple ID state not found: \(error.localizedDescription)"
+                    )
                 }
                 break
             }
@@ -826,8 +885,10 @@ extension WordPressAppDelegate {
 
     func removeAppleIDFromKeychain() {
         do {
-            try SFHFKeychainUtils.deleteItem(forUsername: WPAppleIDKeychainUsernameKey,
-                                             andServiceName: WPAppleIDKeychainServiceName)
+            try SFHFKeychainUtils.deleteItem(
+                forUsername: WPAppleIDKeychainUsernameKey,
+                andServiceName: WPAppleIDKeychainServiceName
+            )
         } catch let error as NSError {
             if error.code != errSecItemNotFound {
                 Loggers.app.error("Error while removing Apple User ID from keychain: \(error.localizedDescription)")
@@ -846,14 +907,21 @@ extension WordPressAppDelegate {
         }
 
         let service = WordPressComSyncService()
-        service.syncWPCom(authToken: "valid_token", isJetpackLogin: false, onSuccess: { _ in
-            if let blog = try? BlogQuery().hostname(containing: wpComSiteAddress).blog(in: ContextManager.shared.mainContext) {
-                self.windowManager.showUI(for: blog)
-            } else {
-                fatalError("Can't find blog: \(wpComSiteAddress)")
+        service.syncWPCom(
+            authToken: "valid_token",
+            isJetpackLogin: false,
+            onSuccess: { _ in
+                if let blog = try? BlogQuery().hostname(containing: wpComSiteAddress)
+                    .blog(in: ContextManager.shared.mainContext)
+                {
+                    self.windowManager.showUI(for: blog)
+                } else {
+                    fatalError("Can't find blog: \(wpComSiteAddress)")
+                }
+            },
+            onFailure: {
+                fatalError("Can't sync blogs: \($0)")
             }
-        }, onFailure: {
-            fatalError("Can't sync blogs: \($0)")
-        })
+        )
     }
 }

--- a/WordPress/Classes/Utility/Editor/EditorConfiguration+Blog.swift
+++ b/WordPress/Classes/Utility/Editor/EditorConfiguration+Blog.swift
@@ -14,7 +14,8 @@ extension EditorConfiguration {
         if applicationPassword != nil {
             siteApiRootString = selfHostedApiUrl
         } else {
-            siteApiRootString = shouldUseWPComRestApi ? blog.wordPressComRestApi?.baseURL.absoluteString : selfHostedApiUrl
+            siteApiRootString =
+                shouldUseWPComRestApi ? blog.wordPressComRestApi?.baseURL.absoluteString : selfHostedApiUrl
         }
 
         let siteId = blog.dotComID?.stringValue
@@ -48,15 +49,15 @@ extension EditorConfiguration {
             siteURL: siteURL,
             siteApiRoot: siteApiRoot
         )
-            .setSiteApiNamespace(siteApiNamespace)
-            .setNamespaceExcludedPaths(["/wpcom/v2/following/recommendations", "/wpcom/v2/following/mine"])
-            .setAuthHeader(authHeader)
-            .setShouldUseThemeStyles(GutenbergSettings().isThemeStylesEnabled(for: blog))
-            // Limited to Jetpack-connected sites until editor assets endpoint is available in WordPress core
-            .setShouldUsePlugins(Self.shouldEnablePlugins(for: blog, appPassword: applicationPassword))
-            .setLocale(WordPressComLanguageDatabase.shared.deviceLanguage.slug)
-            .setEnableNetworkLogging(ExtensiveLogging.enabled)
-            .setNetworkFallbackMode(.automatic)
+        .setSiteApiNamespace(siteApiNamespace)
+        .setNamespaceExcludedPaths(["/wpcom/v2/following/recommendations", "/wpcom/v2/following/mine"])
+        .setAuthHeader(authHeader)
+        .setShouldUseThemeStyles(GutenbergSettings().isThemeStylesEnabled(for: blog))
+        // Limited to Jetpack-connected sites until editor assets endpoint is available in WordPress core
+        .setShouldUsePlugins(Self.shouldEnablePlugins(for: blog, appPassword: applicationPassword))
+        .setLocale(WordPressComLanguageDatabase.shared.deviceLanguage.slug)
+        .setEnableNetworkLogging(ExtensiveLogging.enabled)
+        .setNetworkFallbackMode(.automatic)
 
         // Build editor assets endpoint
         var editorAssetsEndpoint = siteApiRoot
@@ -77,8 +78,7 @@ extension EditorConfiguration {
         // Requires a Jetpack until editor assets endpoint is available in WordPress core.
         // Requires a WP.com Simple site or an application password to authenticate all REST
         // API requests, including those originating from non-core blocks.
-        return RemoteFeatureFlag.newGutenbergPlugins.enabled() &&
-            blog.isAccessibleThroughWPCom &&
-            (blog.isHostedAtWPcom || appPassword != nil)
+        RemoteFeatureFlag.newGutenbergPlugins.enabled() && blog.isAccessibleThroughWPCom
+            && (blog.isHostedAtWPcom || appPassword != nil)
     }
 }

--- a/WordPress/WordPressNotificationServiceExtension/Sources/NotificationService.swift
+++ b/WordPress/WordPressNotificationServiceExtension/Sources/NotificationService.swift
@@ -41,7 +41,10 @@ class NotificationService: UNNotificationServiceExtension {
 
     // MARK: UNNotificationServiceExtension
 
-    override func didReceive(_ request: UNNotificationRequest, withContentHandler contentHandler: @escaping (UNNotificationContent) -> Void) {
+    override func didReceive(
+        _ request: UNNotificationRequest,
+        withContentHandler contentHandler: @escaping (UNNotificationContent) -> Void
+    ) {
         self.contentHandler = contentHandler
         self.bestAttemptContent = request.content.mutableCopy() as? UNMutableNotificationContent
 
@@ -58,7 +61,8 @@ class NotificationService: UNNotificationServiceExtension {
             let apsAlert = notificationContent.apsAlert,
             let notificationType = notificationContent.type,
             let notificationKind = NotificationKind(rawValue: notificationType),
-            token != nil else {
+            token != nil
+        else {
 
             let hasToken = token != nil
             tracks.trackNotificationMalformed(hasToken: hasToken, notificationBody: request.content.body)
@@ -90,7 +94,8 @@ class NotificationService: UNNotificationServiceExtension {
         // comment likes will always have a bolded title.
         if notificationContent.title.isEmpty,
             !notificationContent.body.isEmpty,
-            !NotificationKind.omitsRichNotificationBody(notificationKind) {
+            !NotificationKind.omitsRichNotificationBody(notificationKind)
+        {
             notificationContent.title = notificationContent.body
             notificationContent.body = ""
         }
@@ -112,7 +117,8 @@ class NotificationService: UNNotificationServiceExtension {
                 gravatarURLString: nil,
                 notificationIdentifier: nil,
                 notificationReadStatus: true,
-                noticon: nil)
+                noticon: nil
+            )
 
             notificationContent.userInfo[CodingUserInfoKey.richNotificationViewModel.rawValue] = viewModel.data
             contentHandler(notificationContent)
@@ -132,14 +138,18 @@ class NotificationService: UNNotificationServiceExtension {
 
         service.loadNotes(noteIds: [noteID]) { [self, tracks] error, notifications in
             if let error {
-                tracks.trackNotificationRetrievalFailed(notificationIdentifier: noteID, errorDescription: error.localizedDescription)
+                tracks.trackNotificationRetrievalFailed(
+                    notificationIdentifier: noteID,
+                    errorDescription: error.localizedDescription
+                )
                 contentHandler(notificationContent)
                 return
             }
 
             guard let remoteNotifications = notifications,
                 remoteNotifications.count == 1,
-                let notification = remoteNotifications.first else {
+                let notification = remoteNotifications.first
+            else {
                 contentHandler(notificationContent)
                 return
             }
@@ -152,21 +162,25 @@ class NotificationService: UNNotificationServiceExtension {
                 gravatarURLString: notification.icon,
                 notificationIdentifier: notification.notificationId,
                 notificationReadStatus: notification.read,
-                noticon: notification.noticon)
+                noticon: notification.noticon
+            )
 
             // Only populate title / body for notification kinds with rich body content
             if !NotificationKind.omitsRichNotificationBody(notificationKind) {
                 notificationContent.title = contentFormatter.attributedSubject?.string ?? apsAlert
 
                 // Improve the notification body by trimming whitespace and reducing any multiple blank lines
-                notificationContent.body = contentFormatter.attributedBody?.string.condenseWhitespace().truncate(with: 256) ?? ""
+                notificationContent.body =
+                    contentFormatter.attributedBody?.string.condenseWhitespace().truncate(with: 256) ?? ""
             }
 
             notificationContent.userInfo[CodingUserInfoKey.richNotificationViewModel.rawValue] = viewModel.data
 
             tracks.trackNotificationAssembled()
 
-            let iconURL = NotificationKind.isNotificationIconSupported(notificationKind) ? notification.icon.flatMap(URL.init) : nil
+            let iconURL =
+                NotificationKind.isNotificationIconSupported(notificationKind)
+                ? notification.icon.flatMap(URL.init) : nil
 
             // If the notification contains any image media, download it and
             // attach it to the notification.
@@ -184,7 +198,10 @@ class NotificationService: UNNotificationServiceExtension {
 
                 guard
                     let self, let data, let fileExtension,
-                    let fileURL = self.saveMediaAttachment(data: data, fileName: String(format: "%@.%@", identifier, fileExtension))
+                    let fileURL = self.saveMediaAttachment(
+                        data: data,
+                        fileName: String(format: "%@.%@", identifier, fileExtension)
+                    )
                 else {
                     return
                 }
@@ -192,7 +209,8 @@ class NotificationService: UNNotificationServiceExtension {
                 let imageAttachment = try? UNNotificationAttachment(
                     identifier: identifier,
                     url: fileURL,
-                    options: nil)
+                    options: nil
+                )
 
                 if let imageAttachment {
                     notificationContent.attachments = [imageAttachment]
@@ -207,7 +225,8 @@ class NotificationService: UNNotificationServiceExtension {
         notificationService?.wordPressComRestApi.invalidateAndCancelTasks()
 
         if let contentHandler,
-            let bestAttemptContent {
+            let bestAttemptContent
+        {
 
             contentHandler(bestAttemptContent)
         }
@@ -265,12 +284,15 @@ private extension NotificationService {
         let directoryPath = URL.Helpers.temporaryDirectory(named: ProcessInfo.processInfo.globallyUniqueString)
 
         do {
-            try FileManager.default.createDirectory(at: directoryPath, withIntermediateDirectories: true, attributes: nil)
+            try FileManager.default.createDirectory(
+                at: directoryPath,
+                withIntermediateDirectories: true,
+                attributes: nil
+            )
             let fileURL = directoryPath.appendingPathComponent(fileName)
             try data.write(to: fileURL)
             return fileURL
-        }
-        catch {
+        } catch {
             return nil
         }
     }
@@ -298,11 +320,13 @@ private extension NotificationService {
     /// - Returns: the token if found; `nil` otherwise
     ///
     func readExtensionToken() -> String? {
-        guard let oauthToken = try? SFHFKeychainUtils.getPasswordForUsername(
-            configuration.keychainTokenKey,
-            andServiceName: configuration.keychainServiceName,
-            accessGroup: appKeychainAccessGroup
-        ) else {
+        guard
+            let oauthToken = try? SFHFKeychainUtils.getPasswordForUsername(
+                configuration.keychainTokenKey,
+                andServiceName: configuration.keychainServiceName,
+                accessGroup: appKeychainAccessGroup
+            )
+        else {
             debugPrint("Unable to retrieve Notification Service Extension OAuth token")
             return nil
         }
@@ -315,11 +339,13 @@ private extension NotificationService {
     /// - Returns: the username if found; `nil` otherwise
     ///
     func readExtensionUsername() -> String? {
-        guard let username = try? SFHFKeychainUtils.getPasswordForUsername(
-            configuration.keychainUsernameKey,
-            andServiceName: configuration.keychainServiceName,
-            accessGroup: appKeychainAccessGroup
-        ) else {
+        guard
+            let username = try? SFHFKeychainUtils.getPasswordForUsername(
+                configuration.keychainUsernameKey,
+                andServiceName: configuration.keychainServiceName,
+                accessGroup: appKeychainAccessGroup
+            )
+        else {
             debugPrint("Unable to retrieve Notification Service Extension username")
             return nil
         }
@@ -332,11 +358,13 @@ private extension NotificationService {
     /// - Returns: the userID if found; `nil` otherwise
     ///
     func readExtensionUserID() -> String? {
-        guard let userID = try? SFHFKeychainUtils.getPasswordForUsername(
-            configuration.keychainUserIDKey,
-            andServiceName: configuration.keychainServiceName,
-            accessGroup: appKeychainAccessGroup
-        ) else {
+        guard
+            let userID = try? SFHFKeychainUtils.getPasswordForUsername(
+                configuration.keychainUserIDKey,
+                andServiceName: configuration.keychainServiceName,
+                accessGroup: appKeychainAccessGroup
+            )
+        else {
             debugPrint("Unable to retrieve Notification Service Extension userID")
             return nil
         }
@@ -353,5 +381,8 @@ private extension NotificationService {
         return content
     }
 
-    static let viewMilestoneTitle = AppLocalizedString("You hit a milestone 🚀", comment: "Title for a view milestone push notification")
+    static let viewMilestoneTitle = AppLocalizedString(
+        "You hit a milestone 🚀",
+        comment: "Title for a view milestone push notification"
+    )
 }


### PR DESCRIPTION
> [!Note]
> First of a three-PR stack, followed by https://github.com/wordpress-mobile/WordPress-iOS/pull/25649 and https://github.com/wordpress-mobile/WordPress-iOS/pull/25650. Nothing in this PR is called by app code yet.

## Description

The WordPress and Jetpack apps share a single keychain access group, and because it is the only group in the entitlements, every keychain item both apps write is cross-app by accident. This stack moves each app onto its own private access group, keeping the shared group only for the WordPress-to-Jetpack migration contract.

This PR adds the types, with no call sites yet:

1. `AppKeychain` scopes keychain access to the app's private group. Reads fall back to the legacy shared group during the transition, writes go to the private group only, and deletes clear both groups so a logout cannot be undone by the fallback read.
2. `SharedKeychain` is the explicit window into the legacy shared group. Its doc comment restricts it to the three migration call sites, which the next PRs wire up.
3. `KeychainGroupMigrator` performs a one-time, insert-only copy of the shared group into the private group, then sweeps the shared group's leftovers once both apps have recorded a copy at the current migration version.
