### PR TITLE
Pass gravatar size in points and let the SDK apply the display scale

### DIFF
--- a/WordPress/Classes/ViewRelated/Gravatar/UIImageView+Gravatar.swift
+++ b/WordPress/Classes/ViewRelated/Gravatar/UIImageView+Gravatar.swift
@@ -42,7 +42,7 @@ extension UIImageView {
         placeholderImage: UIImage = .gravatarPlaceholderImage,
         forceRefresh: Bool = false
     ) {
-        let avatarURL = AvatarURL.url(for: email, preferredSize: .pixels(gravatarDefaultSize()), gravatarRating: gravatarRating)
+        let avatarURL = AvatarURL.url(for: email, preferredSize: gravatarDefaultSize(), gravatarRating: gravatarRating)
         downloadGravatar(fullURL: avatarURL, placeholder: placeholderImage, animate: false, forceRefresh: forceRefresh)
     }
 
@@ -91,7 +91,7 @@ extension UIImageView {
     }
 
     @objc public func overrideGravatarImageCache(_ image: UIImage, gravatarRating: ObjcGravatarRating, email: String) {
-        guard let gravatarURL = AvatarURL.url(for: email, preferredSize: .pixels(gravatarDefaultSize()), gravatarRating: gravatarRating.map()) else {
+        guard let gravatarURL = AvatarURL.url(for: email, preferredSize: gravatarDefaultSize(), gravatarRating: gravatarRating.map()) else {
             return
         }
 
@@ -99,13 +99,13 @@ extension UIImageView {
         overrideImageCache(for: gravatarURL, with: image)
     }
 
-    private func gravatarDefaultSize() -> Int {
+    private func gravatarDefaultSize() -> Gravatar.ImageSize {
         guard bounds.size.equalTo(.zero) == false else {
-            return GravatarDefaults.imageSize
+            return .pixels(GravatarDefaults.imageSize)
         }
 
-        let targetSize = max(bounds.width, bounds.height) * UIScreen.main.scale
-        return Int(targetSize)
+        // Pass the size in points and let the Gravatar SDK apply the display scale.
+        return .points(max(bounds.width, bounds.height))
     }
 }
 


### PR DESCRIPTION
Change gravatarDefaultSize to return a Gravatar.ImageSize using .points, so the Gravatar SDK derives the pixel size from the current display scale instead of multiplying by the deprecated UIScreen.main.scale in view code.

However, the Gravatar SDK uses `UITraitCollection.current.displayScale`, which probably should be corrected too. But at least the extension here does not use `UIScreen.main.scale`.