### PR TITLE
Localization: drop stale WordPressKit remote-extraction path

### DIFF
--- a/fastlane/lanes/localization.rb
+++ b/fastlane/lanes/localization.rb
@@ -101,8 +101,7 @@ MANUALLY_MAINTAINED_STRINGS_FILES = {
 }.freeze
 
 # Remote Swift Packages whose localizable strings we want to extract (they're checked out under Derived Data
-# during resolvePackageDependencies). Currently none: WordPressKit is now vendored under Modules/Sources, so
-# it's already covered by the `Modules/Sources/` path below.
+# during resolvePackageDependencies). Currently none. Leaving here for future-proofing.
 REMOTE_SWIFT_PACKAGES_TO_LOCALIZE = [].freeze
 
 # Application-agnostic settings for the `upload_to_app_store` action (also known as `deliver`).

--- a/fastlane/lanes/localization.rb
+++ b/fastlane/lanes/localization.rb
@@ -100,10 +100,10 @@ MANUALLY_MAINTAINED_STRINGS_FILES = {
   File.join('WordPress', 'JetpackIntents', 'en.lproj', 'Sites.strings') => 'ios-widget.' # Strings from the `.intentdefinition`, used for configuring the iOS Widget
 }.freeze
 
-# The names of the remote Swift Packages that we want to add to our localizations, as they'll be checked out during resolvePackageDependencies in the Derived Data folder
-REMOTE_SWIFT_PACKAGES_TO_LOCALIZE = %w[
-  WordPressKit-iOS
-].freeze
+# Remote Swift Packages whose localizable strings we want to extract (they're checked out under Derived Data
+# during resolvePackageDependencies). Currently none: WordPressKit is now vendored under Modules/Sources, so
+# it's already covered by the `Modules/Sources/` path below.
+REMOTE_SWIFT_PACKAGES_TO_LOCALIZE = [].freeze
 
 # Application-agnostic settings for the `upload_to_app_store` action (also known as `deliver`).
 # Used in `update_*_metadata_on_app_store_connect` lanes.


### PR DESCRIPTION
Minimal cleanup spotted while auditing the localization pipeline.

## Summary

- `REMOTE_SWIFT_PACKAGES_TO_LOCALIZE` listed `WordPressKit-iOS`, so `generate_strings_file` added `DerivedData/SourcePackages/checkouts/WordPressKit-iOS/Sources` to the `genstrings` inputs.
- WordPressKit is now **vendored** under `Modules/Sources/WordPressKit` (declared locally in `Modules/Package.swift`, absent from `Package.resolved`) — so it's already covered by the existing `Modules/Sources/` path, and the remote checkout path no longer resolves.

## Change

- Empty the list (`REMOTE_SWIFT_PACKAGES_TO_LOCALIZE = []`) and update the comment. The extraction scaffolding stays in place for any future remote, string-bearing package.

## Test plan

- [ ] `complete_code_freeze` → `generate_strings_file_for_glotpress` still extracts WordPressKit's strings (now via `Modules/Sources/`).

Pre-existing and unrelated to #25688 — filed separately on purpose.
