### PR TITLE
Bump wordpress-rs to a build exposing unified support conversations

### DIFF
--- a/Modules/Package.resolved
+++ b/Modules/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "49b054a77ad3470b9b49c42d61f34905f5ca3f3211e1557c142c484a9ad7bda8",
+  "originHash" : "3be88eddc8e9d11af21594a5314ff884d41ff6ebfb5d21ddcb242a46452f8ad1",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -336,8 +336,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/automattic/wordpress-rs",
       "state" : {
-        "revision" : "7065171801606268e9ad0554cf8ec3b7de8ff04d",
-        "version" : "0.3.0"
+        "branch" : "pr-build/1414",
+        "revision" : "6a6719115709e06fe9af56cc164ee75a3c601583"
       }
     },
     {

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -63,7 +63,11 @@ let package = Package(
         .package(url: "https://github.com/wordpress-mobile/GutenbergKit", from: "0.15.0"),
         .package(
             url: "https://github.com/automattic/wordpress-rs",
-            exact: "0.3.0"
+            // Interim pr-build pin: first SPM-consumable wordpress-rs build exposing the
+            // unified support-conversations endpoints (`unifiedConversations`, added in
+            // wordpress-rs#1288). No tagged release includes them yet — move to a tagged
+            // release before this ships. See PR description.
+            branch: "pr-build/1414"
         ),
         .package(
             url: "https://github.com/Automattic/color-studio",


### PR DESCRIPTION
## Why this is needed

We're porting the Android **unified "Get help" support** flow ([WordPress-Android#22946](https://github.com/wordpress-mobile/WordPress-Android/pull/22946), [#23011](https://github.com/wordpress-mobile/WordPress-Android/pull/23011)) to iOS. That flow merges the separate **"Ask the Bots"** and **"Ask the Happiness Engineers"** features into a single combined conversations list + type‑branched detail, backed by a **new server‑side combined endpoint** in `wordpress-rs`.

iOS today pins `wordpress-rs` **`0.3.0`**, which only exposes the *separate* executors:

- `supportBots` — bot chats
- `supportTickets` — HE tickets
- `supportEligibility`

It does **not** expose the combined `unifiedConversations` executor (list / detail / reply for *both* conversation types) that the whole unification is built on. That endpoint was added in **[wordpress-rs#1288](https://github.com/Automattic/wordpress-rs/pull/1288)** ("Add unified support conversations endpoints") — the same rs change Android adopted (`1288-85a8554`). Without this bump the iOS port is blocked.

## What changed

Repins `wordpress-rs` from `exact: "0.3.0"` to `branch: "pr-build/1414"` in `Modules/Package.swift` + `Modules/Package.resolved`.

`pr-build/1414` is the first **SPM‑consumable** `wordpress-rs` build that includes the unified endpoints. The endpoint landed on `trunk`, but `trunk`'s `Package.swift` is configured `.local` (it expects a locally‑built Rust xcframework, which iOS has no tooling to produce), and every existing release **tag** predates #1288. The `pr-build/<PR#>` branches are `.release`‑configured against a prebuilt xcframework published to the CDN, so SPM can download the binary — exactly the mechanism used previously in `integrate/wordpress-rs-pr-1367`. `pr-build/1414`'s only delta over trunk is an unrelated dependabot CI bump that doesn't touch the Swift/Rust surface.

## Verification

- `swift package resolve` succeeds and downloads `…/wordpress-rs/pr-builds/1414/libwordpressFFI.xcframework.zip` from the CDN.
- The public client surface (`WPComApiClient.swift`) diff from `0.3.0` → `pr-build/1414` is **purely additive** — it only adds the `unifiedConversations` executor; the existing `supportBots` / `supportTickets` / `supportEligibility` / `me` executors the app already uses are unchanged. So the bump is expected to be non‑breaking for current call sites.
- Full app build/test verification is left to CI.

## ⚠️ Interim pin — must move to a tagged release before shipping

This is an **interim `pr-build` pin**, not a stable release. Before the unified‑support feature ships, `wordpress-rs` needs to cut a **tagged release** that includes the #1288 unified endpoints, and this dependency should be repinned to that tag (the iOS equivalent of the "move to a tagged release before merge" caveat from the Android PR). `pr-build/*` branches are not guaranteed to be permanent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
