### PR TITLE
Use directionalLayoutMargins for symmetric layout margins

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Blaze/DashboardBlazeCampaignsCardView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Blaze/DashboardBlazeCampaignsCardView.swift
@@ -57,7 +57,7 @@ final class DashboardBlazeCampaignsCardView: UIView {
         frameView.add(subview: contentStackView)
         contentStackView.addArrangedSubview({
             let container = UIStackView(arrangedSubviews: [campaignView])
-            container.layoutMargins = Constants.campaignViewInsets
+            container.directionalLayoutMargins = Constants.campaignViewInsets
             container.isLayoutMarginsRelativeArrangement = true
             return container
         }())
@@ -147,7 +147,7 @@ private extension DashboardBlazeCampaignsCardView {
     }
 
     enum Constants {
-        static let campaignViewInsets = UIEdgeInsets(top: 16, left: 16, bottom: 16, right: 16)
+        static let campaignViewInsets = NSDirectionalEdgeInsets(top: 16, leading: 16, bottom: 16, trailing: 16)
         static let createCampaignInsets = NSDirectionalEdgeInsets(top: 16, leading: 16, bottom: 8, trailing: 16)
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Prompts/DashboardPromptsCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Prompts/DashboardPromptsCardCell.swift
@@ -81,7 +81,7 @@ class DashboardPromptsCardCell: UICollectionViewCell, Reusable {
         stackView.alignment = .center
         stackView.translatesAutoresizingMaskIntoConstraints = false
         stackView.spacing = Constants.spacing
-        stackView.layoutMargins = Constants.containerMargins
+        stackView.directionalLayoutMargins = Constants.containerMargins
         stackView.isLayoutMarginsRelativeArrangement = true
         return stackView
     }()
@@ -576,7 +576,7 @@ private extension DashboardPromptsCardCell {
         static let answeredButtonsSpacing: CGFloat = 16
         static let answerInfoViewSpacing: CGFloat = 6
         static let attributionTrailingImageSpacing: CGFloat = 6
-        static let containerMargins = UIEdgeInsets(top: 0, left: 16, bottom: 0, right: 16)
+        static let containerMargins = NSDirectionalEdgeInsets(top: 0, leading: 16, bottom: 0, trailing: 16)
         static let maxAvatarCount = 3
         static let exampleAnswerCount = 19
         static let cardFrameConstraintPriority = UILayoutPriority(999)

--- a/WordPress/Classes/ViewRelated/Comments/Views/Detail/CommentContentTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Comments/Views/Detail/CommentContentTableViewCell.swift
@@ -231,7 +231,7 @@ final class CommentContentTableViewCell: UITableViewCell, NibReusable {
 
     func configureForCommentDetails() {
         containerStackView.isLayoutMarginsRelativeArrangement = true
-        containerStackView.layoutMargins = UIEdgeInsets(.vertical, 4)
+        containerStackView.directionalLayoutMargins = NSDirectionalEdgeInsets(top: 4, leading: 0, bottom: 4, trailing: 0)
     }
 
     private func configure(with state: CommentCellViewModel.State) {

--- a/WordPress/Classes/ViewRelated/Me/My Profile/Change Username/ChangeUsernameViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/My Profile/Change Username/ChangeUsernameViewController.swift
@@ -43,7 +43,7 @@ final class ChangeUsernameViewController: UITableViewController {
         trackViewLoaded()
 
         WPStyleGuide.configureColors(view: view, tableView: tableView)
-        tableView.layoutMargins = WPStyleGuide.edgeInsetForLoginTextFields()
+        tableView.directionalLayoutMargins = WPStyleGuide.edgeInsetForLoginTextFields()
 
         setupViewModel()
         setupUI()

--- a/WordPress/Classes/ViewRelated/Me/Views/MeHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Me/Views/MeHeaderView.swift
@@ -115,7 +115,7 @@ final class MeHeaderView: UIView {
     func configureHorizontalMode() {
         stackView.axis = .horizontal
         stackView.spacing = 16
-        stackView.layoutMargins = UIEdgeInsets(horizontal: 30, vertical: 6)
+        stackView.directionalLayoutMargins = NSDirectionalEdgeInsets(top: 6, leading: 30, bottom: 6, trailing: 30)
         infoStackView.alignment = .leading
         setIconSize(40)
     }

--- a/WordPress/Classes/ViewRelated/Media/SiteMedia/Controllers/SiteMediaPreviewViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/SiteMedia/Controllers/SiteMediaPreviewViewController.swift
@@ -111,7 +111,7 @@ final class SiteMediaPreviewViewController: UIViewController {
 
         let container = UIStackView(arrangedSubviews: [infoView])
         container.alignment = .center
-        container.layoutMargins = UIEdgeInsets(.all, 8)
+        container.directionalLayoutMargins = NSDirectionalEdgeInsets(top: 8, leading: 8, bottom: 8, trailing: 8)
         container.isLayoutMarginsRelativeArrangement = true
         container.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(container)

--- a/WordPress/Classes/ViewRelated/Media/StockPhotos/StockPhotosWelcomeView.swift
+++ b/WordPress/Classes/ViewRelated/Media/StockPhotos/StockPhotosWelcomeView.swift
@@ -29,7 +29,7 @@ final class StockPhotosWelcomeView: UIView {
         stack.alignment = .center
         stack.spacing = 24
         stack.isLayoutMarginsRelativeArrangement = true
-        stack.layoutMargins = UIEdgeInsets(top: 16, left: 32, bottom: 16, right: 32)
+        stack.directionalLayoutMargins = NSDirectionalEdgeInsets(top: 16, leading: 32, bottom: 16, trailing: 32)
 
         let wrapper = UIStackView(arrangedSubviews: [stack])
         wrapper.alignment = .center

--- a/WordPress/Classes/ViewRelated/Menus/Categories/Menu+ViewDesign.h
+++ b/WordPress/Classes/ViewRelated/Menus/Categories/Menu+ViewDesign.h
@@ -12,7 +12,7 @@ extern CGFloat const MenusDesignDefaultContentSpacing;
  */
 @interface Menu (ViewDesign)
 
-+ (UIEdgeInsets)viewDefaultDesignInsets;
++ (NSDirectionalEdgeInsets)viewDefaultDesignInsets;
 
 @end
 

--- a/WordPress/Classes/ViewRelated/Menus/Categories/Menu+ViewDesign.m
+++ b/WordPress/Classes/ViewRelated/Menus/Categories/Menu+ViewDesign.m
@@ -6,9 +6,9 @@ CGFloat const MenusDesignDefaultContentSpacing = 16.0;
 
 @implementation Menu (ViewDesign)
 
-+ (UIEdgeInsets)viewDefaultDesignInsets
++ (NSDirectionalEdgeInsets)viewDefaultDesignInsets
 {
-    return UIEdgeInsetsMake(10.0, 10.0, 10.0, 10.0);
+    return NSDirectionalEdgeInsetsMake(10.0, 10.0, 10.0, 10.0);
 }
 
 @end

--- a/WordPress/Classes/ViewRelated/Menus/Controllers/MenuDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Menus/Controllers/MenuDetailsViewController.m
@@ -32,10 +32,10 @@ static NSTimeInterval const TextfieldEditingAnimationDuration = 0.3;
     [super viewDidLoad];
 
     self.stackView.layoutMarginsRelativeArrangement = YES;
-    UIEdgeInsets margin = [Menu viewDefaultDesignInsets];
+    NSDirectionalEdgeInsets margin = [Menu viewDefaultDesignInsets];
     margin.top = 0;
     margin.bottom = 0;
-    self.stackView.layoutMargins = margin;
+    self.stackView.directionalLayoutMargins = margin;
     self.stackView.spacing = 4.0;
 
     [self setupTextField];

--- a/WordPress/Classes/ViewRelated/Menus/Controllers/MenuItemSourceResultsViewController.m
+++ b/WordPress/Classes/ViewRelated/Menus/Controllers/MenuItemSourceResultsViewController.m
@@ -79,11 +79,11 @@ static CGFloat const SearchBarHeight = 44.0;
     stackView.axis = UILayoutConstraintAxisVertical;
     stackView.spacing = MenusDesignDefaultContentSpacing / 2.0;
 
-    UIEdgeInsets margins = UIEdgeInsetsZero;
+    NSDirectionalEdgeInsets margins = NSDirectionalEdgeInsetsZero;
     margins.bottom = stackView.spacing;
-    margins.left = MenusDesignDefaultContentSpacing;
-    margins.right = MenusDesignDefaultContentSpacing;
-    stackView.layoutMargins = margins;
+    margins.leading = MenusDesignDefaultContentSpacing;
+    margins.trailing = MenusDesignDefaultContentSpacing;
+    stackView.directionalLayoutMargins = margins;
     stackView.layoutMarginsRelativeArrangement = YES;
 
     NSAssert(_stackedTableHeaderView != nil, @"stackedTableHeaderView is nil");

--- a/WordPress/Classes/ViewRelated/Menus/Controllers/MenusViewController.m
+++ b/WordPress/Classes/ViewRelated/Menus/Controllers/MenusViewController.m
@@ -81,7 +81,7 @@ static CGFloat const ScrollViewOffsetAdjustmentPadding = 10.0;
     self.scrollView.delegate = self;
 
     // add a bit of padding to the scrollable content
-    self.stackView.layoutMargins = UIEdgeInsetsMake(0, 0, 10, 0);
+    self.stackView.directionalLayoutMargins = NSDirectionalEdgeInsetsMake(0, 0, 10, 0);
     self.stackView.layoutMarginsRelativeArrangement = YES;
 
     self.headerViewController.delegate = self;

--- a/WordPress/Classes/ViewRelated/Menus/Views/MenuItemAbstractView.m
+++ b/WordPress/Classes/ViewRelated/Menus/Views/MenuItemAbstractView.m
@@ -91,12 +91,12 @@ CGFloat const MenuItemsStackableViewDefaultHeight = 44.0;
                                               [stackView.bottomAnchor constraintEqualToAnchor:_contentView.bottomAnchor]
                                               ]];
 
-    UIEdgeInsets margins = UIEdgeInsetsZero;
+    NSDirectionalEdgeInsets margins = NSDirectionalEdgeInsetsZero;
     margins.top = 8.0;
     margins.bottom = 8.0;
-    margins.left = MenusDesignDefaultContentSpacing;
-    margins.right = MenusDesignDefaultContentSpacing;
-    stackView.layoutMargins = margins;
+    margins.leading = MenusDesignDefaultContentSpacing;
+    margins.trailing = MenusDesignDefaultContentSpacing;
+    stackView.directionalLayoutMargins = margins;
     stackView.layoutMarginsRelativeArrangement = YES;
     stackView.distribution = UIStackViewDistributionFill;
     stackView.alignment = UIStackViewAlignmentCenter;

--- a/WordPress/Classes/ViewRelated/Menus/Views/MenuItemSourceCell.m
+++ b/WordPress/Classes/ViewRelated/Menus/Views/MenuItemSourceCell.m
@@ -51,13 +51,13 @@ static CGFloat const MenuItemSourceCellHierarchyIdentationWidth = 17.0;
     stackView.alignment = UIStackViewAlignmentLeading;
     stackView.axis = UILayoutConstraintAxisHorizontal;
 
-    UIEdgeInsets margins = UIEdgeInsetsZero;
+    NSDirectionalEdgeInsets margins = NSDirectionalEdgeInsetsZero;
     margins.top = 10.0;
-    margins.left = MenusDesignDefaultContentSpacing;
-    margins.right = MenusDesignDefaultContentSpacing;
+    margins.leading = MenusDesignDefaultContentSpacing;
+    margins.trailing = MenusDesignDefaultContentSpacing;
     margins.bottom = 10.0;
 
-    stackView.layoutMargins = margins;
+    stackView.directionalLayoutMargins = margins;
     stackView.layoutMarginsRelativeArrangement = YES;
     stackView.spacing = MenusDesignDefaultContentSpacing / 2.0;
     [self.contentView addSubview:stackView];

--- a/WordPress/Classes/ViewRelated/Menus/Views/MenusSelectionDetailView.m
+++ b/WordPress/Classes/ViewRelated/Menus/Views/MenusSelectionDetailView.m
@@ -25,12 +25,12 @@
 
     self.translatesAutoresizingMaskIntoConstraints = NO;
 
-    UIEdgeInsets margins = UIEdgeInsetsZero;
+    NSDirectionalEdgeInsets margins = NSDirectionalEdgeInsetsZero;
     CGFloat spacing = MenusDesignDefaultContentSpacing;
     // Spacing + tweak for design stroke offset.
-    margins.left = spacing;
-    margins.right = spacing;
-    self.stackView.layoutMargins = margins;
+    margins.leading = spacing;
+    margins.trailing = spacing;
+    self.stackView.directionalLayoutMargins = margins;
     self.stackView.layoutMarginsRelativeArrangement = YES;
     self.stackView.distribution = UIStackViewDistributionFill;
     self.stackView.alignment = UIStackViewAlignmentCenter;
@@ -66,7 +66,7 @@
     stackView.alignment = UIStackViewAlignmentFill;
     stackView.distribution = UIStackViewDistributionFill;
     stackView.axis = UILayoutConstraintAxisVertical;
-    stackView.layoutMargins = UIEdgeInsetsMake(14, 0, 14, 0);
+    stackView.directionalLayoutMargins = NSDirectionalEdgeInsetsMake(14, 0, 14, 0);
     stackView.layoutMarginsRelativeArrangement = YES;
     [stackView setContentHuggingPriority:UILayoutPriorityDefaultLow forAxis:UILayoutConstraintAxisHorizontal];
     _labelsStackView = stackView;

--- a/WordPress/Classes/ViewRelated/Menus/Views/MenusSelectionItemView.m
+++ b/WordPress/Classes/ViewRelated/Menus/Views/MenusSelectionItemView.m
@@ -53,10 +53,10 @@
     stackView.axis = UILayoutConstraintAxisHorizontal;
     stackView.distribution = UIStackViewDistributionFill;
 
-    UIEdgeInsets insets = UIEdgeInsetsZero;
-    insets.left = MenusDesignDefaultContentSpacing;
-    insets.right = MenusDesignDefaultContentSpacing;
-    stackView.layoutMargins = insets;
+    NSDirectionalEdgeInsets insets = NSDirectionalEdgeInsetsZero;
+    insets.leading = MenusDesignDefaultContentSpacing;
+    insets.trailing = MenusDesignDefaultContentSpacing;
+    stackView.directionalLayoutMargins = insets;
     stackView.layoutMarginsRelativeArrangement = YES;
     stackView.spacing = MenusDesignDefaultContentSpacing / 2.0;
 

--- a/WordPress/Classes/ViewRelated/NUX/Helpers/WPStyleGuide+SiteCreation.swift
+++ b/WordPress/Classes/ViewRelated/NUX/Helpers/WPStyleGuide+SiteCreation.swift
@@ -2,8 +2,8 @@ import WordPressShared
 
 extension WPStyleGuide {
 
-    class func edgeInsetForLoginTextFields() -> UIEdgeInsets {
-        return UIEdgeInsets(top: 7, left: 20, bottom: 7, right: 20)
+    class func edgeInsetForLoginTextFields() -> NSDirectionalEdgeInsets {
+        return NSDirectionalEdgeInsets(top: 7, leading: 20, bottom: 7, trailing: 20)
     }
 
     /// Return the system font in medium weight for the given style

--- a/WordPress/Classes/ViewRelated/Post/Search/PostSearchTokenTableCell.swift
+++ b/WordPress/Classes/ViewRelated/Post/Search/PostSearchTokenTableCell.swift
@@ -20,7 +20,7 @@ final class PostSearchTokenTableCell: UITableViewCell {
         stackView.spacing = 8
         stackView.alignment = .center
         stackView.isLayoutMarginsRelativeArrangement = true
-        stackView.layoutMargins = UIEdgeInsets(top: 4, left: 16, bottom: 12, right: 16)
+        stackView.directionalLayoutMargins = NSDirectionalEdgeInsets(top: 4, leading: 16, bottom: 12, trailing: 16)
         stackView.translatesAutoresizingMaskIntoConstraints = false
 
         contentView.addSubview(stackView)

--- a/WordPress/Classes/ViewRelated/System/Notices/NoticePresenter.swift
+++ b/WordPress/Classes/ViewRelated/System/Notices/NoticePresenter.swift
@@ -469,7 +469,7 @@ private extension UIWindow {
 ///
 class NoticeContainerView: UIView {
     /// The space between the Notice and its parent View
-    private let containerMargin = UIEdgeInsets(top: 8.0, left: 8.0, bottom: 15.0, right: 8.0)
+    private let containerMargin = NSDirectionalEdgeInsets(top: 8.0, leading: 8.0, bottom: 15.0, trailing: 8.0)
     var bottomConstraint: NSLayoutConstraint?
     var topConstraint: NSLayoutConstraint?
     var noticeWidthConstraint: NSLayoutConstraint?
@@ -483,7 +483,7 @@ class NoticeContainerView: UIView {
 
         translatesAutoresizingMaskIntoConstraints = false
 
-        layoutMargins = containerMargin
+        directionalLayoutMargins = containerMargin
 
         // Padding views on either side, of equal width to ensure centering
         let leftPaddingView = UIView()

--- a/WordPress/Classes/ViewRelated/System/Notices/NoticeStyle.swift
+++ b/WordPress/Classes/ViewRelated/System/Notices/NoticeStyle.swift
@@ -28,7 +28,7 @@ public protocol NoticeStyle {
     var backgroundColor: UIColor { get }
 
     /// The space between the border of the Notice and the contents (title, label, and buttons).
-    var layoutMargins: UIEdgeInsets { get }
+    var directionalLayoutMargins: NSDirectionalEdgeInsets { get }
 
     // Misc
     var isDismissable: Bool { get }
@@ -61,7 +61,7 @@ public struct NormalNoticeStyle: NoticeStyle {
     public var actionButtonFont: UIFont? { return UIFont.systemFont(ofSize: 14.0, weight: .medium) }
     public let cancelButtonFont: UIFont? = nil
 
-    public let layoutMargins = UIEdgeInsets(top: 10.0, left: 16.0, bottom: 10.0, right: 16.0)
+    public let directionalLayoutMargins = NSDirectionalEdgeInsets(top: 10.0, leading: 16.0, bottom: 10.0, trailing: 16.0)
 
     public let isDismissable = true
     public var showNextArrow = false
@@ -83,7 +83,7 @@ public struct InAppUpdateNoticeStyle: NoticeStyle {
     public var actionButtonFont: UIFont? { return WPStyleGuide.fontForTextStyle(.headline) }
     public var cancelButtonFont: UIFont? { return WPStyleGuide.fontForTextStyle(.body) }
 
-    public let layoutMargins = UIEdgeInsets(top: 13.0, left: 16.0, bottom: 13.0, right: 16.0)
+    public let directionalLayoutMargins = NSDirectionalEdgeInsets(top: 13.0, leading: 16.0, bottom: 13.0, trailing: 16.0)
 
     public var isDismissable = false
     public let showNextArrow = false

--- a/WordPress/Classes/ViewRelated/System/Notices/NoticeView.swift
+++ b/WordPress/Classes/ViewRelated/System/Notices/NoticeView.swift
@@ -123,8 +123,8 @@ class NoticeView: UIView {
         // the shadow only appears _outside_ of the notice roundrect, and doesn't appear underneath
         // and obscure the blur visual effect view.
         let maskPath = CGMutablePath()
-        let leftInset = notice.style.layoutMargins.left * 2
-        let topInset = notice.style.layoutMargins.top * 2
+        let leftInset = notice.style.directionalLayoutMargins.leading * 2
+        let topInset = notice.style.directionalLayoutMargins.top * 2
         maskPath.addRect(bounds.insetBy(dx: -leftInset, dy: -topInset))
         maskPath.addPath(shadowPath)
         shadowMaskLayer.path = maskPath
@@ -143,7 +143,7 @@ class NoticeView: UIView {
         labelStackView.axis = .vertical
         labelStackView.spacing = Metrics.labelLineSpacing
         labelStackView.isLayoutMarginsRelativeArrangement = true
-        labelStackView.layoutMargins = notice.style.layoutMargins
+        labelStackView.directionalLayoutMargins = notice.style.directionalLayoutMargins
 
         labelStackView.addArrangedSubview(titleLabel)
         labelStackView.addArrangedSubview(messageLabel)
@@ -177,7 +177,7 @@ class NoticeView: UIView {
         contentStackView.addArrangedSubview(actionBackgroundView)
         actionBackgroundView.translatesAutoresizingMaskIntoConstraints = false
 
-        actionBackgroundView.layoutMargins = notice.style.layoutMargins
+        actionBackgroundView.directionalLayoutMargins = notice.style.directionalLayoutMargins
         actionBackgroundView.backgroundColor = notice.style.backgroundColor
 
         actionBackgroundView.addSubview(actionButton)
@@ -235,12 +235,12 @@ class NoticeView: UIView {
         cancelBackgroundView.translatesAutoresizingMaskIntoConstraints = false
 
         actionBackgroundView.addSubview(actionButton)
-        actionBackgroundView.layoutMargins = Metrics.dualLayoutMargins
+        actionBackgroundView.directionalLayoutMargins = Metrics.dualLayoutMargins
         actionBackgroundView.pinSubviewToAllEdgeMargins(actionButton)
         actionBackgroundView.addTopBorder()
 
         cancelBackgroundView.addSubview(cancelButton)
-        cancelBackgroundView.layoutMargins = Metrics.dualLayoutMargins
+        cancelBackgroundView.directionalLayoutMargins = Metrics.dualLayoutMargins
         cancelBackgroundView.pinSubviewToAllEdgeMargins(cancelButton)
         cancelBackgroundView.addTopBorder()
         cancelBackgroundView.addTrailingBorder()
@@ -269,7 +269,7 @@ class NoticeView: UIView {
 
         contentStackView.addArrangedSubview(actionBackgroundView)
         actionBackgroundView.translatesAutoresizingMaskIntoConstraints = false
-        actionBackgroundView.layoutMargins = notice.style.layoutMargins
+        actionBackgroundView.directionalLayoutMargins = notice.style.directionalLayoutMargins
         actionBackgroundView.backgroundColor = notice.style.backgroundColor
 
         NSLayoutConstraint.activate([
@@ -377,7 +377,7 @@ class NoticeView: UIView {
 
     private enum Metrics {
         static let cornerRadius: CGFloat = 4.0
-        static let dualLayoutMargins = UIEdgeInsets(top: 6.0, left: 6.0, bottom: 6.0, right: 6.0)
+        static let dualLayoutMargins = NSDirectionalEdgeInsets(top: 6.0, leading: 6.0, bottom: 6.0, trailing: 6.0)
         static let labelLineSpacing: CGFloat = 3.0
         static let arrowSize = CGSize(width: 20, height: 10)
         static let arrowPosition: CGFloat = -24 /// Arrow is positioned along the right hand side by default.


### PR DESCRIPTION
Replace horizontally symmetric UIEdgeInsets layoutMargins writes with NSDirectionalEdgeInsets directionalLayoutMargins so the affected stack views and views resolve leading and trailing edges correctly under right-to-left layouts. Each site has equal left and right insets, so the change preserves the existing visual behavior.
