### PR TITLE
Exclude fastlane store metadata from CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -8,8 +8,7 @@ Gemfile*              @wordpress-mobile/apps-infra-tooling
 .bundle/              @wordpress-mobile/apps-infra-tooling
 .rubocop*.yml         @wordpress-mobile/apps-infra-tooling
 fastlane/             @wordpress-mobile/apps-infra-tooling
-# Store-listing localization is content, not infra — disown it to avoid
-# pinging the team on translation-only release churn.
+# Store-listing localization is content, not infra.
 fastlane/metadata/
 fastlane/jetpack_metadata/
 fastlane/reader_metadata/

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -8,6 +8,11 @@ Gemfile*              @wordpress-mobile/apps-infra-tooling
 .bundle/              @wordpress-mobile/apps-infra-tooling
 .rubocop*.yml         @wordpress-mobile/apps-infra-tooling
 fastlane/             @wordpress-mobile/apps-infra-tooling
+# Store-listing localization is content, not infra — disown it to avoid
+# pinging the team on translation-only release churn.
+fastlane/metadata/
+fastlane/jetpack_metadata/
+fastlane/reader_metadata/
 
 # CI and automation
 .buildkite/           @wordpress-mobile/apps-infra-tooling


### PR DESCRIPTION
Same rationale as https://github.com/wordpress-mobile/WordPress-Android/pull/22981

<details>
<summary>AI-generated PR details</summary>


The `fastlane/` CODEOWNERS rule claims the per-locale store-listing folders (`metadata/`, `jetpack_metadata/`, `reader_metadata/`), so release PRs that only bump localized changelogs request review from `@wordpress-mobile/apps-infra-tooling` for nothing.

This disowns those folders with owner-less overrides. A CODEOWNERS pattern with no owner removes ownership, and last-match-wins keeps it ahead of the broad `fastlane/` rule, so tooling under `fastlane/` (Fastfile, lanes, resources) stays owned.

Part of the `codeowners-metadata` wave ([AINFRA-2437](https://linear.app/a8c/issue/AINFRA-2437)); sibling repos with still-open routing PRs got the same change folded in.

## How to test

In the repo's CODEOWNERS view, a file under `fastlane/metadata/` shows no owner, while `fastlane/Fastfile` still shows `@wordpress-mobile/apps-infra-tooling`.

---

Posted by Claude Code (Opus 4.8) on behalf of @mokagio with approval.


</details>