### PR TITLE
Localization: wire AI plural translation into the GlotPress reverse fold

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,7 +46,7 @@ WordPress-iOS uses a modular architecture with the main app and separate Swift p
 ### Important Considerations
 - **Multi-site Support**: Code must handle both WordPress.com and self-hosted sites
 - **Accessibility**: Use proper accessibility labels and traits
-- **Localization**: follow best practices from @docs/localization.md
+- **Localization**: follow best practices from @docs/localization.md. For how strings flow through GlotPress and the AI translation tier (the `human ?? AI ?? English` floor), see @docs/localization-pipeline.md.
 
 ## Xcode Schemes
 - `WordPress` builds the WordPress iOS app and runs `WordPressUnitTests.xctestplan` — default for builds and the full unit test suite. Use this scheme to run unit tests.

--- a/docs/localization-pipeline.md
+++ b/docs/localization-pipeline.md
@@ -1,0 +1,81 @@
+# Localization translation pipeline
+
+How user-facing strings get from English source into every shipped locale. This is the **release/tooling** view (the fastlane lanes under `fastlane/lanes/`); for how to *write* localizable strings in app code, see [localization.md](./localization.md).
+
+> The contract for every shipped string is **`human ?? AI ?? English`**: a human (GlotPress) translation if one exists, otherwise a machine translation, otherwise the English source. Nothing ships a broken placeholder — machine output that fails the format-specifier gate falls back to English.
+
+## The round trip
+
+Strings make two trips, both driven from fastlane.
+
+### Forward (code freeze) — English → GlotPress
+
+Run as part of `complete_code_freeze` (`generate_strings_file_for_glotpress`):
+
+- **Regular strings** are extracted from source (`ios_generate_strings_file_from_code`, i.e. `genstrings` over `NSLocalizedString` / `AppLocalizedString`) into `WordPress/Resources/en.lproj/Localizable.strings`, then the manually-maintained `.strings` files are merged in. These English originals are uploaded to the [apps/ios GlotPress project](https://translate.wordpress.org/projects/apps/ios/dev/).
+- **Plurals** are authored in `WordPress/Classes/Plurals.xcstrings` (English `one`/`other`). The forward lane (`generate_plural_strings_for_glotpress`) flattens each plural form into an independent string keyed `<key>|==|plural.<cldr-category>` and merges those originals into the same `Localizable.strings`, so they ride the same GlotPress project as everything else.
+
+Translators then do their work in GlotPress.
+
+### Reverse (release prep) — GlotPress → app
+
+`download_localized_strings` (called by `complete_code_freeze` / `finalize_release`) runs, in order:
+
+1. **Download** each locale's `Localizable.strings` from GlotPress (`ios_download_strings_files_from_glotpress`) into `WordPress/Resources/<locale>.lproj/`, and commit. The export filter is `status: current`, so **only translated strings come back** — untranslated ones are *omitted entirely* (not emitted as empty values; the action even errors if it finds an empty value). This is why `pl` ships ~1,650 of ~4,280 keys while `fr` ships ~all of them.
+2. **Re-dispatch** the relevant subset back to the manually-maintained `.strings` files (`ios_extract_keys_from_strings_files`), and commit.
+3. **Plural fold** (`download_localized_plurals`): pull the flat plural translations back out of the downloaded `Localizable.strings`, fold them into `Plurals.xcstrings`, and fill the gaps with the AI tier (below).
+
+Step 3 runs via `run_plural_step`, which logs and continues on failure — the AI tier can never break a release.
+
+## The AI tier
+
+The machine-translation rung of the floor. It is **injected and gated**, never mandatory:
+
+- **Gate**: `ANTHROPIC_API_KEY`. Absent ⇒ the AI tier is skipped entirely and untranslated cells keep their English fallback — i.e. exactly the pre-AI behavior. Providing the key (e.g. in the release environment) is what turns it on.
+- **Placeholder gate**: every machine cell must preserve the source's `printf`/`NSString` format specifiers exactly (count + type; positional `%1$@` may reorder). A mismatch is rejected and the cell falls back to English. So the AI tier can only ever produce a *safe* translation or nothing.
+- **Model**: `claude-opus-4-8` by default (see `AITranslator::DEFAULT_MODEL`).
+
+The reusable primitives live in `fastlane/lanes/`: `AITranslator` (prompt building + validation; `translate` / `translate_plural` / `translate_all` / the async Message-Batches path), `TranslationValidator` (the placeholder gate), `Glossary` (brand do-not-translate list + per-locale terms), and `AnthropicBatch` (SDK glue). All the logic is pure and unit-tested with a canned-reply lambda; only `AITranslator.with_anthropic` touches the network.
+
+## What's wired today: plurals
+
+The plural reverse-fold (`PluralStrings.fold_translations!`) fills each `(key, locale)` cell of `Plurals.xcstrings` as `human ?? AI ?? English` — human ⇒ `translated`; AI / English ⇒ `needs_review`. The AI tier is called **once per `(key, locale)` form-set** (`AITranslator#translate_plural`), not per cell, with the already-human-translated forms passed as **anchors**. Translating the whole set in one request keeps a single consistent stem across the forms — a per-category call lets the model drift between synonyms (Polish `słowo` → `wyrazy` → `słów`), which it structurally can't prevent.
+
+**`Plurals.xcstrings` is a String Catalog, which is why this works**: the catalog carries a real `needs_review` state, so a machine cell is recorded as machine output, a human translation supersedes it on the next download, and an unchanged machine cell is carried over as-is on a re-fold rather than re-translated. The fold is idempotent — a re-run with the same input neither re-spends on the model nor churns the staged text, and a cell that fell back to English (the AI declined) is retried next time.
+
+> **This does not ship machine translations yet.** `Plurals.xcstrings` is built into the app but **not consumed at runtime** — no code reads from it; the app still renders plurals the legacy way. The fold *pre-populates* the catalog so it's ready when plurals cut over to it. Until that cutover, the AI plural translations sit in the catalog unused.
+
+## What's deferred: regular strings
+
+Regular (non-plural) strings are **not** machine-translated, by design. The app still ships the legacy `WordPress/Resources/<locale>.lproj/Localizable.strings` for them — `Localizable.xcstrings` (`generate_strings_catalog`) is generated as the future backing store but isn't the runtime store yet. A machine translation written into the legacy `.strings` would be **live immediately**, and we don't want machine-translated regular strings shipping before the catalog cutover.
+
+So regular-string MT waits for the same shape as plurals: once `Localizable.xcstrings` becomes the runtime store, a regular-string **catalog reverse-fold** folds the human translations in and AI-fills the `needs_review` gaps, staged in the catalog (not shipped) until cutover — exactly as the plural fold does today.
+
+When that's built, two facts established here will carry over:
+
+- **"Undefined by GlotPress" = absent**, not empty. The export omits untranslated strings (`status: current`; verified no empty-valued entries), so absence is the untranslated signal.
+- **Humans always supersede MT**, and machine output never returns to GlotPress — so there's no translation-memory pollution and no manual reconciliation, as long as MT lives in a state-bearing store (the catalog's `needs_review`).
+
+## Why these choices
+
+- **Why translate whole plural form-sets at once?** Per-category calls let the model pick different synonyms for different forms of the same word. One request for the whole set, with human forms as anchors, keeps one stem.
+- **Why is the AI tier gated and non-fatal?** Cost and safety: it runs only where a key is configured, and a failure logs and continues rather than breaking a release.
+- **Why does regular-string MT need the catalog, not legacy `.strings`?** The catalog's `needs_review` state lets a machine translation be *staged* (built but not shipped until cutover) and lets humans supersede it automatically. Legacy `.strings` has no state and is live, so anything written there ships immediately — which is exactly what we don't want before cutover.
+
+## Operational notes
+
+- **Eyeball one string against the live model** (needs `ANTHROPIC_API_KEY` + `bundle install`):
+  `ruby fastlane/lanes/ai_translator.rb fr "You have %1$d new posts" "Notification text. %1$d is the count."`
+- **Tests** are pure stdlib minitest and run in CI (`.buildkite/commands/test-localization-tooling.sh`): `ruby fastlane/lanes/*_test.rb`.
+
+## Code map
+
+| Concern | File |
+| --- | --- |
+| Translation tier (prompts, validation, `translate*`) | `fastlane/lanes/ai_translator.rb` |
+| Placeholder safety gate | `fastlane/lanes/translation_validator.rb` |
+| Brand do-not-translate + per-locale terms | `fastlane/lanes/translation_glossary.rb` |
+| Anthropic SDK glue + Message Batches | `fastlane/lanes/anthropic_batch.rb` |
+| Plural fold (`Localizable.strings` ⇄ `Plurals.xcstrings`) + AI wiring | `fastlane/lanes/plural_strings_helper.rb`, `fastlane/lanes/localization_plurals.rb` |
+| Catalog generation (future regular-string backing store) | `fastlane/lanes/localization_catalog.rb` |
+| Download/upload orchestration | `fastlane/lanes/localization.rb` |

--- a/fastlane/lanes/localization_plurals.rb
+++ b/fastlane/lanes/localization_plurals.rb
@@ -81,7 +81,7 @@ platform :ios do
       catalog,
       categories_by_locale: categories_by_locale,
       translations_by_locale: plural_translations_by_locale(File.join(PROJECT_ROOT_FOLDER, 'WordPress', 'Resources')),
-      ai_translator: method(:ai_translate_plural)
+      ai_translator: plural_ai_translator
     )
     File.write(PLURALS_CATALOG, "#{JSON.pretty_generate(catalog)}\n")
     UI.message("Folded plural translations from Localizable.strings into #{File.basename(PLURALS_CATALOG)} (#{written} locale variations).")
@@ -138,13 +138,36 @@ platform :ios do
     end
   end
 
-  # Machine-translation floor for the reverse fold: invoked for every plural slot with no human translation.
-  # Returns nil until wired to a translation service, leaving such slots to fall back to the English source
-  # (flagged needs_review). The named `category` + dev `note` let the prompt request the correct grammatical
-  # form (e.g. "give me the Polish *few* form of …").
-  # rubocop:disable Lint/UnusedMethodArgument -- keyword names are the documented call contract
-  def ai_translate_plural(id:, source:, category:, note:, locale:)
-    nil # TODO: call the translation service.
+  # The machine-translation tier for the reverse fold (the AI rung of the `human ?? AI ?? English` floor), or
+  # nil when ANTHROPIC_API_KEY isn't configured — in which case untranslated plural cells keep falling back to
+  # the English source (flagged needs_review), exactly as before this was wired. Built once and reused for
+  # every (key, locale) form-set.
+  #
+  # The returned callable matches PluralStrings.fold_translations!'s form-set contract and is wrapped to
+  # DEGRADE, not crash. Two failure modes, both non-fatal: a per-set API error logs and returns {} so that one
+  # set falls back to English while the rest of the fold proceeds and commits; a setup error — the gem missing
+  # (LoadError) or the client failing to construct (any StandardError, e.g. a malformed ANTHROPIC_BASE_URL) —
+  # logs and returns nil, disabling the AI tier for this run while the human/English fold still proceeds and
+  # commits (rather than dropping the whole reverse step). The reverse step is additionally guarded by
+  # `run_plural_step`. Going through `AITranslator#translate_plural` — the whole form-set in one request — keeps
+  # one consistent word/stem across the forms (a per-cell call lets the model drift between synonyms, e.g.
+  # Polish słowo → wyrazy → słów).
+  def plural_ai_translator
+    if ENV['ANTHROPIC_API_KEY'].to_s.empty?
+      UI.important('ANTHROPIC_API_KEY not set — skipping AI plural translation; untranslated plurals fall back to English (needs_review).')
+      return nil
+    end
+
+    require_relative 'ai_translator'
+    translator = AITranslator.with_anthropic
+    lambda do |english_forms:, categories:, locale:, note:, anchors:|
+      translator.translate_plural(english_forms: english_forms, categories: categories, locale: locale, note: note, anchors: anchors)
+    rescue StandardError => e
+      UI.error("AI plural translation failed for #{locale} (#{e.message}); falling back to English for this form-set.")
+      {}
+    end
+  rescue LoadError, StandardError => e
+    UI.important("AI translation tier unavailable (#{e.message}); untranslated plurals fall back to English.")
+    nil
   end
-  # rubocop:enable Lint/UnusedMethodArgument
 end

--- a/fastlane/lanes/plural_strings_helper.rb
+++ b/fastlane/lanes/plural_strings_helper.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'json'
-require 'nokogiri'
 
 # Logic for the String Catalog ⇄ GlotPress plural pipeline. Plain Ruby with no fastlane dependencies, so it's
 # unit-testable directly — the lanes in `localization_plurals.rb` call into it.
@@ -11,7 +10,7 @@ require 'nokogiri'
 # `<catalog-key>|==|plural.<cldr-category>` — the same id Apple's `xcodebuild -exportLocalizations`
 # uses. Translations fold back into the catalog JSON using a per-locale CLDR category map that the reverse
 # derives from Apple's exporter at fold time (a throwaway one-plural project — categories are a locale property).
-module PluralStrings
+module PluralStrings # rubocop:disable Metrics/ModuleLength -- one cohesive pipeline of small, single-purpose, individually-documented helpers
   XLIFF_NS = { 'x' => 'urn:oasis:names:tc:xliff:document:1.2' }.freeze
   INFIX = '|==|plural.'
   CLDR_ORDER = %w[zero one two few many other].freeze
@@ -88,6 +87,7 @@ module PluralStrings
   # Apple owns the truth; the reverse derives this at fold time from a throwaway-fixture export.
   # @return [Hash{String=>Array<String>}] locale => categories (CLDR order).
   def categories_by_locale_from_skeletons(xliff_paths)
+    require 'nokogiri' # only the exporter-skeleton path needs it; kept lazy so the pure fold has no gem dependency
     xliff_paths.each_with_object({}) do |path, acc|
       cats = Nokogiri::XML(File.read(path)).xpath('//x:trans-unit', XLIFF_NS).filter_map do |tu|
         id = tu['id'].to_s
@@ -101,8 +101,18 @@ module PluralStrings
   # variations — the inverse of `flat_originals`. For each plural key and target locale, emit exactly the
   # categories that locale needs (per `categories_by_locale`), filling each with `human ?? AI ?? English`.
   # Human cells are `translated`; AI / English-fallback cells are `needs_review` (machine output to re-check).
-  # `ai_translator` is optional and may return nil (the floor falls through to English). Mutates `catalog`;
-  # returns the count of (key, locale) variations written.
+  # Mutates `catalog`; returns the count of (key, locale) variations written. Idempotent for machine output: a
+  # reusable AI cell from a prior fold (needs_review, not an English fallback) is carried over rather than
+  # re-translated, so an unchanged re-run neither re-calls the model nor churns the staged text.
+  #
+  # `ai_translator` (optional) is invoked ONCE per (key, locale) with the whole form-set — not per cell — so
+  # the model keeps one consistent stem across the forms; a per-category call lets it drift between synonyms
+  # (e.g. Polish słowo -> wyrazy -> słów). It is called as:
+  #   ai_translator.call(english_forms:, categories:, locale:, note:, anchors:) => { <cat> => translation }
+  # where `anchors` are the forms already in hand — human translations plus reusable machine cells kept from a
+  # prior fold — passed as fixed context to stay consistent with, and excluded from what's asked for. It may
+  # return nil / {} or omit any category — those cells fall through to English. `AITranslator#translate_plural`
+  # implements this contract directly, so wiring the live tier is `ai_translator: translator.method(:translate_plural)`.
   #
   # @param categories_by_locale [Hash{String=>Array<String>}] locale => CLDR categories it needs
   # @param translations_by_locale [Hash{String=>Hash{String=>String}}] locale => { "<key>|==|plural.<cat>" => value }
@@ -116,7 +126,10 @@ module PluralStrings
 
   FoldContext = Struct.new(:source, :targets, :translations, :ai)
   PluralEntry = Struct.new(:key, :comment, :plural)
-  private_constant :FoldContext, :PluralEntry
+  # One (key, locale) fold slot: the categories the locale needs, its downloaded human forms, and the existing
+  # catalog localization (nil on first fold) whose reusable machine cells make the fold idempotent.
+  Slot = Struct.new(:locale, :cats, :human, :existing)
+  private_constant :FoldContext, :PluralEntry, :Slot
 
   # Fold one catalog entry across all target locales; returns the number of locales written (0 if not a plural).
   def fold_entry!(body, key, ctx)
@@ -124,33 +137,111 @@ module PluralStrings
     return 0 unless plural
 
     entry = PluralEntry.new(key, body['comment'], plural)
-    ctx.targets.each { |locale, cats| body['localizations'][locale] = plural_variation(entry, cats, ctx.translations[locale] || {}, ctx.ai, locale) }
+    locals = body['localizations']
+    ctx.targets.each { |locale, cats| locals[locale] = plural_variation(entry, slot_for(ctx, locals, locale, cats), ctx.ai) }
     ctx.targets.size
   end
   private_class_method :fold_entry!
+
+  # The per-(key, locale) fold inputs: the locale's needed categories, its downloaded human forms, and the
+  # existing catalog localization (nil on first fold) whose reusable machine cells keep the fold idempotent.
+  def slot_for(ctx, locals, locale, cats)
+    Slot.new(locale, cats, ctx.translations[locale] || {}, locals[locale])
+  end
+  private_class_method :slot_for
 
   def cldr_sort(categories)
     categories.sort_by { |c| CLDR_ORDER.index(c) || CLDR_ORDER.length }
   end
   private_class_method :cldr_sort
 
-  # One locale's plural variation hash: { 'variations' => { 'plural' => { <cat> => stringUnit } } }.
-  def plural_variation(entry, cats, human, ai_translator, locale)
-    forms = cats.to_h { |cat| [cat, fold_cell(entry, cat, human, ai_translator, locale)] }
+  # One locale's plural variation hash: { 'variations' => { 'plural' => { <cat> => stringUnit } } }. Resolve the
+  # English and human forms first, carry over any reusable machine cells from the previous fold (so re-runs are
+  # idempotent), ask the AI tier (once, whole form-set) for whatever's STILL missing, then write each cell as
+  # human ?? AI ?? English.
+  def plural_variation(entry, slot, ai_translator)
+    cats = slot.cats
+    english_forms = english_forms_for(entry.plural, cats)
+    human_forms = human_forms_for(entry.key, cats, slot.human)
+    kept_ai = kept_ai_forms(slot.existing, cats, human_forms, english_forms)
+    anchors = human_forms.merge(kept_ai)
+    ai_forms = kept_ai.merge(fresh_ai_forms(ai_translator, entry, slot, english_forms, anchors))
+
+    forms = cats.to_h { |cat| [cat, fold_cell(cat, human_forms, ai_forms, english_forms)] }
     { 'variations' => { 'plural' => forms } }
   end
   private_class_method :plural_variation
 
-  # One target stringUnit for (entry, cat, locale): human ?? AI ?? English source; state reflects provenance
-  # (human => translated; AI / English fallback => needs_review).
-  def fold_cell(entry, cat, human, ai_translator, locale)
-    id = "#{entry.key}#{INFIX}#{cat}"
-    human_value = human[id]
-    return cell('translated', human_value) unless human_value.to_s.empty?
+  # Machine cells from the previous fold worth reusing, keyed by CLDR category — the crux of an idempotent
+  # re-run. A cell is kept only when it holds a real machine translation (needs_review, non-empty, and not just
+  # the English fallback) for a category the current download hasn't since covered with a human form. Kept cells
+  # both anchor the AI request and pass straight through, so an unchanged fold never re-calls the (billable,
+  # non-deterministic) model nor churns needs_review text a reviewer may be mid-review of. English-fallback
+  # cells (the AI declined last time) are deliberately NOT kept, so a transient outage is retried next run.
+  def kept_ai_forms(existing, cats, human_forms, english_forms)
+    prior = existing.is_a?(Hash) ? existing.dig('variations', 'plural') : nil
+    return {} unless prior.is_a?(Hash)
 
-    english = entry.plural.dig(cat, 'stringUnit', 'value') || entry.plural.dig('other', 'stringUnit', 'value')
-    ai = ai_translator&.call(id: id, source: english, category: cat, note: entry.comment, locale: locale)
-    cell('needs_review', ai.to_s.empty? ? english : ai)
+    cats.each_with_object({}) do |cat, acc|
+      value = kept_ai_value(prior[cat], english_forms[cat])
+      acc[cat] = value if value && !human_forms.key?(cat)
+    end
+  end
+  private_class_method :kept_ai_forms
+
+  # A previous cell's value if it's a reusable machine translation (needs_review and not merely the English
+  # fallback), else nil so the category is re-filled.
+  def kept_ai_value(prior_cell, english)
+    unit = prior_cell.is_a?(Hash) ? prior_cell['stringUnit'] : nil
+    return nil unless unit.is_a?(Hash) && unit['state'] == 'needs_review'
+
+    value = unit['value'].to_s
+    value unless value.empty? || value == english
+  end
+  private_class_method :kept_ai_value
+
+  # The AI tier's fresh output for the categories still missing after human + kept-machine forms — or {} when
+  # there's no translator or nothing is missing, so the fold itself (not just the injected callable) skips a
+  # needless, billable request when every form is already in hand.
+  def fresh_ai_forms(ai_translator, entry, slot, english_forms, anchors)
+    return {} if ai_translator.nil? || (slot.cats - anchors.keys).empty?
+
+    ai_translator.call(english_forms: english_forms, categories: slot.cats, locale: slot.locale, note: entry.comment, anchors: anchors) || {}
+  end
+  private_class_method :fresh_ai_forms
+
+  # English value per needed category — the form's own English, or the `other` value both for categories English
+  # doesn't itself distinguish (zero/two/few/many) AND for any form left blank in the source. CLDR guarantees a
+  # non-empty `other` (the forward lane enforces it via `plural_keys_missing_other`), so this never yields blank.
+  def english_forms_for(plural, cats)
+    other = plural.dig('other', 'stringUnit', 'value')
+    cats.to_h do |cat|
+      own = plural.dig(cat, 'stringUnit', 'value')
+      [cat, own.to_s.empty? ? other : own]
+    end
+  end
+  private_class_method :english_forms_for
+
+  # Human (GlotPress) translations present for this key, keyed by CLDR category. These ship as `translated` and
+  # double as the AI request's anchors so the machine-filled forms stay consistent with the human's word choice.
+  # A blank-or-whitespace-only value isn't a real translation — it's dropped, so it neither ships as `translated`
+  # nor anchors the request (the category falls through to AI / English instead).
+  def human_forms_for(key, cats, human)
+    cats.each_with_object({}) do |cat, acc|
+      value = human["#{key}#{INFIX}#{cat}"]
+      acc[cat] = value unless value.to_s.strip.empty?
+    end
+  end
+  private_class_method :human_forms_for
+
+  # One target stringUnit for a category: human ?? AI ?? English; state reflects provenance (human =>
+  # translated; AI / English fallback => needs_review, i.e. machine output to re-check).
+  def fold_cell(cat, human_forms, ai_forms, english_forms)
+    human = human_forms[cat]
+    return cell('translated', human) unless human.to_s.empty?
+
+    ai = ai_forms[cat]
+    cell('needs_review', ai.to_s.empty? ? english_forms[cat] : ai)
   end
   private_class_method :fold_cell
 

--- a/fastlane/lanes/plural_strings_helper_test.rb
+++ b/fastlane/lanes/plural_strings_helper_test.rb
@@ -1,0 +1,254 @@
+# frozen_string_literal: true
+
+# Pure-Ruby unit suite for PluralStrings.fold_translations! — the reverse fold that folds downloaded plural
+# translations back into the String Catalog with the `human ?? AI ?? English` floor. Run directly:
+# `ruby fastlane/lanes/plural_strings_helper_test.rb`. No bundle / network (the AI tier is a stub lambda).
+require 'minitest/autorun'
+require_relative 'plural_strings_helper'
+
+# Exercises provenance (human => translated; AI / English fallback => needs_review) and the form-set contract:
+# the AI tier is called ONCE per (key, locale) with the whole set of needed categories and the human forms as
+# anchors — never per cell.
+class PluralStringsFoldTest < Minitest::Test # rubocop:disable Metrics/ClassLength -- exhaustive scenario coverage
+  KEY = 'posts.count'
+  INFIX = PluralStrings::INFIX
+
+  def unit(state, value)
+    { 'stringUnit' => { 'state' => state, 'value' => value } }
+  end
+
+  # A catalog with one English plural (one/other). `extra` adds sibling entries (e.g. a non-plural string).
+  def catalog(extra: {})
+    {
+      'sourceLanguage' => 'en',
+      'version' => '1.0',
+      'strings' => {
+        KEY => {
+          'comment' => 'Number of posts.',
+          'localizations' => { 'en' => { 'variations' => { 'plural' => {
+            'one' => unit('translated', '%lld post'),
+            'other' => unit('translated', '%lld posts')
+          } } } }
+        }
+      }.merge(extra)
+    }
+  end
+
+  # The full stringUnit wrapper a fold wrote for (locale, category) of the plural key under test.
+  def cell(cat, catalog:, locale:)
+    catalog.dig('strings', KEY, 'localizations', locale, 'variations', 'plural', cat)
+  end
+
+  # An AI stub returning `reply`, recording every call's kwargs so the form-set contract can be asserted.
+  def recording_translator(reply:, calls:)
+    lambda do |english_forms:, categories:, locale:, note:, anchors:|
+      calls << { english_forms: english_forms, categories: categories, locale: locale, note: note, anchors: anchors }
+      reply
+    end
+  end
+
+  def fold(cat, categories_by_locale:, translations_by_locale: {}, ai_translator: nil)
+    PluralStrings.fold_translations!(cat, categories_by_locale: categories_by_locale, translations_by_locale: translations_by_locale, ai_translator: ai_translator)
+  end
+
+  # Polish needs four categories but only `one` is human-translated — the setup the form-set contract is about.
+  # Folds with the supplied AI reply and returns [catalog, recorded_calls].
+  def fold_polish(reply:)
+    cat = catalog
+    calls = []
+    fold(cat,
+         categories_by_locale: { 'pl' => %w[one few many other] },
+         translations_by_locale: { 'pl' => { "#{KEY}#{INFIX}one" => '%lld wpis' } },
+         ai_translator: recording_translator(reply: reply, calls: calls))
+    [cat, calls]
+  end
+
+  POLISH_AI = { 'few' => '%lld wpisy', 'many' => '%lld wpisów', 'other' => '%lld wpisu' }.freeze
+
+  def test_human_translation_wins_and_is_marked_translated
+    cat = catalog
+    written = fold(cat, categories_by_locale: { 'fr' => %w[one other] }, translations_by_locale: {
+                     'fr' => { "#{KEY}#{INFIX}one" => '%lld article', "#{KEY}#{INFIX}other" => '%lld articles' }
+                   })
+
+    assert_equal 1, written
+    assert_equal unit('translated', '%lld article'), cell('one', catalog: cat, locale: 'fr')
+    assert_equal unit('translated', '%lld articles'), cell('other', catalog: cat, locale: 'fr')
+  end
+
+  def test_english_fallback_when_no_human_and_no_ai
+    cat = catalog
+    fold(cat, categories_by_locale: { 'fr' => %w[one other] })
+
+    # No human, no AI tier wired: each cell falls through to the English source, flagged for review.
+    assert_equal unit('needs_review', '%lld post'), cell('one', catalog: cat, locale: 'fr')
+    assert_equal unit('needs_review', '%lld posts'), cell('other', catalog: cat, locale: 'fr')
+  end
+
+  def test_ai_fills_missing_cells_and_marks_needs_review
+    cat = catalog
+    ai = recording_translator(reply: { 'one' => '%lld article', 'other' => '%lld articles' }, calls: [])
+    fold(cat, categories_by_locale: { 'fr' => %w[one other] }, ai_translator: ai)
+
+    assert_equal unit('needs_review', '%lld article'), cell('one', catalog: cat, locale: 'fr')
+    assert_equal unit('needs_review', '%lld articles'), cell('other', catalog: cat, locale: 'fr')
+  end
+
+  def test_formset_call_carries_english_forms_anchors_and_note
+    _cat, calls = fold_polish(reply: POLISH_AI)
+
+    assert_equal 1, calls.size, 'expected a single form-set call, not one per category'
+    call = calls.first
+    assert_equal %w[one few many other], call[:categories]
+    assert_equal 'pl', call[:locale]
+    assert_equal 'Number of posts.', call[:note]
+    assert_equal({ 'one' => '%lld wpis' }, call[:anchors])
+    # few/many/other have no English form of their own, so they fall back to the English `other` value.
+    assert_equal({ 'one' => '%lld post', 'few' => '%lld posts', 'many' => '%lld posts', 'other' => '%lld posts' }, call[:english_forms])
+  end
+
+  def test_formset_result_merges_human_and_ai_by_provenance
+    cat, = fold_polish(reply: POLISH_AI)
+
+    assert_equal unit('translated', '%lld wpis'), cell('one', catalog: cat, locale: 'pl') # human
+    assert_equal unit('needs_review', '%lld wpisy'), cell('few', catalog: cat, locale: 'pl') # AI
+    assert_equal unit('needs_review', '%lld wpisów'), cell('many', catalog: cat, locale: 'pl')
+    assert_equal unit('needs_review', '%lld wpisu'), cell('other', catalog: cat, locale: 'pl')
+  end
+
+  def test_ai_omitted_category_falls_back_to_english
+    cat = catalog
+    ai = recording_translator(reply: { 'one' => '%lld Beitrag' }, calls: []) # 'other' omitted
+    fold(cat, categories_by_locale: { 'de' => %w[one other] }, ai_translator: ai)
+
+    assert_equal unit('needs_review', '%lld Beitrag'), cell('one', catalog: cat, locale: 'de')
+    assert_equal unit('needs_review', '%lld posts'), cell('other', catalog: cat, locale: 'de') # English fallback
+  end
+
+  def test_ai_nil_return_falls_back_to_english
+    cat = catalog
+    fold(cat, categories_by_locale: { 'de' => %w[one other] }, ai_translator: ->(**) {}) # declines entirely (nil)
+
+    assert_equal unit('needs_review', '%lld post'), cell('one', catalog: cat, locale: 'de')
+    assert_equal unit('needs_review', '%lld posts'), cell('other', catalog: cat, locale: 'de')
+  end
+
+  def test_source_locale_is_not_folded
+    cat = catalog
+    original_en = cat.dig('strings', KEY, 'localizations', 'en')
+    written = fold(cat, categories_by_locale: { 'en' => %w[one other], 'fr' => %w[one other] })
+
+    assert_equal 1, written, 'the source locale must be excluded from the fold'
+    assert_same original_en, cat.dig('strings', KEY, 'localizations', 'en'), 'source localization left untouched'
+    refute_nil cell('one', catalog: cat, locale: 'fr')
+  end
+
+  def test_non_plural_entries_are_skipped
+    extra = { 'app.title' => { 'localizations' => { 'en' => unit('translated', 'WordPress') } } }
+    cat = catalog(extra: extra)
+    written = fold(cat, categories_by_locale: { 'fr' => %w[one other] })
+
+    assert_equal 1, written, 'only the plural entry is counted'
+    # The non-plural entry is left exactly as it was — no `fr` localization invented for it.
+    assert_equal({ 'en' => unit('translated', 'WordPress') }, cat.dig('strings', 'app.title', 'localizations'))
+  end
+
+  def test_counts_variations_across_locales
+    cat = catalog
+    written = fold(cat, categories_by_locale: { 'fr' => %w[one other], 'de' => %w[one other] })
+
+    assert_equal 2, written
+  end
+
+  # Re-running the fold with unchanged input must not re-call the model: the prior AI cells are carried over as
+  # anchors, so nothing is left to translate and the staged text is stable (no re-spend, no churn).
+  def test_rerun_preserves_ai_cells_and_skips_the_model
+    cat, first_calls = fold_polish(reply: POLISH_AI)
+    assert_equal 1, first_calls.size
+
+    second_calls = []
+    # A translator that would return DIFFERENT text if called — proving the re-run never touches it.
+    fold(cat,
+         categories_by_locale: { 'pl' => %w[one few many other] },
+         translations_by_locale: { 'pl' => { "#{KEY}#{INFIX}one" => '%lld wpis' } },
+         ai_translator: recording_translator(reply: { 'few' => 'DRIFT', 'many' => 'DRIFT', 'other' => 'DRIFT' }, calls: second_calls))
+
+    assert_empty second_calls, 'a re-run must not re-call the model for cells it already filled'
+    # The staged cells are unchanged: human `one`, and the first run's AI `few/many/other` (never the DRIFT text).
+    expected = { 'variations' => { 'plural' => {
+      'one' => unit('translated', '%lld wpis'),
+      'few' => unit('needs_review', '%lld wpisy'),
+      'many' => unit('needs_review', '%lld wpisów'),
+      'other' => unit('needs_review', '%lld wpisu')
+    } } }
+    assert_equal expected, cat.dig('strings', KEY, 'localizations', 'pl')
+  end
+
+  # A cell that fell back to English (the AI declined) is machine output only in name — it must be retried on the
+  # next run, not preserved, so a transient outage doesn't freeze English into the catalog.
+  def test_english_fallback_cells_are_retried_on_the_next_run
+    cat = catalog
+    fold(cat, # first run: AI declines entirely, so few/many/other fall back to English
+         categories_by_locale: { 'pl' => %w[one few many other] },
+         translations_by_locale: { 'pl' => { "#{KEY}#{INFIX}one" => '%lld wpis' } },
+         ai_translator: ->(**) {})
+    assert_equal unit('needs_review', '%lld posts'), cell('few', catalog: cat, locale: 'pl')
+
+    calls = []
+    fold(cat, # second run: AI recovers — the English-fallback cells must be re-offered to it
+         categories_by_locale: { 'pl' => %w[one few many other] },
+         translations_by_locale: { 'pl' => { "#{KEY}#{INFIX}one" => '%lld wpis' } },
+         ai_translator: recording_translator(reply: POLISH_AI, calls: calls))
+
+    assert_equal 1, calls.size, 'English-fallback cells must be retried when the AI tier recovers'
+    assert_equal({ 'one' => '%lld wpis' }, calls.first[:anchors], 'only the human form anchors; English-fallback cells are not kept')
+    assert_equal unit('needs_review', '%lld wpisy'), cell('few', catalog: cat, locale: 'pl')
+  end
+
+  # When a human translation arrives for a category the AI filled last run, it supersedes the machine cell; with
+  # every category now human- or kept-AI-covered, no model call is made.
+  def test_human_translation_supersedes_a_prior_ai_cell
+    cat, = fold_polish(reply: POLISH_AI)
+    assert_equal unit('needs_review', '%lld wpisy'), cell('few', catalog: cat, locale: 'pl')
+
+    calls = []
+    fold(cat,
+         categories_by_locale: { 'pl' => %w[one few many other] },
+         translations_by_locale: { 'pl' => { "#{KEY}#{INFIX}one" => '%lld wpis', "#{KEY}#{INFIX}few" => '%lld wpisy!' } },
+         ai_translator: recording_translator(reply: {}, calls: calls))
+
+    assert_equal unit('translated', '%lld wpisy!'), cell('few', catalog: cat, locale: 'pl')
+    assert_empty calls, 'human + kept-AI cover every category, so no model call'
+  end
+
+  # A source form left explicitly blank (only `other` carries text) must fall back to the English `other`, never
+  # ship a blank plural cell.
+  def test_blank_source_form_falls_back_to_english_not_empty
+    cat = {
+      'sourceLanguage' => 'en',
+      'strings' => { KEY => { 'localizations' => { 'en' => { 'variations' => { 'plural' => {
+        'one' => unit('translated', ''),
+        'other' => unit('translated', '%lld posts')
+      } } } } } }
+    }
+    fold(cat, categories_by_locale: { 'de' => %w[one other] })
+
+    assert_equal unit('needs_review', '%lld posts'), cell('one', catalog: cat, locale: 'de')
+    assert_equal unit('needs_review', '%lld posts'), cell('other', catalog: cat, locale: 'de')
+  end
+
+  # A whitespace-only GlotPress value is not a real translation: it must not ship as `translated`, must not anchor
+  # the AI request, and the category falls through to AI / English instead.
+  def test_whitespace_only_human_value_is_treated_as_untranslated
+    cat = catalog
+    calls = []
+    fold(cat,
+         categories_by_locale: { 'pl' => %w[one other] },
+         translations_by_locale: { 'pl' => { "#{KEY}#{INFIX}one" => '   ', "#{KEY}#{INFIX}other" => '%lld wpisów' } },
+         ai_translator: recording_translator(reply: { 'one' => '%lld wpis' }, calls: calls))
+
+    assert_equal({ 'other' => '%lld wpisów' }, calls.first[:anchors], 'a blank human value must not anchor the request')
+    assert_equal unit('needs_review', '%lld wpis'), cell('one', catalog: cat, locale: 'pl')
+    assert_equal unit('translated', '%lld wpisów'), cell('other', catalog: cat, locale: 'pl')
+  end
+end


### PR DESCRIPTION
Fills untranslated plurals in `Plurals.xcstrings` with AI translations when we download strings from GlotPress. This replaces the placeholder left by #25688, using the translation code that merged in #25705.

## How it works

When a release downloads translations from GlotPress, each plural form in each language now gets the best available text, in this order: a human translation if GlotPress has one, otherwise an AI translation, otherwise the English text (`human ?? AI ?? English`). Human translations are marked `translated`; everything else is marked `needs_review` so machine output stays identifiable.

Three properties worth calling out:

- **It's off by default and can't break a release.** The AI step only runs when `ANTHROPIC_API_KEY` is set. Without the key — or if the API errors mid-run — the affected plurals keep their English fallback, which is exactly what happens today.
- **The model translates each plural in one request, not one form at a time.** Asking for the Polish forms of "%1$ld word" one by one lets the model pick a different word each time (`słowo` → `wyrazy` → `słów`). One request per plural per language keeps the same word across all forms, and any human-translated forms are included in the request so the AI matches their word choice.
- **Re-running the lane doesn't re-translate.** AI text already in the catalog is kept as-is — no repeat API cost, no churn under a reviewer mid-review. A human translation always replaces it on the next download.

## Nothing user-visible changes

`Plurals.xcstrings` is built into the app but nothing reads it at runtime yet — plurals still render from the legacy files. This PR stages translations in the catalog so they're ready when plurals switch over to it. No machine-translated text ships today.

Regular (non-plural) strings are deliberately untouched: they ship from the live `Localizable.strings`, where a machine translation would reach users immediately. They wait for the String Catalog cutover — the reasoning is written down in `docs/localization-pipeline.md`, which this PR adds.

## Test plan

- [x] `ruby fastlane/lanes/*_test.rb` — 69 tests green (also run in CI)
- [x] Live run of `bundle exec fastlane ios download_localized_plurals` with an API key: all 66 plural/language combinations (2 plurals × 33 languages) filled with real translations. Format placeholders preserved in every cell, and each language got exactly the plural forms its grammar requires (Japanese one, Polish four, Arabic six). The only exceptions: Arabic's `one`/`two` forms, where the model dropped the numeral (natural Arabic phrasing) and the placeholder check correctly rejected it — those cells kept English, as designed.
- [x] Re-folding the populated catalog leaves it unchanged and doesn't re-request cells that already hold AI text

To test this yourself, run the lane (needs `ANTHROPIC_API_KEY` and `bundle install`). It commits the folded catalog — discard that commit rather than pushing it. This PR deliberately keeps the catalog English-only; it gets populated for real during release runs.

## Related

- #25705 — the AI translation code this wires in (merged)
- #25688 — the String Catalog plural pipeline that left the placeholder this fills
