### PR TITLE
Replace NUXButton with UIButton

### DIFF
--- a/WordPress/Classes/Extensions/UIButton+Extensions.swift
+++ b/WordPress/Classes/Extensions/UIButton+Extensions.swift
@@ -1,5 +1,77 @@
 import UIKit
 import WordPressShared
+import WordPressUI
+
+extension UIButton.Configuration {
+    /// Replicates the legacy WordPressAuthenticator `NUXButton` primary style
+    /// so screens converted off the library keep rendering identically:
+    /// corner radius 8, content insets (12, 20, 12, 20), medium-weight title3
+    /// font. All state colors, including the normal state, are owned by the
+    /// update handler installed by `configureAsPrimaryNUXButton()`; apply via
+    /// that method, never directly.
+    fileprivate static func primaryNUX() -> UIButton.Configuration {
+        var configuration = UIButton.Configuration.filled()
+        configuration.cornerStyle = .fixed
+        configuration.background.cornerRadius = 8
+        configuration.contentInsets = NSDirectionalEdgeInsets(top: 12, leading: 20, bottom: 12, trailing: 20)
+        configuration.titleTextAttributesTransformer = UIConfigurationTextAttributesTransformer { attributes in
+            var attributes = attributes
+            attributes.font = WPStyleGuide.mediumWeightFont(forStyle: .title3)
+            return attributes
+        }
+        return configuration
+    }
+}
+
+extension UIButton {
+    static func makePrimaryNUXButton() -> UIButton {
+        let button = UIButton()
+        button.configureAsPrimaryNUXButton()
+        return button
+    }
+
+    /// Applies the `primaryNUX` configuration plus the state-dependent colors
+    /// the legacy `NUXButton` rendered (highlighted and disabled backgrounds),
+    /// which a static configuration cannot express.
+    func configureAsPrimaryNUXButton() {
+        configuration = .primaryNUX()
+        configurationUpdateHandler = { button in
+            guard var configuration = button.configuration else {
+                return
+            }
+            if button.state.contains(.highlighted) {
+                configuration.baseBackgroundColor = UIAppColor.primary(.shade80)
+                configuration.baseForegroundColor = .white
+            } else if button.state.contains(.disabled) {
+                configuration.baseBackgroundColor = .secondarySystemFill
+                configuration.baseForegroundColor = UIAppColor.neutral(.shade20)
+            } else {
+                configuration.baseBackgroundColor = UIAppColor.primary
+                configuration.baseForegroundColor = .white
+            }
+            button.configuration = configuration
+        }
+    }
+
+    /// Mirrors the legacy `NUXButton.showActivityIndicator(_:)`: the spinner is
+    /// shown centered in place of the title. Showing the indicator clears the
+    /// configuration title (which may shrink the button to its intrinsic spinner
+    /// size) but keeps the title as the accessibility label; callers must set
+    /// the title again after hiding the indicator.
+    func setActivityIndicatorVisible(_ visible: Bool) {
+        guard var configuration else {
+            return
+        }
+        configuration.showsActivityIndicator = visible
+        if visible {
+            accessibilityLabel = configuration.title
+            configuration.title = nil
+        } else {
+            accessibilityLabel = nil
+        }
+        self.configuration = configuration
+    }
+}
 
 extension UIButton {
     /// Creates a bar button item that looks like the native title menu

--- a/WordPress/Classes/Extensions/UIButton+Extensions.swift
+++ b/WordPress/Classes/Extensions/UIButton+Extensions.swift
@@ -14,21 +14,28 @@ extension UIButton {
     /// Creates a bar button item that looks like the native title menu
     /// (see `navigationItem.titleMenuProvider`, iOS 16+).
     static func makeMenuButton(title: String) -> UIButton {
-        UIButton(configuration: {
-            var configuration = UIButton.Configuration.plain()
-            configuration.title = title
-            configuration.titleTextAttributesTransformer = UIConfigurationTextAttributesTransformer {
-                var attributes = $0
-                attributes.font = AppStyleGuide.current.navigationBarStandardFont
-                return attributes
-            }
-            configuration.image = UIImage(systemName: "chevron.down.circle.fill")?.withBaselineOffset(fromBottom: 4)
-            configuration.preferredSymbolConfigurationForImage = UIImage.SymbolConfiguration(paletteColors: [.secondaryLabel, .secondarySystemFill])
-                .applying(UIImage.SymbolConfiguration(font: WPStyleGuide.fontForTextStyle(.subheadline, fontWeight: .semibold)))
-            configuration.imagePlacement = .trailing
-            configuration.imagePadding = 4
-            configuration.baseForegroundColor = .label
-            return configuration
-        }())
+        UIButton(
+            configuration: {
+                var configuration = UIButton.Configuration.plain()
+                configuration.title = title
+                configuration.titleTextAttributesTransformer = UIConfigurationTextAttributesTransformer {
+                    var attributes = $0
+                    attributes.font = AppStyleGuide.current.navigationBarStandardFont
+                    return attributes
+                }
+                configuration.image = UIImage(systemName: "chevron.down.circle.fill")?.withBaselineOffset(fromBottom: 4)
+                configuration.preferredSymbolConfigurationForImage =
+                    UIImage.SymbolConfiguration(paletteColors: [.secondaryLabel, .secondarySystemFill])
+                    .applying(
+                        UIImage.SymbolConfiguration(
+                            font: WPStyleGuide.fontForTextStyle(.subheadline, fontWeight: .semibold)
+                        )
+                    )
+                configuration.imagePlacement = .trailing
+                configuration.imagePadding = 4
+                configuration.baseForegroundColor = .label
+                return configuration
+            }()
+        )
     }
 }

--- a/WordPress/Classes/Utility/ImmuTable/WPImmuTableRows.swift
+++ b/WordPress/Classes/Utility/ImmuTable/WPImmuTableRows.swift
@@ -15,7 +15,16 @@ struct NavigationItemRow: ImmuTableRow {
     let accessibilityIdentifier: String?
     let loading: Bool
 
-    init(title: String, detail: String? = nil, icon: UIImage? = nil, tintColor: UIColor? = nil, accessoryType: UITableViewCell.AccessoryType = .disclosureIndicator, action: @escaping ImmuTableAction, accessibilityIdentifier: String? = nil, loading: Bool = false) {
+    init(
+        title: String,
+        detail: String? = nil,
+        icon: UIImage? = nil,
+        tintColor: UIColor? = nil,
+        accessoryType: UITableViewCell.AccessoryType = .disclosureIndicator,
+        action: @escaping ImmuTableAction,
+        accessibilityIdentifier: String? = nil,
+        loading: Bool = false
+    ) {
         self.title = title
         self.detail = detail
         self.icon = icon
@@ -56,7 +65,14 @@ struct IndicatorNavigationItemRow: ImmuTableRow {
     let accessoryType: UITableViewCell.AccessoryType
     let action: ImmuTableAction?
 
-    init(title: String, icon: UIImage? = nil, tintColor: UIColor?, showIndicator: Bool = false, accessoryType: UITableViewCell.AccessoryType = .disclosureIndicator, action: @escaping ImmuTableAction) {
+    init(
+        title: String,
+        icon: UIImage? = nil,
+        tintColor: UIColor?,
+        showIndicator: Bool = false,
+        accessoryType: UITableViewCell.AccessoryType = .disclosureIndicator,
+        action: @escaping ImmuTableAction
+    ) {
         self.title = title
         self.icon = icon
         self.tintColor = tintColor
@@ -88,7 +104,13 @@ struct EditableTextRow: ImmuTableRow {
     let action: ImmuTableAction?
     let fieldName: String?
 
-    init(title: String, value: String, accessoryImage: UIImage? = nil, action: ImmuTableAction?, fieldName: String? = nil) {
+    init(
+        title: String,
+        value: String,
+        accessoryImage: UIImage? = nil,
+        action: ImmuTableAction?,
+        fieldName: String? = nil
+    ) {
         self.title = title
         self.value = value
         self.accessoryImage = accessoryImage
@@ -102,7 +124,10 @@ struct EditableTextRow: ImmuTableRow {
         cell.accessibilityLabel = title
         cell.accessibilityValue = value
         if cell.isUserInteractionEnabled {
-            cell.accessibilityHint = NSLocalizedString("Tap to edit", comment: "Accessibility hint prompting the user to tap a table row to edit its value.")
+            cell.accessibilityHint = NSLocalizedString(
+                "Tap to edit",
+                comment: "Accessibility hint prompting the user to tap a table row to edit its value."
+            )
         }
         cell.accessoryType = .disclosureIndicator
         if accessoryImage != nil {
@@ -250,7 +275,12 @@ struct BrandedNavigationRow: ImmuTableRow {
     let action: ImmuTableAction?
     let accessibilityIdentifier: String?
 
-    init(title: String, action: @escaping ImmuTableAction, showIndicator: Bool = false, accessibilityIdentifier: String? = nil) {
+    init(
+        title: String,
+        action: @escaping ImmuTableAction,
+        showIndicator: Bool = false,
+        accessibilityIdentifier: String? = nil
+    ) {
         self.title = title
         self.showIndicator = showIndicator
         self.action = action
@@ -319,7 +349,7 @@ struct TextWithButtonRow: ImmuTableRow {
     typealias CellType = TextWithAccessoryButtonCell
 
     static let cell: ImmuTableCell = {
-        return ImmuTableCell.nib(TextWithAccessoryButtonCell.defaultNib, CellType.self)
+        ImmuTableCell.nib(TextWithAccessoryButtonCell.defaultNib, CellType.self)
     }()
 
     let title: String
@@ -343,7 +373,7 @@ struct TextWithButtonIndicatingActivityRow: ImmuTableRow {
     typealias CellType = TextWithAccessoryButtonCell
 
     static let cell: ImmuTableCell = {
-        return ImmuTableCell.nib(TextWithAccessoryButtonCell.defaultNib, CellType.self)
+        ImmuTableCell.nib(TextWithAccessoryButtonCell.defaultNib, CellType.self)
     }()
 
     let title: String
@@ -370,12 +400,14 @@ struct SwitchRow: ImmuTableRow {
     let onChange: (Bool) -> Void
     let accessibilityIdentifier: String?
 
-    init(title: String,
-         value: Bool,
-         icon: UIImage? = nil,
-         isUserInteractionEnabled: Bool = true,
-         onChange: @escaping (Bool) -> Void,
-         accessibilityIdentifier: String? = nil) {
+    init(
+        title: String,
+        value: Bool,
+        icon: UIImage? = nil,
+        isUserInteractionEnabled: Bool = true,
+        onChange: @escaping (Bool) -> Void,
+        accessibilityIdentifier: String? = nil
+    ) {
         self.title = title
         self.value = value
         self.icon = icon
@@ -408,7 +440,14 @@ struct SwitchWithSubtitleRow: ImmuTableRow {
     let onChange: (Bool) -> Void
     let accessibilityIdentifier: String?
 
-    init(title: String, value: Bool, subtitle: String? = nil, icon: UIImage? = nil, onChange: @escaping (Bool) -> Void, accessibilityIdentifier: String? = nil) {
+    init(
+        title: String,
+        value: Bool,
+        subtitle: String? = nil,
+        icon: UIImage? = nil,
+        onChange: @escaping (Bool) -> Void,
+        accessibilityIdentifier: String? = nil
+    ) {
         self.title = title
         self.subtitle = subtitle
         self.value = value
@@ -432,14 +471,16 @@ struct SwitchWithSubtitleRow: ImmuTableRow {
 
 class ExpandableRow: ImmuTableRow {
     static let cell: ImmuTableCell = {
-        return ImmuTableCell.nib(ExpandableCell.defaultNib, CellType.self)
+        ImmuTableCell.nib(ExpandableCell.defaultNib, CellType.self)
     }()
 
-    init(title: String,
-         expandedText: NSAttributedString?,
-         expanded: Bool,
-         action: ImmuTableAction?,
-         onLinkTap: ((URL) -> Void)?) {
+    init(
+        title: String,
+        expandedText: NSAttributedString?,
+        expanded: Bool,
+        action: ImmuTableAction?,
+        onLinkTap: ((URL) -> Void)?
+    ) {
         self.title = title
         self.expandedText = expandedText
         self.expanded = expanded

--- a/WordPress/Classes/Utility/ImmuTable/WPImmuTableRows.swift
+++ b/WordPress/Classes/Utility/ImmuTable/WPImmuTableRows.swift
@@ -385,7 +385,7 @@ struct TextWithButtonIndicatingActivityRow: ImmuTableRow {
 
         cell.mainLabelText = title
         cell.secondaryLabelText = subtitle
-        cell.button?.showActivityIndicator(true)
+        cell.button?.setActivityIndicatorVisible(true)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Cells/TextWithAccessoryButtonCell.swift
+++ b/WordPress/Classes/ViewRelated/Cells/TextWithAccessoryButtonCell.swift
@@ -5,7 +5,7 @@ import WordPressUI
 class TextWithAccessoryButtonCell: WPReusableTableViewCell, NibLoadable {
     var buttonText: String? {
         get {
-            return button?.title(for: .normal)
+            button?.title(for: .normal)
         }
         set {
             button?.setTitle(newValue, for: .normal)

--- a/WordPress/Classes/ViewRelated/Cells/TextWithAccessoryButtonCell.swift
+++ b/WordPress/Classes/ViewRelated/Cells/TextWithAccessoryButtonCell.swift
@@ -1,15 +1,13 @@
 import UIKit
-import WordPressAuthenticator
 import WordPressUI
 
 class TextWithAccessoryButtonCell: WPReusableTableViewCell, NibLoadable {
     var buttonText: String? {
         get {
-            button?.title(for: .normal)
+            button?.configuration?.title
         }
         set {
-            button?.setTitle(newValue, for: .normal)
-            button?.sizeToFit()
+            button?.configuration?.title = newValue
         }
     }
 
@@ -19,7 +17,7 @@ class TextWithAccessoryButtonCell: WPReusableTableViewCell, NibLoadable {
         }
     }
     @IBOutlet private var secondaryLabel: UILabel?
-    @IBOutlet public private(set) var button: NUXButton?
+    @IBOutlet public private(set) var button: UIButton?
 
     var onButtonTap: (() -> Void)?
 
@@ -55,16 +53,16 @@ class TextWithAccessoryButtonCell: WPReusableTableViewCell, NibLoadable {
 
     override func prepareForReuse() {
         super.prepareForReuse()
-        button?.showActivityIndicator(false)
+        button?.setActivityIndicatorVisible(false)
     }
 }
 
 private extension TextWithAccessoryButtonCell {
     func initialSetup() {
-        button?.isPrimary = true
+        button?.configureAsPrimaryNUXButton()
     }
 
-    @IBAction func buttonTapped(_ button: NUXButton) {
+    @IBAction func buttonTapped(_ button: UIButton) {
         onButtonTap?()
     }
 }

--- a/WordPress/Classes/ViewRelated/Cells/TextWithAccessoryButtonCell.xib
+++ b/WordPress/Classes/ViewRelated/Cells/TextWithAccessoryButtonCell.xib
@@ -29,13 +29,11 @@
                         </label>
                     </subviews>
                 </stackView>
-                <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="YSR-GY-91s" customClass="NUXButton" customModule="WordPressAuthenticator">
+                <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="YSR-GY-91s">
                     <rect key="frame" x="523" y="12" width="41" height="36"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="36" id="244-ge-uM1"/>
                     </constraints>
-                    <inset key="contentEdgeInsets" minX="-5" minY="0.0" maxX="0.0" maxY="0.0"/>
-                    <state key="normal" title="Button"/>
                     <connections>
                         <action selector="buttonTapped:" destination="iN0-l3-epB" eventType="touchUpInside" id="B71-pz-WXU"/>
                     </connections>

--- a/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainDetails/ViewController/RegisterDomainDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainDetails/ViewController/RegisterDomainDetailsViewController.swift
@@ -66,8 +66,10 @@ class RegisterDomainDetailsViewController: UITableViewController {
     }
 
     private func configureView() {
-        title = NSLocalizedString("Register domain",
-                                  comment: "Title for the Register domain screen")
+        title = NSLocalizedString(
+            "Register domain",
+            comment: "Title for the Register domain screen"
+        )
 
         configureTableView()
         WPStyleGuide.configureColors(view: view, tableView: tableView)
@@ -210,11 +212,14 @@ extension RegisterDomainDetailsViewController {
 
 extension RegisterDomainDetailsViewController: InlineEditableNameValueCellDelegate {
 
-    func inlineEditableNameValueCell(_ cell: InlineEditableNameValueCell,
-                                     valueTextFieldDidChange text: String) {
+    func inlineEditableNameValueCell(
+        _ cell: InlineEditableNameValueCell,
+        valueTextFieldDidChange text: String
+    ) {
         guard let indexPath = tableView.indexPath(for: cell),
-            let sectionType = SectionIndex(rawValue: indexPath.section) else {
-                return
+            let sectionType = SectionIndex(rawValue: indexPath.section)
+        else {
+            return
         }
 
         viewModel.updateValue(text, at: indexPath)
@@ -222,8 +227,9 @@ extension RegisterDomainDetailsViewController: InlineEditableNameValueCellDelega
         if sectionType == .address,
             viewModel.addressSectionIndexHelper.addressField(for: indexPath.row) == .addressLine1,
             indexPath.row == viewModel.addressSectionIndexHelper.extraAddressLineCount,
-            text.isEmpty == false {
-                viewModel.enableAddAddressRow()
+            text.isEmpty == false
+        {
+            viewModel.enableAddAddressRow()
         }
     }
 
@@ -231,9 +237,12 @@ extension RegisterDomainDetailsViewController: InlineEditableNameValueCellDelega
         inlineEditableNameValueCell(cell, valueTextFieldDidChange: text)
     }
 
-    func inlineEditableNameValueCell(_ cell: InlineEditableNameValueCell, valueTextFieldShouldReturn textField: UITextField) -> Bool {
+    func inlineEditableNameValueCell(
+        _ cell: InlineEditableNameValueCell,
+        valueTextFieldShouldReturn textField: UITextField
+    ) -> Bool {
         guard let indexPath = tableView.indexPath(for: cell) else {
-                return false
+            return false
         }
 
         let nextSection = indexPath.section + 1
@@ -241,12 +250,16 @@ extension RegisterDomainDetailsViewController: InlineEditableNameValueCellDelega
 
         // If there's an enabled editable row next in this section then select it, otherwise check the next section
         if tableView.numberOfRows(inSection: indexPath.section) > nextRow,
-            let nextCell = tableView.cellForRow(at: IndexPath(row: nextRow, section: indexPath.section)) as? InlineEditableNameValueCell,
-            nextCell.valueTextField.isEnabled {
+            let nextCell = tableView.cellForRow(at: IndexPath(row: nextRow, section: indexPath.section))
+                as? InlineEditableNameValueCell,
+            nextCell.valueTextField.isEnabled
+        {
             nextCell.valueTextField.becomeFirstResponder()
         } else if tableView.numberOfSections > nextSection,
-            let nextCell = tableView.cellForRow(at: IndexPath(row: indexPath.row, section: nextSection)) as? InlineEditableNameValueCell,
-            nextCell.valueTextField.isEnabled {
+            let nextCell = tableView.cellForRow(at: IndexPath(row: indexPath.row, section: nextSection))
+                as? InlineEditableNameValueCell,
+            nextCell.valueTextField.isEnabled
+        {
             nextCell.valueTextField.becomeFirstResponder()
         } else {
             textField.resignFirstResponder()
@@ -274,9 +287,11 @@ extension RegisterDomainDetailsViewController {
             switch field {
             case .country:
                 if !viewModel.countryNames.isEmpty {
-                    showItemSelectionPage(onSelectionAt: indexPath,
-                                          title: Localized.ContactInformation.country,
-                                          items: viewModel.countryNames)
+                    showItemSelectionPage(
+                        onSelectionAt: indexPath,
+                        title: Localized.ContactInformation.country,
+                        items: viewModel.countryNames
+                    )
                 }
             default:
                 break
@@ -288,9 +303,11 @@ extension RegisterDomainDetailsViewController {
                 viewModel.replaceAddNewAddressLine()
             case .state:
                 if !viewModel.stateNames.isEmpty {
-                    showItemSelectionPage(onSelectionAt: indexPath,
-                                          title: Localized.Address.state,
-                                          items: viewModel.stateNames)
+                    showItemSelectionPage(
+                        onSelectionAt: indexPath,
+                        title: Localized.Address.state,
+                        items: viewModel.stateNames
+                    )
                 }
             default:
                 break
@@ -305,13 +322,16 @@ extension RegisterDomainDetailsViewController {
         for item in items {
             let attributedItem = NSAttributedString(
                 string: item,
-                attributes: [.font: WPStyleGuide.tableviewTextFont(),
-                             .foregroundColor: UIColor.label]
+                attributes: [
+                    .font: WPStyleGuide.tableviewTextFont(),
+                    .foregroundColor: UIColor.label
+                ]
             )
             let option = OptionsTableViewOption(
                 image: nil,
                 title: attributedItem,
-                accessibilityLabel: nil)
+                accessibilityLabel: nil
+            )
             options.append(option)
         }
         let viewController = OptionsTableViewController(options: options)
@@ -343,11 +363,11 @@ extension RegisterDomainDetailsViewController {
 extension RegisterDomainDetailsViewController {
 
     override func numberOfSections(in tableView: UITableView) -> Int {
-        return viewModel.sections.count
+        viewModel.sections.count
     }
 
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return viewModel.sections[section].rows.count
+        viewModel.sections[section].rows.count
     }
 
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {

--- a/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainDetails/ViewController/RegisterDomainDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainDetails/ViewController/RegisterDomainDetailsViewController.swift
@@ -33,7 +33,7 @@ class RegisterDomainDetailsViewController: UITableViewController {
             for: .touchUpInside
         )
 
-        buttonView.submitButton.setTitle(Localized.buttonTitle, for: .normal)
+        buttonView.submitButton.configuration?.title = Localized.buttonTitle
 
         return buttonView
     }()

--- a/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainDetails/Views/RegisterDomainDetailsFooterView.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainDetails/Views/RegisterDomainDetailsFooterView.swift
@@ -1,14 +1,13 @@
 import UIKit
-import WordPressAuthenticator
 
 class RegisterDomainDetailsFooterView: UIView, NibLoadable {
 
-    @IBOutlet weak var submitButton: NUXButton!
+    @IBOutlet weak var submitButton: UIButton!
 
     override func awakeFromNib() {
         super.awakeFromNib()
         clipsToBounds = false
-        submitButton.isPrimary = true
+        submitButton.configureAsPrimaryNUXButton()
         backgroundColor = .systemBackground
     }
 }

--- a/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainDetails/Views/RegisterDomainDetailsFooterView.xib
+++ b/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainDetails/Views/RegisterDomainDetailsFooterView.xib
@@ -22,12 +22,11 @@
                         <constraint firstAttribute="height" constant="10" id="59G-OJ-yES"/>
                     </constraints>
                 </imageView>
-                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="aWW-fc-OkB" customClass="NUXButton" customModule="WordPressAuthenticator">
+                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="aWW-fc-OkB">
                     <rect key="frame" x="20" y="16" width="335" height="50"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="50" id="ujS-fE-lvl"/>
                     </constraints>
-                    <state key="normal" title="Button"/>
                 </button>
             </subviews>
             <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>

--- a/WordPress/Classes/ViewRelated/Jetpack/Login/JetpackLoginViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Login/JetpackLoginViewController.swift
@@ -23,7 +23,7 @@ extension UIViewController {
     static func jetpackConnection(blog: Blog) -> ConnectJetpackViewController {
         // `RESTAPIJetpackLoginViewController` use REST API to connect sites to Jetpack, which provides a much better
         // UX than `JetpackLoginViewController` which connects sites via web-views.
-        return RESTAPIJetpackLoginViewController(blog: blog) ?? JetpackLoginViewController(blog: blog)
+        RESTAPIJetpackLoginViewController(blog: blog) ?? JetpackLoginViewController(blog: blog)
     }
 }
 
@@ -43,7 +43,9 @@ public class JetpackLoginViewController: UIViewController {
 
     // This variable is used to prevent signing into another WP.com account, if the site is not connected to the already signed-in default account.
     private var shouldDisableLogin: Bool {
-        guard let defaultAccount = try? WPAccount.lookupDefaultWordPressComAccount(in: ContextManager.shared.mainContext) else {
+        guard
+            let defaultAccount = try? WPAccount.lookupDefaultWordPressComAccount(in: ContextManager.shared.mainContext)
+        else {
             return false
         }
         return defaultAccount.email != blog.jetpack?.connectedEmail
@@ -91,7 +93,10 @@ public class JetpackLoginViewController: UIViewController {
         setupControls()
     }
 
-    public override func willTransition(to newCollection: UITraitCollection, with coordinator: UIViewControllerTransitionCoordinator) {
+    public override func willTransition(
+        to newCollection: UITraitCollection,
+        with coordinator: UIViewControllerTransitionCoordinator
+    ) {
         super.willTransition(to: newCollection, with: coordinator)
         toggleHidingImageView(for: newCollection)
     }
@@ -134,7 +139,8 @@ public class JetpackLoginViewController: UIViewController {
             if let connectedEmail = jetpack.connectedEmail, shouldDisableLogin {
                 message = Constants.Jetpack.connectToDefaultAccount(connectedEmail: connectedEmail)
             } else {
-                message = jetpack.isUpdatedToRequiredVersion ? Constants.Jetpack.isUpdated : Constants.Jetpack.updateRequired
+                message =
+                    jetpack.isUpdatedToRequiredVersion ? Constants.Jetpack.isUpdated : Constants.Jetpack.updateRequired
             }
         } else {
             message = promptType.installMessage
@@ -155,16 +161,24 @@ public class JetpackLoginViewController: UIViewController {
         signinButton.setTitle(Constants.Buttons.loginTitle, for: .normal)
         signinButton.isHidden = shouldDisableLogin || !(blog.hasJetpack && !jetpack.isSiteConnection)
 
-        let paragraph = NSMutableParagraphStyle(minLineHeight: WPStyleGuide.fontSizeForTextStyle(.footnote),
-                                                lineBreakMode: .byWordWrapping,
-                                                alignment: .center)
-        let attributes: [NSAttributedString.Key: Any] = [.font: WPStyleGuide.fontForTextStyle(.footnote),
-                                                         .foregroundColor: UIColor.secondaryLabel,
-                                                         .paragraphStyle: paragraph]
-        let attributedTitle = NSMutableAttributedString(string: Constants.Buttons.termsAndConditionsTitle,
-                                                        attributes: attributes)
-        attributedTitle.applyStylesToMatchesWithPattern(Constants.Buttons.termsAndConditions,
-                                                        styles: [.underlineStyle: NSUnderlineStyle.single.rawValue])
+        let paragraph = NSMutableParagraphStyle(
+            minLineHeight: WPStyleGuide.fontSizeForTextStyle(.footnote),
+            lineBreakMode: .byWordWrapping,
+            alignment: .center
+        )
+        let attributes: [NSAttributedString.Key: Any] = [
+            .font: WPStyleGuide.fontForTextStyle(.footnote),
+            .foregroundColor: UIColor.secondaryLabel,
+            .paragraphStyle: paragraph
+        ]
+        let attributedTitle = NSMutableAttributedString(
+            string: Constants.Buttons.termsAndConditionsTitle,
+            attributes: attributes
+        )
+        attributedTitle.applyStylesToMatchesWithPattern(
+            Constants.Buttons.termsAndConditions,
+            styles: [.underlineStyle: NSUnderlineStyle.single.rawValue]
+        )
         tacButton.setAttributedTitle(attributedTitle, for: .normal)
         tacButton.isHidden = installJetpackButton.isHidden
 
@@ -187,7 +201,8 @@ public class JetpackLoginViewController: UIViewController {
             guard let self else { return }
 
             let email = self.blog.jetpack?.connectedEmail
-            let accountID = await WordPressDotComAuthenticator().signIn(from: self, context: .jetpackSite(accountEmail: email))
+            let accountID = await WordPressDotComAuthenticator()
+                .signIn(from: self, context: .jetpackSite(accountEmail: email))
             if accountID != nil {
                 self.completionBlock?()
             }
@@ -317,11 +332,15 @@ public enum JetpackLoginPromptType {
     var installMessage: String {
         switch self {
         case .stats:
-            return NSLocalizedString("To use stats on your site, you'll need to install the Jetpack plugin.",
-                                        comment: "Message asking the user if they want to set up Jetpack from stats")
+            return NSLocalizedString(
+                "To use stats on your site, you'll need to install the Jetpack plugin.",
+                comment: "Message asking the user if they want to set up Jetpack from stats"
+            )
         case .notifications:
-            return NSLocalizedString("To get helpful notifications on your phone from your WordPress site, you'll need to install the Jetpack plugin.",
-                                        comment: "Message asking the user if they want to set up Jetpack from notifications")
+            return NSLocalizedString(
+                "To get helpful notifications on your phone from your WordPress site, you'll need to install the Jetpack plugin.",
+                comment: "Message asking the user if they want to set up Jetpack from notifications"
+            )
         case .bypassXMLRPC:
             return NSLocalizedString(
                 "jetpack.install.allFeatures.description",
@@ -334,13 +353,19 @@ public enum JetpackLoginPromptType {
     var connectMessage: String {
         switch self {
         case .stats:
-            return NSLocalizedString("jetpack.install.connectUser.stats.description",
-                                     value: "To use stats on your site, you'll need to connect the Jetpack plugin to your user account.",
-                                     comment: "Message asking the user if they want to set up Jetpack from stats by connecting their user account")
+            return NSLocalizedString(
+                "jetpack.install.connectUser.stats.description",
+                value: "To use stats on your site, you'll need to connect the Jetpack plugin to your user account.",
+                comment:
+                    "Message asking the user if they want to set up Jetpack from stats by connecting their user account"
+            )
         case .notifications:
-            return NSLocalizedString("jetpack.install.connectUser.notifications.description",
-                                     value: "To get helpful notifications on your phone from your WordPress site, you'll need to connect to your user account.",
-                                     comment: "Message asking the user if they want to set up Jetpack from notifications")
+            return NSLocalizedString(
+                "jetpack.install.connectUser.notifications.description",
+                value:
+                    "To get helpful notifications on your phone from your WordPress site, you'll need to connect to your user account.",
+                comment: "Message asking the user if they want to set up Jetpack from notifications"
+            )
         case .bypassXMLRPC:
             return NSLocalizedString(
                 "jetpack.install.connectUser.bypassXMLRPC.description",
@@ -367,28 +392,56 @@ private enum JetpackWebviewType {
 
 private enum Constants {
     enum Buttons {
-        static let termsAndConditions = NSLocalizedString("Terms and Conditions", comment: "The underlined title sentence")
-        static let termsAndConditionsTitle = String.localizedStringWithFormat(NSLocalizedString("By setting up Jetpack you agree to our\n%@",
-                                                                                                comment: "Title of the button which opens the Jetpack terms and conditions page. The sentence is composed by 2 lines separated by a line break \n. Also there is a placeholder %@ which is: Terms and Conditions"), termsAndConditions)
-        static let faqTitle = NSLocalizedString("Jetpack FAQ", comment: "Title of the button which opens the Jetpack FAQ page.")
-        static let jetpackInstallTitle = NSLocalizedString("Install Jetpack", comment: "Title of a button for Jetpack Installation.")
+        static let termsAndConditions = NSLocalizedString(
+            "Terms and Conditions",
+            comment: "The underlined title sentence"
+        )
+        static let termsAndConditionsTitle = String.localizedStringWithFormat(
+            NSLocalizedString(
+                "By setting up Jetpack you agree to our\n%@",
+                comment:
+                    "Title of the button which opens the Jetpack terms and conditions page. The sentence is composed by 2 lines separated by a line break \n. Also there is a placeholder %@ which is: Terms and Conditions"
+            ),
+            termsAndConditions
+        )
+        static let faqTitle = NSLocalizedString(
+            "Jetpack FAQ",
+            comment: "Title of the button which opens the Jetpack FAQ page."
+        )
+        static let jetpackInstallTitle = NSLocalizedString(
+            "Install Jetpack",
+            comment: "Title of a button for Jetpack Installation."
+        )
         static let loginTitle = NSLocalizedString("Log in", comment: "Title of a button for signing in.")
-        static let connectUserTitle = NSLocalizedString("jetpack.install.connectUser.button.title", value: "Connect your user account", comment: "Title of a button for connecting user account to Jetpack.")
+        static let connectUserTitle = NSLocalizedString(
+            "jetpack.install.connectUser.button.title",
+            value: "Connect your user account",
+            comment: "Title of a button for connecting user account to Jetpack."
+        )
     }
 
     enum Jetpack {
-        static let isUpdated = NSLocalizedString("Looks like you have Jetpack set up on your site. Congrats! " +
-            "Log in with your WordPress.com credentials to enable " +
-            "Stats and Notifications.",
-                                                      comment: "Message asking the user to sign into Jetpack with WordPress.com credentials")
-        static let updateRequired = String.localizedStringWithFormat(NSLocalizedString("Jetpack %@ or later is required. " +
-            "Do you want to update Jetpack?",
-                                                                                              comment: "Message stating the minimum required " +
-                                                                                                "version for Jetpack and asks the user " +
-            "if they want to upgrade"), JetpackState.minimumVersionRequired)
+        static let isUpdated = NSLocalizedString(
+            "Looks like you have Jetpack set up on your site. Congrats! "
+                + "Log in with your WordPress.com credentials to enable " + "Stats and Notifications.",
+            comment: "Message asking the user to sign into Jetpack with WordPress.com credentials"
+        )
+        static let updateRequired = String.localizedStringWithFormat(
+            NSLocalizedString(
+                "Jetpack %@ or later is required. " + "Do you want to update Jetpack?",
+                comment: "Message stating the minimum required " + "version for Jetpack and asks the user "
+                    + "if they want to upgrade"
+            ),
+            JetpackState.minimumVersionRequired
+        )
         static func connectToDefaultAccount(connectedEmail: String) -> String {
             String.localizedStringWithFormat(
-                NSLocalizedString("jetpackSite.connectToDefaultAccount", value: "You need to sign in with %@ to use Stats and Notifications.", comment: "Message stating that the user is unable to use Stats and Notifications because their site is connected to a different WordPress.com account"),
+                NSLocalizedString(
+                    "jetpackSite.connectToDefaultAccount",
+                    value: "You need to sign in with %@ to use Stats and Notifications.",
+                    comment:
+                        "Message stating that the user is unable to use Stats and Notifications because their site is connected to a different WordPress.com account"
+                ),
                 connectedEmail
             )
         }

--- a/WordPress/Classes/ViewRelated/Jetpack/Login/JetpackLoginViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Login/JetpackLoginViewController.swift
@@ -2,7 +2,6 @@ import Foundation
 import UIKit
 import WordPressData
 import WordPressShared
-import WordPressAuthenticator
 import WordPressUI
 
 protocol JetpackConnectionSupport: AnyObject {
@@ -64,9 +63,9 @@ public class JetpackLoginViewController: UIViewController {
 
     @IBOutlet fileprivate weak var jetpackImage: UIImageView!
     @IBOutlet fileprivate weak var descriptionLabel: UILabel!
-    @IBOutlet fileprivate weak var signinButton: WPNUXMainButton!
-    @IBOutlet fileprivate weak var connectUserButton: NUXButton!
-    @IBOutlet fileprivate weak var installJetpackButton: WPNUXMainButton!
+    @IBOutlet fileprivate weak var signinButton: UIButton!
+    @IBOutlet fileprivate weak var connectUserButton: UIButton!
+    @IBOutlet fileprivate weak var installJetpackButton: UIButton!
     @IBOutlet private var tacButton: UIButton!
     @IBOutlet private var faqButton: UIButton!
 
@@ -112,6 +111,14 @@ public class JetpackLoginViewController: UIViewController {
         descriptionLabel.font = WPStyleGuide.fontForTextStyle(.body)
         descriptionLabel.textColor = .label
 
+        signinButton.configureAsPrimaryNUXButton()
+        signinButton.configuration?.title = Constants.Buttons.loginTitle
+        installJetpackButton.configureAsPrimaryNUXButton()
+        installJetpackButton.configuration?.title = Constants.Buttons.jetpackInstallTitle
+        connectUserButton.configureAsPrimaryNUXButton()
+        connectUserButton.configuration?.title = Constants.Buttons.connectUserTitle
+        connectUserButton.configuration?.titleLineBreakMode = .byWordWrapping
+
         tacButton.titleLabel?.numberOfLines = 0
 
         faqButton.titleLabel?.font = WPStyleGuide.fontForTextStyle(.subheadline, fontWeight: .medium)
@@ -149,16 +156,8 @@ public class JetpackLoginViewController: UIViewController {
         descriptionLabel.text = message
         descriptionLabel.sizeToFit()
 
-        installJetpackButton.setTitle(Constants.Buttons.jetpackInstallTitle, for: .normal)
         installJetpackButton.isHidden = blog.hasJetpack
-        installJetpackButton.contentEdgeInsets = UIEdgeInsets(top: 12, left: 20, bottom: 12, right: 20)
-
-        connectUserButton.setTitle(Constants.Buttons.connectUserTitle, for: .normal)
         connectUserButton.isHidden = !(blog.hasJetpack && jetpack.isSiteConnection)
-        connectUserButton.titleLabel?.numberOfLines = 2
-        connectUserButton.contentEdgeInsets = UIEdgeInsets(top: 12, left: 20, bottom: 12, right: 20)
-
-        signinButton.setTitle(Constants.Buttons.loginTitle, for: .normal)
         signinButton.isHidden = shouldDisableLogin || !(blog.hasJetpack && !jetpack.isSiteConnection)
 
         let paragraph = NSMutableParagraphStyle(

--- a/WordPress/Classes/ViewRelated/Jetpack/Login/JetpackLoginViewController.xib
+++ b/WordPress/Classes/ViewRelated/Jetpack/Login/JetpackLoginViewController.xib
@@ -40,38 +40,20 @@
                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="iCv-gL-vpC" userLabel="Main buttons">
                             <rect key="frame" x="0.0" y="230" width="315" height="102"/>
                             <subviews>
-                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="lMy-o2-gd3" customClass="NUXButton" customModule="WordPressAuthenticator">
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="lMy-o2-gd3">
                                     <rect key="frame" x="133" y="0.0" width="49" height="34"/>
-                                    <state key="normal" title="Log in">
-                                        <color key="titleColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                    </state>
-                                    <userDefinedRuntimeAttributes>
-                                        <userDefinedRuntimeAttribute type="boolean" keyPath="isPrimary" value="YES"/>
-                                    </userDefinedRuntimeAttributes>
                                     <connections>
                                         <action selector="didTouchSignInButton:" destination="-1" eventType="touchUpInside" id="4XZ-kZ-sw4"/>
                                     </connections>
                                 </button>
-                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Qm1-Pi-98R" customClass="NUXButton" customModule="WordPressAuthenticator">
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Qm1-Pi-98R">
                                     <rect key="frame" x="97" y="34" width="121" height="34"/>
-                                    <state key="normal" title="Set up Jetpack">
-                                        <color key="titleColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                    </state>
-                                    <userDefinedRuntimeAttributes>
-                                        <userDefinedRuntimeAttribute type="boolean" keyPath="isPrimary" value="YES"/>
-                                    </userDefinedRuntimeAttributes>
                                     <connections>
                                         <action selector="didTouchInstallJetpackButton:" destination="-1" eventType="touchUpInside" id="jig-Gw-45O"/>
                                     </connections>
                                 </button>
-                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="VTV-9i-gcK" userLabel="Connect your user accont" customClass="NUXButton" customModule="WordPressAuthenticator">
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="VTV-9i-gcK" userLabel="Connect your user accont">
                                     <rect key="frame" x="48.666666666666686" y="68" width="218" height="34"/>
-                                    <state key="normal" title="Connect your user account">
-                                        <color key="titleColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                    </state>
-                                    <userDefinedRuntimeAttributes>
-                                        <userDefinedRuntimeAttribute type="boolean" keyPath="isPrimary" value="YES"/>
-                                    </userDefinedRuntimeAttributes>
                                     <connections>
                                         <action selector="didTouchConnectUserAccountButton:" destination="-1" eventType="touchUpInside" id="rbB-O7-30R"/>
                                         <action selector="didTouchInstallJetpackButton:" destination="-1" eventType="touchUpInside" id="o2L-ud-Obn"/>

--- a/WordPress/Classes/ViewRelated/Jetpack/Login/JetpackLoginViewController.xib
+++ b/WordPress/Classes/ViewRelated/Jetpack/Login/JetpackLoginViewController.xib
@@ -56,7 +56,6 @@
                                     <rect key="frame" x="48.666666666666686" y="68" width="218" height="34"/>
                                     <connections>
                                         <action selector="didTouchConnectUserAccountButton:" destination="-1" eventType="touchUpInside" id="rbB-O7-30R"/>
-                                        <action selector="didTouchInstallJetpackButton:" destination="-1" eventType="touchUpInside" id="o2L-ud-Obn"/>
                                     </connections>
                                 </button>
                             </subviews>

--- a/WordPress/Classes/ViewRelated/Site Creation/Final Assembly/SiteAssemblyButtonBar.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Final Assembly/SiteAssemblyButtonBar.swift
@@ -1,0 +1,59 @@
+import UIKit
+
+/// The bottom-pinned bar hosting the single "Done" button shown when site
+/// assembly succeeds. Replaces the storyboard-based `NUXButtonViewController`
+/// previously reused from WordPressAuthenticator.
+final class SiteAssemblyButtonBar: UIView {
+
+    /// Invoked when the button is tapped.
+    var onTap: (() -> Void)?
+
+    private let button: UIButton
+
+    init(buttonTitle: String, showsTopShadow: Bool) {
+        self.button = UIButton.makePrimaryNUXButton()
+
+        super.init(frame: .zero)
+
+        translatesAutoresizingMaskIntoConstraints = false
+
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.configuration?.title = buttonTitle
+        // A stable identifier for UI automation, intentionally not derived from
+        // the localized title.
+        button.accessibilityIdentifier = "Done Button"
+        button.addTarget(self, action: #selector(buttonTapped), for: .touchUpInside)
+        addSubview(button)
+
+        NSLayoutConstraint.activate([
+            button.topAnchor.constraint(equalTo: topAnchor, constant: 16),
+            button.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 16),
+            trailingAnchor.constraint(equalTo: button.trailingAnchor, constant: 16),
+            bottomAnchor.constraint(equalTo: button.bottomAnchor, constant: 16),
+            button.heightAnchor.constraint(greaterThanOrEqualToConstant: 44)
+        ])
+
+        if showsTopShadow {
+            let shadowView = UIImageView(image: UIImage(named: "darkgrey-shadow"))
+            shadowView.translatesAutoresizingMaskIntoConstraints = false
+            addSubview(shadowView)
+
+            NSLayoutConstraint.activate([
+                // The shadow hangs above the bar's top edge, matching the layout
+                // of the storyboard this view replaces.
+                shadowView.heightAnchor.constraint(equalToConstant: 10),
+                shadowView.bottomAnchor.constraint(equalTo: topAnchor),
+                shadowView.leadingAnchor.constraint(equalTo: leadingAnchor),
+                shadowView.trailingAnchor.constraint(equalTo: trailingAnchor)
+            ])
+        }
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    @objc private func buttonTapped() {
+        onTap?()
+    }
+}

--- a/WordPress/Classes/ViewRelated/Site Creation/Final Assembly/SiteAssemblyContentView.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Final Assembly/SiteAssemblyContentView.swift
@@ -89,7 +89,7 @@ final class SiteAssemblyContentView: UIView {
     /// We adjust the button container view slightly to account for the Home indicator ("unsafe") region on the device.
     private var buttonContainerContainer: UIView?
 
-    /// The button container view is associated with the root view of a `NUXButtonViewController`
+    /// The bottom-pinned container hosting the Done button bar.
     var buttonContainerView: UIView? {
         didSet {
             installButtonContainerView()

--- a/WordPress/Classes/ViewRelated/Site Creation/Final Assembly/SiteAssemblyContentView.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Final Assembly/SiteAssemblyContentView.swift
@@ -178,8 +178,10 @@ final class SiteAssemblyContentView: UIView {
             label.textColor = .label
             label.textAlignment = .center
 
-            let statusText = NSLocalizedString("Hooray!\nAlmost done",
-                                               comment: "User-facing string, presented to reflect that site assembly is underway.")
+            let statusText = NSLocalizedString(
+                "Hooray!\nAlmost done",
+                comment: "User-facing string, presented to reflect that site assembly is underway."
+            )
             label.text = statusText
             label.accessibilityLabel = statusText
 
@@ -196,8 +198,10 @@ final class SiteAssemblyContentView: UIView {
             label.textColor = .secondaryLabel
             label.textAlignment = .center
 
-            let statusText = NSLocalizedString("Your site will be ready shortly",
-                                               comment: "User-facing string, presented to reflect that site assembly is underway.")
+            let statusText = NSLocalizedString(
+                "Your site will be ready shortly",
+                comment: "User-facing string, presented to reflect that site assembly is underway."
+            )
             label.text = statusText
             label.accessibilityLabel = statusText
 
@@ -216,17 +220,25 @@ final class SiteAssemblyContentView: UIView {
             //on the message
 
             let statusMessages = [
-                NSLocalizedString("Grabbing site URL",
-                                  comment: "User-facing string, presented to reflect that site assembly is underway."),
+                NSLocalizedString(
+                    "Grabbing site URL",
+                    comment: "User-facing string, presented to reflect that site assembly is underway."
+                ),
 
-                NSLocalizedString("Adding site features",
-                                  comment: "User-facing string, presented to reflect that site assembly is underway."),
+                NSLocalizedString(
+                    "Adding site features",
+                    comment: "User-facing string, presented to reflect that site assembly is underway."
+                ),
 
-                NSLocalizedString("Setting up theme",
-                                  comment: "User-facing string, presented to reflect that site assembly is underway."),
+                NSLocalizedString(
+                    "Setting up theme",
+                    comment: "User-facing string, presented to reflect that site assembly is underway."
+                ),
 
-                NSLocalizedString("Creating dashboard",
-                                  comment: "User-facing string, presented to reflect that site assembly is underway."),
+                NSLocalizedString(
+                    "Creating dashboard",
+                    comment: "User-facing string, presented to reflect that site assembly is underway."
+                )
             ]
 
             let icon: UIImage = {
@@ -274,7 +286,8 @@ final class SiteAssemblyContentView: UIView {
     /// This method is intended to be called by its owning view controller when constraints change.
     func adjustConstraints() {
         guard let assembledSitePreferredSize = assembledSiteView?.preferredSize,
-            let widthConstraint = assembledSiteWidthConstraint else {
+            let widthConstraint = assembledSiteWidthConstraint
+        else {
 
             return
         }
@@ -308,11 +321,13 @@ final class SiteAssemblyContentView: UIView {
 
     private func configure() {
         translatesAutoresizingMaskIntoConstraints = true
-        autoresizingMask = [ .flexibleWidth, .flexibleHeight ]
+        autoresizingMask = [.flexibleWidth, .flexibleHeight]
 
         backgroundColor = .systemGroupedBackground
 
-        statusStackView.addArrangedSubviews([ statusTitleLabel, statusSubtitleLabel, statusImageView, statusMessageRotatingView, activityIndicator ])
+        statusStackView.addArrangedSubviews([
+            statusTitleLabel, statusSubtitleLabel, statusImageView, statusMessageRotatingView, activityIndicator
+        ])
         addSubviews([completionLabelsStack, statusStackView])
 
         // Increase the spacing around the illustration
@@ -320,18 +335,33 @@ final class SiteAssemblyContentView: UIView {
         statusStackView.setCustomSpacing(Parameters.verticalSpacing, after: statusImageView)
 
         let completionLabelTopInsetInitial = Parameters.verticalSpacing * 2
-        let completionLabelInitialTopConstraint = completionLabelsStack.topAnchor.constraint(equalTo: prevailingLayoutGuide.topAnchor, constant: completionLabelTopInsetInitial)
+        let completionLabelInitialTopConstraint = completionLabelsStack.topAnchor.constraint(
+            equalTo: prevailingLayoutGuide.topAnchor,
+            constant: completionLabelTopInsetInitial
+        )
         self.completionLabelTopConstraint = completionLabelInitialTopConstraint
 
         NSLayoutConstraint.activate([
             completionLabelInitialTopConstraint,
-            completionLabelsStack.leadingAnchor.constraint(equalTo: prevailingLayoutGuide.leadingAnchor, constant: Parameters.horizontalMargin),
-            prevailingLayoutGuide.trailingAnchor.constraint(equalTo: completionLabelsStack.trailingAnchor, constant: Parameters.horizontalMargin),
+            completionLabelsStack.leadingAnchor.constraint(
+                equalTo: prevailingLayoutGuide.leadingAnchor,
+                constant: Parameters.horizontalMargin
+            ),
+            prevailingLayoutGuide.trailingAnchor.constraint(
+                equalTo: completionLabelsStack.trailingAnchor,
+                constant: Parameters.horizontalMargin
+            ),
             completionLabelsStack.centerXAnchor.constraint(equalTo: centerXAnchor),
-            statusStackView.leadingAnchor.constraint(equalTo: prevailingLayoutGuide.leadingAnchor, constant: Parameters.horizontalMargin),
-            prevailingLayoutGuide.trailingAnchor.constraint(equalTo: statusStackView.trailingAnchor, constant: Parameters.horizontalMargin),
+            statusStackView.leadingAnchor.constraint(
+                equalTo: prevailingLayoutGuide.leadingAnchor,
+                constant: Parameters.horizontalMargin
+            ),
+            prevailingLayoutGuide.trailingAnchor.constraint(
+                equalTo: statusStackView.trailingAnchor,
+                constant: Parameters.horizontalMargin
+            ),
             statusStackView.centerXAnchor.constraint(equalTo: centerXAnchor),
-            statusStackView.centerYAnchor.constraint(equalTo: centerYAnchor),
+            statusStackView.centerYAnchor.constraint(equalTo: centerYAnchor)
         ])
     }
 
@@ -344,7 +374,11 @@ final class SiteAssemblyContentView: UIView {
             assembledSiteView.removeFromSuperview()
         }
 
-        let assembledSiteView = AssembledSiteView(domainName: siteName, siteURLString: siteURLString, siteCreator: siteCreator)
+        let assembledSiteView = AssembledSiteView(
+            domainName: siteName,
+            siteURLString: siteURLString,
+            siteCreator: siteCreator
+        )
         addSubview(assembledSiteView)
 
         if let buttonContainer = buttonContainerContainer {
@@ -358,17 +392,20 @@ final class SiteAssemblyContentView: UIView {
 
         let preferredAssembledSiteSize = assembledSiteView.preferredSize
 
-        let assembledSiteWidthConstraint = assembledSiteView.widthAnchor.constraint(equalToConstant: preferredAssembledSiteSize.width)
+        let assembledSiteWidthConstraint = assembledSiteView.widthAnchor.constraint(
+            equalToConstant: preferredAssembledSiteSize.width
+        )
         self.assembledSiteWidthConstraint = assembledSiteWidthConstraint
 
         let assembledSiteViewBottomConstraint: NSLayoutConstraint
         if shouldShowDomainPurchase() {
             assembledSiteView.layer.cornerRadius = 12
             assembledSiteView.layer.masksToBounds = true
-            assembledSiteViewBottomConstraint = (buttonContainerView?.topAnchor ?? bottomAnchor).constraint(
-                equalTo: assembledSiteView.bottomAnchor,
-                constant: 24
-            )
+            assembledSiteViewBottomConstraint = (buttonContainerView?.topAnchor ?? bottomAnchor)
+                .constraint(
+                    equalTo: assembledSiteView.bottomAnchor,
+                    constant: 24
+                )
 
             completionLabel.text = Strings.Paid.completionTitle
             completionLabel.accessibilityLabel = Strings.Paid.completionTitle
@@ -382,11 +419,15 @@ final class SiteAssemblyContentView: UIView {
 
         NSLayoutConstraint.activate([
             initialSiteTopConstraint,
-            assembledSiteView.topAnchor.constraint(greaterThanOrEqualTo: completionLabelsStack.bottomAnchor, constant: assembledSiteTopInset),
+            assembledSiteView.topAnchor.constraint(
+                greaterThanOrEqualTo: completionLabelsStack.bottomAnchor,
+                constant: assembledSiteTopInset
+            ),
             assembledSiteViewBottomConstraint,
             assembledSiteView.centerXAnchor.constraint(equalTo: centerXAnchor),
             assembledSiteWidthConstraint,
-            (buttonContainerView?.topAnchor ?? bottomAnchor).constraint(equalTo: assembledSiteView.bottomAnchor, constant: 15)
+            (buttonContainerView?.topAnchor ?? bottomAnchor)
+                .constraint(equalTo: assembledSiteView.bottomAnchor, constant: 15)
         ])
 
         self.assembledSiteView = assembledSiteView
@@ -409,17 +450,23 @@ final class SiteAssemblyContentView: UIView {
 
         let buttonContainerHeight = buttonContainerView.bounds.height
         let safelyOffscreen = Parameters.buttonContainerScaleFactor * buttonContainerHeight
-        let bottomConstraint = buttonContainerView.bottomAnchor.constraint(equalTo: prevailingLayoutGuide.bottomAnchor, constant: safelyOffscreen)
+        let bottomConstraint = buttonContainerView.bottomAnchor.constraint(
+            equalTo: prevailingLayoutGuide.bottomAnchor,
+            constant: safelyOffscreen
+        )
         self.buttonContainerBottomConstraint = bottomConstraint
 
         NSLayoutConstraint.activate([
             buttonContainerView.topAnchor.constraint(equalTo: buttonContainerContainer.topAnchor),
             buttonContainerView.leadingAnchor.constraint(equalTo: buttonContainerContainer.leadingAnchor),
             buttonContainerView.trailingAnchor.constraint(equalTo: buttonContainerContainer.trailingAnchor),
-            buttonContainerContainer.heightAnchor.constraint(equalTo: buttonContainerView.heightAnchor, multiplier: Parameters.buttonContainerScaleFactor),
+            buttonContainerContainer.heightAnchor.constraint(
+                equalTo: buttonContainerView.heightAnchor,
+                multiplier: Parameters.buttonContainerScaleFactor
+            ),
             buttonContainerContainer.leadingAnchor.constraint(equalTo: leadingAnchor),
             buttonContainerContainer.trailingAnchor.constraint(equalTo: trailingAnchor),
-            bottomConstraint,
+            bottomConstraint
         ])
     }
 
@@ -435,7 +482,7 @@ final class SiteAssemblyContentView: UIView {
             errorStateView.leadingAnchor.constraint(equalTo: leadingAnchor),
             errorStateView.trailingAnchor.constraint(equalTo: trailingAnchor),
             errorStateView.topAnchor.constraint(equalTo: topAnchor),
-            errorStateView.bottomAnchor.constraint(equalTo: bottomAnchor),
+            errorStateView.bottomAnchor.constraint(equalTo: bottomAnchor)
         ])
     }
 
@@ -448,37 +495,52 @@ final class SiteAssemblyContentView: UIView {
     }
 
     private func layoutInProgress() {
-        UIView.animate(withDuration: Parameters.animationDuration, delay: 0, options: .curveEaseOut, animations: { [weak self] in
-            guard let self else {
-                return
+        UIView.animate(
+            withDuration: Parameters.animationDuration,
+            delay: 0,
+            options: .curveEaseOut,
+            animations: { [weak self] in
+                guard let self else {
+                    return
+                }
+                self.errorStateView?.alpha = 0
+                self.statusStackView.alpha = 1
+                self.accessibilityElements = [self.statusMessageRotatingView.statusLabel]
             }
-            self.errorStateView?.alpha = 0
-            self.statusStackView.alpha = 1
-            self.accessibilityElements = [ self.statusMessageRotatingView.statusLabel ]
-        })
+        )
     }
 
     private func layoutFailed() {
-        UIView.animate(withDuration: Parameters.animationDuration, delay: 0, options: .curveEaseOut, animations: { [weak self] in
-            guard let self else {
-                return
-            }
+        UIView.animate(
+            withDuration: Parameters.animationDuration,
+            delay: 0,
+            options: .curveEaseOut,
+            animations: { [weak self] in
+                guard let self else {
+                    return
+                }
 
-            self.statusStackView.alpha = 0
+                self.statusStackView.alpha = 0
 
-            if let errorView = self.errorStateView {
-                errorView.alpha = 1
-                self.accessibilityElements = [ errorView ]
+                if let errorView = self.errorStateView {
+                    errorView.alpha = 1
+                    self.accessibilityElements = [errorView]
+                }
             }
-        })
+        )
     }
 
     private func layoutSucceeded() {
         assembledSiteView?.loadSiteIfNeeded()
 
-        UIView.animate(withDuration: Parameters.animationDuration, delay: 0, options: .curveEaseOut, animations: { [statusStackView] in
-            statusStackView.alpha = 0
-            }, completion: { [weak self] completed in
+        UIView.animate(
+            withDuration: Parameters.animationDuration,
+            delay: 0,
+            options: .curveEaseOut,
+            animations: { [statusStackView] in
+                statusStackView.alpha = 0
+            },
+            completion: { [weak self] completed in
                 guard completed, let self else {
                     return
                 }
@@ -487,38 +549,45 @@ final class SiteAssemblyContentView: UIView {
                 self.completionLabelTopConstraint?.constant = completionLabelTopInsetFinal
 
                 self.assembledSiteTopConstraint?.isActive = false
-                let transitionConstraint = self.assembledSiteView?.topAnchor.constraint(
-                    equalTo: self.completionLabelsStack.bottomAnchor,
-                    constant: Parameters.verticalSpacing
-                )
+                let transitionConstraint = self.assembledSiteView?.topAnchor
+                    .constraint(
+                        equalTo: self.completionLabelsStack.bottomAnchor,
+                        constant: Parameters.verticalSpacing
+                    )
                 transitionConstraint?.isActive = true
                 self.assembledSiteTopConstraint = transitionConstraint
 
                 self.buttonContainerBottomConstraint?.constant = 0
 
-                UIView.animate(withDuration: Parameters.animationDuration,
-                               delay: 0,
-                               options: .curveEaseOut,
-                               animations: { [weak self] in
-                    guard let self else {
-                        return
+                UIView.animate(
+                    withDuration: Parameters.animationDuration,
+                    delay: 0,
+                    options: .curveEaseOut,
+                    animations: { [weak self] in
+                        guard let self else {
+                            return
+                        }
+
+                        self.completionLabel.isHidden = false
+                        self.completionDescription.isHidden = false
+                        self.completionLabel.text =
+                            self.shouldShowDomainPurchase()
+                            ? Strings.Paid.completionTitle : Strings.Free.completionTitle
+                        self.completionDescription.text =
+                            self.shouldShowDomainPurchase() ? Strings.Paid.description : Strings.Free.description
+                        self.noticeView.isHidden = !self.shouldShowDomainPurchase()
+
+                        if let buttonView = self.buttonContainerView {
+                            self.accessibilityElements = [self.completionLabel, buttonView]
+                        } else {
+                            self.accessibilityElements = [self.completionLabel]
+                        }
+
+                        self.layoutIfNeeded()
                     }
-
-                    self.completionLabel.isHidden = false
-                    self.completionDescription.isHidden = false
-                    self.completionLabel.text = self.shouldShowDomainPurchase() ? Strings.Paid.completionTitle : Strings.Free.completionTitle
-                    self.completionDescription.text = self.shouldShowDomainPurchase() ? Strings.Paid.description : Strings.Free.description
-                    self.noticeView.isHidden = !self.shouldShowDomainPurchase()
-
-                    if let buttonView = self.buttonContainerView {
-                        self.accessibilityElements = [ self.completionLabel, buttonView ]
-                    } else {
-                        self.accessibilityElements = [ self.completionLabel ]
-                    }
-
-                    self.layoutIfNeeded()
-                })
-            })
+                )
+            }
+        )
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Site Creation/Final Assembly/SiteAssemblyWizardContent.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Final Assembly/SiteAssemblyWizardContent.swift
@@ -3,8 +3,6 @@ import WordPressData
 import WordPressKit
 import WordPressShared
 
-import WordPressAuthenticator
-
 // MARK: - SiteAssemblyWizardContent
 
 /// This view controller manages the final step in the enhanced site creation sequence - invoking the service &
@@ -30,9 +28,6 @@ final class SiteAssemblyWizardContent: UIViewController {
 
     /// The content view serves as the root view of this view controller.
     private let contentView: SiteAssemblyContentView
-
-    /// We reuse a `NUXButtonViewController` from `WordPressAuthenticator`. Ideally this might be in `WordPressUI`.
-    private let buttonViewController = NUXButtonViewController.instance()
 
     /// This view controller manages the interaction with error states that can arise during site assembly.
     private var errorStateViewController: ErrorStateViewController?
@@ -70,7 +65,7 @@ final class SiteAssemblyWizardContent: UIViewController {
         super.viewDidLoad()
 
         hidesBottomBarWhenPushed = true
-        installButtonViewController()
+        installButtonBar()
         SiteCreationAnalyticsHelper.trackSiteCreationSuccessLoading(siteCreator.design)
     }
 
@@ -168,20 +163,29 @@ final class SiteAssemblyWizardContent: UIViewController {
         }
     }
 
-    private func installButtonViewController() {
-        buttonViewController.delegate = self
-
-        let primaryButtonText = NSLocalizedString(
-            "Done",
-            comment: "Tapping a button with this label allows the user to exit the Site Creation flow"
+    private func installButtonBar() {
+        // The Jetpack app suppresses the bar's top shadow, matching the empty
+        // `buttonViewTopShadowImage` its authenticator style used to supply.
+        let buttonBar = SiteAssemblyButtonBar(
+            buttonTitle: SharedStrings.Button.done,
+            showsTopShadow: AppConfiguration.isWordPress
         )
-        buttonViewController.setButtonTitles(primary: primaryButtonText)
+        buttonBar.onTap = { [weak self] in
+            self?.doneButtonTapped()
+        }
 
-        contentView.buttonContainerView = buttonViewController.view
+        // installButtonContainerView computes the initial off-screen offset from
+        // bounds.height before Auto Layout runs. Only the height matters here, and
+        // it is width-independent (single-line button title), so the zero width
+        // that view.bounds may still have at viewDidLoad time is harmless.
+        let fittingSize = buttonBar.systemLayoutSizeFitting(
+            CGSize(width: view.bounds.width, height: UIView.layoutFittingCompressedSize.height),
+            withHorizontalFittingPriority: .required,
+            verticalFittingPriority: .fittingSizeLevel
+        )
+        buttonBar.frame = CGRect(origin: .zero, size: CGSize(width: view.bounds.width, height: fittingSize.height))
 
-        buttonViewController.willMove(toParent: self)
-        addChild(buttonViewController)
-        buttonViewController.didMove(toParent: self)
+        contentView.buttonContainerView = buttonBar
     }
 
     private func installErrorStateViewController(with type: ErrorStateViewType) {
@@ -272,20 +276,8 @@ private extension SiteAssemblyWizardContent {
         // TODO : using viaDone, capture analytics event via #10335
         attemptSiteCreation()
     }
-}
 
-// MARK: - NetworkStatusDelegate
-
-extension SiteAssemblyWizardContent: NetworkStatusDelegate {
-    func networkStatusDidChange(active: Bool) {
-        isNetworkActive = active
-    }
-}
-
-// MARK: - NUXButtonViewControllerDelegate
-
-extension SiteAssemblyWizardContent: NUXButtonViewControllerDelegate {
-    func primaryButtonPressed() {
+    func doneButtonTapped() {
         SiteCreationAnalyticsHelper.trackSiteCreationSuccessPreviewOkButtonTapped()
 
         guard let blog = createdBlog else { return }
@@ -296,5 +288,13 @@ extension SiteAssemblyWizardContent: NUXButtonViewControllerDelegate {
         dismissTapped(viaDone: true) { [blog] in
             RootViewCoordinator.sharedPresenter.showBlogDetails(for: blog)
         }
+    }
+}
+
+// MARK: - NetworkStatusDelegate
+
+extension SiteAssemblyWizardContent: NetworkStatusDelegate {
+    func networkStatusDidChange(active: Bool) {
+        isNetworkActive = active
     }
 }

--- a/WordPress/Classes/ViewRelated/Site Creation/Shared/ErrorStates/ErrorStateView.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Shared/ErrorStates/ErrorStateView.swift
@@ -1,6 +1,5 @@
 import UIKit
 import Gridicons
-import WordPressAuthenticator
 import WordPressUI
 
 // MARK: ErrorStateView
@@ -116,17 +115,10 @@ final class ErrorStateView: UIView {
 
         if let _ = configuration.retryActionHandler {
             self.retryButton = {
-                let button = NUXButton(frame: .zero)
+                let button = UIButton.makePrimaryNUXButton()
 
                 button.translatesAutoresizingMaskIntoConstraints = false
-                button.isPrimary = true
-
-                let titleText = NSLocalizedString(
-                    "Retry",
-                    comment:
-                        "If a user taps the button with this label, the action that evinced this error view will be retried."
-                )
-                button.setTitle(titleText, for: .normal)
+                button.configuration?.title = SharedStrings.Button.retry
 
                 return button
             }()

--- a/WordPress/Classes/ViewRelated/Site Creation/Shared/ErrorStates/ErrorStateView.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Shared/ErrorStates/ErrorStateView.swift
@@ -121,8 +121,11 @@ final class ErrorStateView: UIView {
                 button.translatesAutoresizingMaskIntoConstraints = false
                 button.isPrimary = true
 
-                let titleText = NSLocalizedString("Retry",
-                                                  comment: "If a user taps the button with this label, the action that evinced this error view will be retried.")
+                let titleText = NSLocalizedString(
+                    "Retry",
+                    comment:
+                        "If a user taps the button with this label, the action that evinced this error view will be retried."
+                )
                 button.setTitle(titleText, for: .normal)
 
                 return button
@@ -140,8 +143,10 @@ final class ErrorStateView: UIView {
                 label.textColor = UIAppColor.primary
                 label.textAlignment = .center
 
-                label.text = NSLocalizedString("Contact Support",
-                                               comment: "If a user taps this label, the app will navigate to the Support view.")
+                label.text = NSLocalizedString(
+                    "Contact Support",
+                    comment: "If a user taps this label, the app will navigate to the Support view."
+                )
                 label.sizeToFit()
 
                 return label
@@ -254,7 +259,10 @@ final class ErrorStateView: UIView {
 
         NSLayoutConstraint.activate([
             contactSupportLabel.centerXAnchor.constraint(equalTo: centerXAnchor),
-            contactSupportLabel.topAnchor.constraint(equalTo: contentStackView.bottomAnchor, constant: Parameters.supportTopInset)
+            contactSupportLabel.topAnchor.constraint(
+                equalTo: contentStackView.bottomAnchor,
+                constant: Parameters.supportTopInset
+            )
         ])
     }
 }


### PR DESCRIPTION
> [!Note]
> I recommend reviewing this PR commit by commit. The first commit is pure code format changes.

## Description

The WordPressAuthenticator library is being removed. A handful of app screens outside the sign-in flow still use its `NUXButton` and `NUXButtonViewController`, so they need their own buttons before the library can go. This PR converts those consumers to `UIButton.Configuration` in final form, so the library's button components can be deleted rather than moved into the app.

The main pieces:
1. A shared `UIButton.Configuration.primaryNUX()` / `configureAsPrimaryNUXButton()` helper reproduces the legacy `NUXButton` primary style (fill, highlighted/disabled colors, insets, font, and the spinner-in-place-of-title loading state), so the converted screens look the same as before.
2. The site-creation success screen's bottom bar, previously a storyboard-based `NUXButtonViewController`, is reimplemented as a small app-owned `SiteAssemblyButtonBar`, which drops the storyboard dependency. The Jetpack app keeps its suppressed top shadow.

| Before | After |
| - | - |
| <img alt="before-site-assembly-done" src="https://github.com/user-attachments/assets/9e04d835-2ede-4c87-8e36-f11869b70229" /> | <img alt="after-site-assembly-done" src="https://github.com/user-attachments/assets/8083d6bf-a936-4c1d-b5fe-3d7bbf5bab94" /> |
| <img width="1206" height="2622" alt="before-jetpack-connect" src="https://github.com/user-attachments/assets/a10e06f9-9cc4-4b31-8e25-b635bfb132a6" /> | <img width="1206" height="2622" alt="after-jetpack-connect" src="https://github.com/user-attachments/assets/ea69a377-772c-45ae-bd88-e2cb53229e94" /> |

## Testing instructions

The visible surfaces are
- the site-creation final ("Done") screen and its error state
- the domain registration details footer
- the plugin details "Update" button
- the legacy Jetpack connect screen (reachable from Stats/Notifications on a self-hosted site without Jetpack).