### PR TITLE
Use traitCollection.displayScale where the display scale is resolved

### DIFF
--- a/WordPress/Classes/ViewRelated/Media/Crop/ImageCropViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/Crop/ImageCropViewController.swift
@@ -74,7 +74,7 @@ class ImageCropViewController: UIViewController, UIScrollViewDelegate {
     // MARK: - Action Handlers
     @IBAction func cropWasPressed() {
         // Calculations!
-        let screenScale = UIScreen.main.scale
+        let screenScale = traitCollection.displayScale
         let zoomScale = scrollView.zoomScale
         let oldSize = rawImage.size
         let resizeRect = CGRect(x: 0, y: 0, width: oldSize.width * zoomScale, height: oldSize.height * zoomScale)

--- a/WordPress/Classes/ViewRelated/Views/SeparatorsView.swift
+++ b/WordPress/Classes/ViewRelated/Views/SeparatorsView.swift
@@ -81,7 +81,7 @@ open class SeparatorsView: UIView {
     open override func draw(_ rect: CGRect) {
         super.draw(rect)
 
-        let scale = UIScreen.main.scale
+        let scale = traitCollection.displayScale
         let ctx = UIGraphicsGetCurrentContext()
         ctx!.clear(rect)
         ctx!.setShouldAntialias(false)


### PR DESCRIPTION
Switch ImageCropViewController and SeparatorsView from UIScreen.main.scale to the view's traitCollection.displayScale. Both read the scale in on-window contexts (a crop button action and draw(_:)), so the trait collection's display scale is always resolved and non-zero.