### PR TITLE
Always show the blogging reminders calendar image

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/BloggingReminders/BloggingRemindersFlowSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/BloggingReminders/BloggingRemindersFlowSettingsViewController.swift
@@ -289,10 +289,8 @@ final class BloggingRemindersFlowSettingsViewController: UIViewController {
         // text sizes, where every point of height is needed for the enlarged labels and controls.
         imageView.isHidden = traitCollection.preferredContentSizeCategory.isAccessibilityCategory
 
-        registerForTraitChanges([UITraitPreferredContentSizeCategory.self]) { [weak self] (_: Self, traitCollection) in
-            guard let self else { return }
-
-            self.imageView.isHidden = traitCollection.preferredContentSizeCategory.isAccessibilityCategory
+        registerForTraitChanges([UITraitPreferredContentSizeCategory.self]) { (self: Self, _) in
+            self.imageView.isHidden = self.traitCollection.preferredContentSizeCategory.isAccessibilityCategory
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Blog/BloggingReminders/BloggingRemindersFlowSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/BloggingReminders/BloggingRemindersFlowSettingsViewController.swift
@@ -280,16 +280,19 @@ final class BloggingRemindersFlowSettingsViewController: UIViewController {
         refreshNextButton()
         refreshFrequencyLabel()
 
-        showFullUI(shouldShowFullUI)
-
         navigationItem.rightBarButtonItem = UIBarButtonItem(systemItem: .close, primaryAction: .init(handler: { [weak self] _ in
             self?.presentingViewController?.dismiss(animated: true)
         }))
 
+        // The calendar image has a low compression resistance, so it shrinks to make room for the
+        // functional controls when vertical space is tight. We only hide it outright at accessibility
+        // text sizes, where every point of height is needed for the enlarged labels and controls.
+        imageView.isHidden = traitCollection.preferredContentSizeCategory.isAccessibilityCategory
+
         registerForTraitChanges([UITraitPreferredContentSizeCategory.self]) { [weak self] (_: Self, traitCollection) in
             guard let self else { return }
 
-            self.imageView.isHidden = traitCollection.preferredContentSizeCategory.isAccessibilityCategory || !self.shouldShowFullUI
+            self.imageView.isHidden = traitCollection.preferredContentSizeCategory.isAccessibilityCategory
         }
     }
 
@@ -307,12 +310,6 @@ final class BloggingRemindersFlowSettingsViewController: UIViewController {
         if isBeingDismissedDirectlyOrByAncestor() && navigationController?.viewControllers.last == self {
             tracker.flowDismissed(source: .dayPicker)
         }
-    }
-
-    override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
-        super.viewWillTransition(to: size, with: coordinator)
-
-        showFullUI(shouldShowFullUI)
     }
 
     // MARK: - Actions
@@ -480,18 +477,6 @@ private extension BloggingRemindersFlowSettingsViewController {
         return view
     }
 
-    /// Determines if the calendar image should be displayed, depending on the screen vertical size
-    var shouldShowFullUI: Bool {
-        (WPDeviceIdentification.isiPhone() && UIScreen.main.bounds.height >= Metrics.minimumHeightForFullUI) ||
-            (WPDeviceIdentification.isiPad() && UIDevice.current.orientation.isPortrait)
-    }
-
-    /// Hides/shows the optional UI Elements (dismiss button & calendar icon)
-    /// - Parameter isVisible: true if we need to show the elements (Full UI), false otherwise
-    func showFullUI(_ isVisible: Bool) {
-        imageView.isHidden = !isVisible
-    }
-
     /// Updates the title of the cconfirmation button depending on the action (new schedule or updated schedule)
     func refreshNextButton() {
         if previousWeekdays.isEmpty {
@@ -509,13 +494,19 @@ private extension BloggingRemindersFlowSettingsViewController {
     /// Updates the label that contains the number of scheduled days as users change them
     func refreshFrequencyLabel() {
         guard !weekdays.isEmpty else {
+            // Collapse the time-selection and frequency containers (not just their contents) so the
+            // stack reclaims their fixed height while no days are selected, keeping the layout compact.
             frequencyLabel.isHidden = true
             timeSelectionStackView.isHidden = true
+            frequencyView.isHidden = true
+            timeSelectionView.isHidden = true
             return
         }
 
         frequencyLabel.isHidden = false
         timeSelectionStackView.isHidden = false
+        frequencyView.isHidden = false
+        timeSelectionView.isHidden = false
 
         let defaultAttributes: [NSAttributedString.Key: AnyObject] = [
             .foregroundColor: UIColor.label,
@@ -838,9 +829,6 @@ private enum Metrics {
     static let frequencyLabelHeight: CGFloat = 30
 
     static let topRowDayCount = 4
-
-    // the smallest logical iPhone height (iPhone 12 mini) to display the full UI, which includes calendar icon.
-    static let minimumHeightForFullUI: CGFloat = 812
 
     enum BloggingPrompts {
         static let titleSpacing: CGFloat = 5.0


### PR DESCRIPTION
The day-picker no longer gates the decorative calendar image on device type or screen height; it always shows and relies on its low compression resistance to shrink when vertical space is tight.

The layout changed slightly. But I think the end result looks okay.

| Device | Before | After  |
|---|---|---|
| iPhone SE (3rd gen) | <img src="https://github.com/user-attachments/assets/1c241681-3db7-4023-8e9e-d5e3654b043c" width="240"> | <img src="https://github.com/user-attachments/assets/0b971e07-5cbc-4a11-9c9f-d4018c45cedd" width="240"> |
| iPhone 16 | <img src="https://github.com/user-attachments/assets/b28835da-8ed4-42c6-9ccd-8e46ae63aa2c" width="240"> | <img src="https://github.com/user-attachments/assets/c35342e5-536b-4c94-ac35-7d089fc63331" width="240"> |
| iPad Pro 11″ — portrait | <img src="https://github.com/user-attachments/assets/1fb6ac13-0df1-44a5-9b46-fa58d13be958" width="240"> | <img src="https://github.com/user-attachments/assets/afe0eb0d-35e9-434d-b408-ea6272c3c75c" width="240"> |
| iPad Pro 11″ — landscape | <img src="https://github.com/user-attachments/assets/e88b5bf5-bf16-4da5-8646-d78099ef38f5" width="340"> | <img src="https://github.com/user-attachments/assets/8ab40afb-851c-4bce-93d2-ddee36b54dd3" width="340"> |
