### PR TITLE
Floor the display scale when sizing remote images

### DIFF
--- a/Modules/Sources/WordPressUI/Extensions/UIImageView+Networking.swift
+++ b/Modules/Sources/WordPressUI/Extensions/UIImageView+Networking.swift
@@ -86,8 +86,9 @@ public extension UIImageView {
             self.image = placeholderImage
         }
 
+        let displayScale = max(1, traitCollection.displayScale)
         let task = URLSession.shared.dataTask(with: request, completionHandler: { [weak self] data, response, error in
-            guard let data, let image = UIImage(data: data, scale: UIScreen.main.scale) else {
+            guard let data, let image = UIImage(data: data, scale: displayScale) else {
                 DispatchQueue.main.async {
                     failure?(error)
                     self?.downloadTask = nil

--- a/WordPress/Classes/ViewRelated/Pages/Views/PageListCell.swift
+++ b/WordPress/Classes/ViewRelated/Pages/Views/PageListCell.swift
@@ -69,7 +69,7 @@ final class PageListCell: UITableViewCell, AbstractPostListCell, PostSearchResul
         featuredImageView.isHidden = viewModel.imageURL == nil
         if let imageURL = viewModel.imageURL {
             let host = MediaHost(viewModel.page)
-            let thumbnailURL = MediaImageService.getResizedImageURL(for: imageURL, blog: viewModel.page.blog, size: Constants.imageSize.scaled(by: UIScreen.main.scale))
+            let thumbnailURL = MediaImageService.getResizedImageURL(for: imageURL, blog: viewModel.page.blog, size: Constants.imageSize.scaled(by: max(1, traitCollection.displayScale)))
             featuredImageView.setImage(with: thumbnailURL, host: host)
         }
 

--- a/WordPress/Classes/ViewRelated/Post/Views/PostListCell.swift
+++ b/WordPress/Classes/ViewRelated/Post/Views/PostListCell.swift
@@ -86,7 +86,7 @@ final class PostListCell: UITableViewCell, AbstractPostListCell, PostSearchResul
         featuredImageView.layer.opacity = viewModel.syncStateViewModel.isEditable ? 1 : 0.25
         if let imageURL = viewModel.imageURL {
             let host = MediaHost(viewModel.post)
-            let thumbnailURL = MediaImageService.getResizedImageURL(for: imageURL, blog: viewModel.post.blog, size: Constants.imageSize.scaled(by: UIScreen.main.scale))
+            let thumbnailURL = MediaImageService.getResizedImageURL(for: imageURL, blog: viewModel.post.blog, size: Constants.imageSize.scaled(by: max(1, traitCollection.displayScale)))
             featuredImageView.setImage(with: thumbnailURL, host: host)
         }
 

--- a/WordPress/Classes/ViewRelated/Themes/ThemeBrowserCell.swift
+++ b/WordPress/Classes/ViewRelated/Themes/ThemeBrowserCell.swift
@@ -209,7 +209,7 @@ open class ThemeBrowserCell: UICollectionViewCell {
             queryItems.append(URLQueryItem(name: "w", value: "\(screenshotWidth)"))
         }
 
-        queryItems.append(URLQueryItem(name: "zoom", value: "\(UIScreen.main.scale)"))
+        queryItems.append(URLQueryItem(name: "zoom", value: "\(max(1, traitCollection.displayScale))"))
         components.queryItems = queryItems
 
         guard let urlString = components.url?.absoluteString else {


### PR DESCRIPTION
Replace UIScreen.main.scale with max(1, traitCollection.displayScale). The view's traitCollection.displayScale can be 0 before its traits resolve, so flooring at 1 (matching AsyncImageKit's ImageSize) avoids zero-size image requests.