### PR TITLE
fix: add specific error message for plain permalink sites

### DIFF
--- a/WordPress/Classes/Login/SelfHostedSiteAuthenticator.swift
+++ b/WordPress/Classes/Login/SelfHostedSiteAuthenticator.swift
@@ -69,6 +69,7 @@ struct SelfHostedSiteAuthenticator {
         case xmlrpcDisabled(Error)
         case xmlrpcEndpointNotFound
         case loadingSiteInfoFailure(Error)
+        case plainPermalinkNotSupported(apiRootURL: String)
         case savingSiteFailure
         case mismatchedUser(expectedUsername: String)
         case cancelled
@@ -89,6 +90,12 @@ struct SelfHostedSiteAuthenticator {
                     "addSite.selfHosted.loadingSiteInfoFailure",
                     value: "Cannot load the WordPress site details",
                     comment: "Error message shown when failing to load details from a self-hosted WordPress site"
+                )
+            case .plainPermalinkNotSupported:
+                return NSLocalizedString(
+                    "addSite.selfHosted.plainPermalinkNotSupported",
+                    value: "This site uses plain permalinks, which are not fully supported. Please enable pretty permalinks in Settings > Permalinks, or contact your hosting provider for assistance.",
+                    comment: "Error message when a self-hosted site uses plain permalinks (rest_route query form) which causes REST API issues"
                 )
             case .savingSiteFailure:
                 return NSLocalizedString(
@@ -386,6 +393,11 @@ struct SelfHostedSiteAuthenticator {
             (siteSettings, isAdmin, jetpackSite, jetpackConnection, xmlrpcOptions) =
                 try await (siteSettings_, isAdmin_, jetpackSite_, jetpackConnection_, xmlrpcOptions_)
         } catch {
+            // If the API root URL uses the rest_route query-parameter form
+            // (plain permalinks), provide a more actionable error message.
+            if apiRootURL.query(forKey: "rest_route") != nil {
+                throw .plainPermalinkNotSupported(apiRootURL: apiRootURL.absoluteString)
+            }
             throw .loadingSiteInfoFailure(error)
         }
 


### PR DESCRIPTION
## Summary

When a self-hosted WordPress site uses plain permalinks, the REST API root is advertised as a query-parameter form (`rest_route=/`) which causes the login to fail with a generic error message.

**Before:** "Cannot load the WordPress site details"  
**After:** "This site uses plain permalinks, which are not fully supported. Please enable pretty permalinks in Settings > Permalinks, or contact your hosting provider for assistance."

## Changes

- Added new `SignInError.plainPermalinkNotSupported` case with a specific, actionable error message
- Added detection of `rest_route` query parameter in the API root URL
- When site details loading fails and the API root uses `rest_route` form, the specific error is shown instead of the generic one

## Files Changed

- `WordPress/Classes/Login/SelfHostedSiteAuthenticator.swift`

## Related Issues

- Fixes #25604
- Related: Automattic/wordpress-rs#1366 (upstream fix for rest_route support)
