### PR TITLE
Make UIStackView convenience initializer use directional layout margins

### DIFF
--- a/Modules/Sources/WordPressUI/Extensions/UIStackView+Extensions.swift
+++ b/Modules/Sources/WordPressUI/Extensions/UIStackView+Extensions.swift
@@ -6,7 +6,7 @@ extension UIStackView {
         alignment: UIStackView.Alignment = .fill,
         distribution: UIStackView.Distribution = .fill,
         spacing: CGFloat? = nil,
-        insets: UIEdgeInsets? = nil,
+        insets: NSDirectionalEdgeInsets? = nil,
         _ arrangedSubviews: [UIView]
     ) {
         self.init(arrangedSubviews: arrangedSubviews)
@@ -18,7 +18,7 @@ extension UIStackView {
         }
         if let insets {
             self.isLayoutMarginsRelativeArrangement = true
-            self.layoutMargins = insets
+            self.directionalLayoutMargins = insets
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/Me/Views/MeHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Me/Views/MeHeaderView.swift
@@ -18,7 +18,7 @@ final class MeHeaderView: UIView {
         axis: .vertical,
         alignment: .center,
         spacing: 10,
-        insets: UIEdgeInsets(horizontal: 20, vertical: 8),
+        insets: NSDirectionalEdgeInsets(top: 8, leading: 20, bottom: 8, trailing: 20),
         [iconView, infoStackView]
     )
 

--- a/WordPress/Classes/ViewRelated/Reader/Cards/ReaderRecommendedTagsCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Cards/ReaderRecommendedTagsCell.swift
@@ -6,7 +6,7 @@ import WordPressUI
 /// - warning: The tags no longer gets shown since v26.6.
 final class ReaderRecommendedTagsCell: UITableViewCell {
     private let scrollView = UIScrollView()
-    private let tagsStackView = UIStackView(axis: .horizontal, spacing: 8, insets: UIEdgeInsets(.vertical, 16), [])
+    private let tagsStackView = UIStackView(axis: .horizontal, spacing: 8, insets: NSDirectionalEdgeInsets(top: 16, leading: 0, bottom: 16, trailing: 0), [])
 
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)

--- a/WordPress/Classes/ViewRelated/Reader/Controllers/ReaderStreamViewController+Ghost.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Controllers/ReaderStreamViewController+Ghost.swift
@@ -50,7 +50,7 @@ private final class ReaderGhostCompactCell: ReaderStreamBaseCell {
         imageView.heightAnchor.constraint(equalTo: imageView.widthAnchor, multiplier: ReaderPostCell.coverAspectRatio).isActive = true
 
         let titleLabel = makeLeafView(height: 18, width: .random(in: 140...200))
-        let stackView = UIStackView(axis: .vertical, alignment: .leading, spacing: 12, insets: UIEdgeInsets(.vertical, 16), [
+        let stackView = UIStackView(axis: .vertical, alignment: .leading, spacing: 12, insets: NSDirectionalEdgeInsets(top: 16, leading: 0, bottom: 16, trailing: 0), [
             titleLabel,
             UIStackView(axis: .vertical, alignment: .leading, spacing: 8, [
                 makeLeafView(height: 10, width: .random(in: 300...600)),
@@ -100,7 +100,7 @@ private final class ReaderGhostRegularCell: ReaderStreamBaseCell {
             ])
         ])
 
-        let stackView = UIStackView(axis: .vertical, alignment: .leading, spacing: 20, insets: UIEdgeInsets(.vertical, 16), [
+        let stackView = UIStackView(axis: .vertical, alignment: .leading, spacing: 20, insets: NSDirectionalEdgeInsets(top: 16, leading: 0, bottom: 16, trailing: 0), [
             makeLeafView(height: 10, width: .random(in: 120...180)),
             UIStackView(axis: .horizontal, alignment: .top, spacing: 18, [
                 leftStackView,


### PR DESCRIPTION
Change the insets parameter of the UIStackView convenience initializer to NSDirectionalEdgeInsets so the stack view's directional layout margins are set directly. All call sites pass horizontally symmetric insets, so the change preserves the existing visual behavior while supporting right-to-left layouts.
