### PR TITLE
Use directional layout margins for asymmetric insets

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/BlogDashboardCardFrameView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/BlogDashboardCardFrameView.swift
@@ -18,7 +18,7 @@ class BlogDashboardCardFrameView: UIView {
     /// Header in which icon, title and chevron are added
     private lazy var headerStackView: UIStackView = {
         let topStackView = UIStackView()
-        topStackView.layoutMargins = Constants.headerPaddingWithEllipsisButtonHidden
+        topStackView.directionalLayoutMargins = Constants.headerPaddingWithEllipsisButtonHidden
         topStackView.isLayoutMarginsRelativeArrangement = true
         topStackView.spacing = Constants.headerHorizontalSpacing
         topStackView.alignment = .center
@@ -129,7 +129,7 @@ class BlogDashboardCardFrameView: UIView {
         if !ellipsisButton.isHidden {
             mainStackViewTrailingConstraint?.constant = -Constants.mainStackViewTrailingPadding
             if #available(iOS 26, *) {
-                buttonContainerStackView.layoutMargins = UIEdgeInsets(.top, 5)
+                buttonContainerStackView.directionalLayoutMargins = NSDirectionalEdgeInsets(top: 5, leading: 0, bottom: 0, trailing: 0)
                 buttonContainerStackView.isLayoutMarginsRelativeArrangement = true
             }
         }
@@ -168,7 +168,7 @@ class BlogDashboardCardFrameView: UIView {
         ])
 
         if #available(iOS 26, *) {
-            mainStackView.layoutMargins = .init(top: 5, left: 0, bottom: 5, right: 0)
+            mainStackView.directionalLayoutMargins = NSDirectionalEdgeInsets(top: 5, leading: 0, bottom: 5, trailing: 0)
             mainStackView.isLayoutMarginsRelativeArrangement = true
         }
 
@@ -214,7 +214,7 @@ class BlogDashboardCardFrameView: UIView {
         let headerPadding = ellipsisButton.isHidden ?
             Constants.headerPaddingWithEllipsisButtonHidden :
             Constants.headerPaddingWithEllipsisButtonShown
-        headerStackView.layoutMargins = headerPadding
+        headerStackView.directionalLayoutMargins = headerPadding
     }
 
     private func addHeaderTapGestureIfNeeded() {
@@ -265,8 +265,8 @@ class BlogDashboardCardFrameView: UIView {
 
     private enum Constants {
         static let bottomPadding: CGFloat = 8
-        static let headerPaddingWithEllipsisButtonHidden = UIEdgeInsets(top: 12, left: 16, bottom: 8, right: 16)
-        static let headerPaddingWithEllipsisButtonShown = UIEdgeInsets(top: 12, left: 16, bottom: 8, right: 8)
+        static let headerPaddingWithEllipsisButtonHidden = NSDirectionalEdgeInsets(top: 12, leading: 16, bottom: 8, trailing: 16)
+        static let headerPaddingWithEllipsisButtonShown = NSDirectionalEdgeInsets(top: 12, leading: 16, bottom: 8, trailing: 8)
         static let headerHorizontalSpacing: CGFloat = 5
         static let cornerRadius = DesignConstants.radius(.large)
         static let buttonContainerStackViewPadding: CGFloat = 8

--- a/WordPress/Classes/ViewRelated/Menus/Views/MenuItemEditingHeaderView.m
+++ b/WordPress/Classes/ViewRelated/Menus/Views/MenuItemEditingHeaderView.m
@@ -81,16 +81,16 @@
     NSAssert(_stackView != nil, @"stackView is nil");
     [_stackView addArrangedSubview:textFieldContainerView];
 
-    UIEdgeInsets margins = UIEdgeInsetsZero;
+    NSDirectionalEdgeInsets margins = NSDirectionalEdgeInsetsZero;
     margins.top = [self defaultStackDesignMargin];
     // Margins for the textFieldContainerView inset the textField.
-    margins.left = MenusDesignDefaultContentSpacing / 2.0;
-    // Inset the right margin a bit less than the left
+    margins.leading = MenusDesignDefaultContentSpacing / 2.0;
+    // Inset the trailing margin a bit less than the leading
     // since the textField also draws the close button and
-    // input area inset on the right.
-    margins.right = MenusDesignDefaultContentSpacing / 4.0;
+    // input area inset on the trailing side.
+    margins.trailing = MenusDesignDefaultContentSpacing / 4.0;
     margins.bottom = margins.top;
-    textFieldContainerView.layoutMargins = margins;
+    textFieldContainerView.directionalLayoutMargins = margins;
     textFieldContainerView.insetsLayoutMarginsFromSafeArea = YES;
 
     UILayoutGuide *marginGuide = textFieldContainerView.layoutMarginsGuide;

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/TopTotalsCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/TopTotalsCell.swift
@@ -26,7 +26,7 @@ final class TopTotalsCell: StatsRowsCell, NibLoadable {
 
             if let topAccessoryView {
                 outerStackView.insertArrangedSubview(topAccessoryView, at: 0)
-                topAccessoryView.layoutMargins = subtitleStackView.layoutMargins
+                topAccessoryView.directionalLayoutMargins = subtitleStackView.directionalLayoutMargins
                 outerStackView.setCustomSpacing(Metrics.topAccessoryViewSpacing, after: topAccessoryView)
             }
         }


### PR DESCRIPTION
| Before | After |
| --- | --- |
| <img width="300" alt="before-rtl-menuitem" src="https://github.com/user-attachments/assets/cc10836c-d4a9-415e-9c0a-e8919818c89d" /> | <img width="300" alt="after-rtl-menuitem" src="https://github.com/user-attachments/assets/57236d5e-53be-44e0-8616-99d34d05d51c" /> |
| <img width="300" alt="before-rtl-dashboard" src="https://github.com/user-attachments/assets/3f057bff-210b-4776-b7d6-996cef62b386" /> | <img width="300" alt="after-rtl-dashboard" src="https://github.com/user-attachments/assets/4e578960-69f5-4234-b4a8-618f9ea13b01" /> |