### PR TITLE
Point MediaEditor-iOS to 1.3.0

### DIFF
--- a/Modules/Package.resolved
+++ b/Modules/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "49b054a77ad3470b9b49c42d61f34905f5ca3f3211e1557c142c484a9ad7bda8",
+  "originHash" : "aadb46fafeb5588e1efd3609cd1355d5ac3c4537c154c7acf9e8cb63849c1d52",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -149,8 +149,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/wordpress-mobile/MediaEditor-iOS",
       "state" : {
-        "branch" : "task/spm-support",
-        "revision" : "e9f74b21276d5cd1cb94ee1c09cc060b23187832"
+        "revision" : "3c980155634905c7fd3a310271e6633e781412b3",
+        "version" : "1.3.0"
       }
     },
     {

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -52,7 +52,7 @@ let package = Package(
 
         .package(url: "https://github.com/weichsel/ZIPFoundation", from: "0.9.19"),
         .package(url: "https://github.com/wordpress-mobile/FSInteractiveMap", from: "0.3.0"),
-        .package(url: "https://github.com/wordpress-mobile/MediaEditor-iOS", exact: "1.3.0"),
+        .package(url: "https://github.com/wordpress-mobile/MediaEditor-iOS", from: "1.3.0"),
         .package(url: "https://github.com/wordpress-mobile/NSObject-SafeExpectations", from: "0.0.6"),
         .package(url: "https://github.com/wordpress-mobile/wpxmlrpc", from: "0.9.0"),
         .package(

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -52,7 +52,7 @@ let package = Package(
 
         .package(url: "https://github.com/weichsel/ZIPFoundation", from: "0.9.19"),
         .package(url: "https://github.com/wordpress-mobile/FSInteractiveMap", from: "0.3.0"),
-        .package(url: "https://github.com/wordpress-mobile/MediaEditor-iOS", branch: "task/spm-support"),
+        .package(url: "https://github.com/wordpress-mobile/MediaEditor-iOS", exact: "1.3.0"),
         .package(url: "https://github.com/wordpress-mobile/NSObject-SafeExpectations", from: "0.0.6"),
         .package(url: "https://github.com/wordpress-mobile/wpxmlrpc", from: "0.9.0"),
         .package(


### PR DESCRIPTION
Finally got down to making the [SwiftPM support in MediaEditor-iOS](https://github.com/wordpress-mobile/MediaEditor-iOS/pull/45) official. This PR moves the dependency off the working branch and onto a new release.

<details>
<summary>AI-generated details</summary>

## Description

Pins the `MediaEditor-iOS` SwiftPM dependency to the tagged `1.3.0` release, replacing the temporary `task/spm-support` branch the package was tracking. The branch existed only to ship SwiftPM support ahead of a tagged release; `1.3.0` now carries that support, so the moving branch reference can be retired for a stable, auditable version pin.

## Testing instructions

- `rake dependencies` resolves cleanly, then build the `WordPress` scheme.
- Exercise the media editor (crop/rotate an image when attaching media to a post) to confirm no behavioral regression.

</details>