### PR TITLE
Localization: stop the AI translator stripping quotes that are part of a translated value

### DIFF
--- a/fastlane/lanes/ai_translator.rb
+++ b/fastlane/lanes/ai_translator.rb
@@ -263,7 +263,7 @@ class AITranslator # rubocop:disable Metrics/ClassLength -- mostly static locali
   def validated_forms(parsed, needed, english_forms)
     other = english_forms['other']
     needed.each_with_object({}) do |category, out|
-      candidate = clean(parsed[category].to_s)
+      candidate = parsed[category].to_s.strip # already JSON-decoded — trim only; clean() would strip a value's own quotes
       next if candidate.empty?
 
       source = english_forms[category] || other
@@ -311,7 +311,7 @@ class AITranslator # rubocop:disable Metrics/ClassLength -- mostly static locali
   # Map each numbered item to its validated translation by key; drop empty/placeholder-breaking ones.
   def validated_batch(parsed, numbered)
     numbered.each_with_object({}) do |(index, string), out|
-      candidate = clean(parsed[index.to_s].to_s)
+      candidate = parsed[index.to_s].to_s.strip # already JSON-decoded — trim only; clean() would strip a value's own quotes
       next if candidate.empty?
 
       out[string[:key]] = candidate if TranslationValidator.placeholders_match?(string[:source], candidate)
@@ -363,9 +363,11 @@ class AITranslator # rubocop:disable Metrics/ClassLength -- mostly static locali
     }
   end
 
-  # Models occasionally wrap the answer in quotation marks or add a trailing newline despite the
-  # "only the translation" instruction; strip those cosmetic wrappers. Anything more substantial (a prose
-  # explanation that slipped through) almost always breaks the placeholder gate and is discarded there.
+  # Strip the cosmetic wrapper a model sometimes adds to a RAW single-string reply — wrapping quotes or a
+  # trailing newline, despite the "only the translation" instruction. Only ever run this on a raw reply, never
+  # on a JSON-decoded value: JSON.parse has already removed the structural quotes, so any quotes left there are
+  # part of the content (a value like "Reader" must keep them). Anything more substantial (a prose explanation
+  # that slipped through) almost always breaks the placeholder gate and is discarded there.
   def clean(text)
     stripped = text.strip
     if stripped.length >= 2 &&

--- a/fastlane/lanes/ai_translator_test.rb
+++ b/fastlane/lanes/ai_translator_test.rb
@@ -305,4 +305,21 @@ class AITranslatorTest < Minitest::Test # rubocop:disable Metrics/ClassLength --
     )
     assert_equal({ 'sample.quoted' => '"Reader"' }, out)
   end
+
+  # The same holds for the curly/smart quotes clean() also strips: a JSON-decoded value wrapped in “ ” keeps them.
+  def test_translate_all_preserves_a_curly_quoted_value
+    reply = '{"1":"“Reader”"}'
+    out = translator(reply: reply).translate_all(
+      [{ key: 'sample.curly', source: '“Reader”' }], locale: 'fr'
+    )
+    assert_equal({ 'sample.curly' => '“Reader”' }, out)
+  end
+
+  # The async Batch path shares validated_batch with translate_all, so it must preserve a quoted value too.
+  def test_collect_batch_preserves_a_quoted_value
+    t = translator(reply: '{}')
+    prep = t.prepare_batch({ 'fr' => [{ key: 'sample.quoted', source: '"Reader"' }] }, batch_size: 25)
+    texts = { 'fr_0' => '{"1":"\"Reader\""}' }
+    assert_equal({ 'fr' => { 'sample.quoted' => '"Reader"' } }, t.collect_batch(texts, prep[:manifest]))
+  end
 end

--- a/fastlane/lanes/ai_translator_test.rb
+++ b/fastlane/lanes/ai_translator_test.rb
@@ -286,4 +286,23 @@ class AITranslatorTest < Minitest::Test # rubocop:disable Metrics/ClassLength --
     prep = t.prepare_batch({ 'fr' => [{ key: 'a', source: 'One' }] }, batch_size: 25)
     assert_equal({ 'fr' => {} }, t.collect_batch({}, prep[:manifest]))
   end
+
+  # When a translation's value is itself wrapped in quotation marks, those quotes are part of the content and
+  # must survive — only the model's cosmetic wrapping around a raw reply should be stripped.
+  def test_translate_plural_preserves_a_quoted_value
+    reply = '{"other":"\"Reader\""}'
+    out = translator(reply: reply).translate_plural(
+      english_forms: { 'other' => '"Reader"' },
+      categories: %w[other], locale: 'fr'
+    )
+    assert_equal({ 'other' => '"Reader"' }, out)
+  end
+
+  def test_translate_all_preserves_a_quoted_value
+    reply = '{"1":"\"Reader\""}'
+    out = translator(reply: reply).translate_all(
+      [{ key: 'sample.quoted', source: '"Reader"' }], locale: 'fr'
+    )
+    assert_equal({ 'sample.quoted' => '"Reader"' }, out)
+  end
 end


### PR DESCRIPTION
Targeting #25705.

The AI translation tier could drop quotation marks that are part of a translated value. `translate_plural` and `translate_all` ran `clean()` — which removes the cosmetic quotes a model wraps around a *raw* reply — on values already decoded by `JSON.parse`, so a value whose own content is quoted (e.g. `"Reader"`) lost its quotes too.

## Fix

Run `clean()` only on the raw single-string reply in `translate()`. The JSON-decoded plural/batch values are whitespace-trimmed but never quote-stripped — `JSON.parse` has already removed the structural quotes, so anything left is content. This also covers the async `collect_batch` path (it shares `validated_batch`) and curly `“…”` quotes.

## Test plan

- [x] Four regression guards fail before the fix and pass after — straight `"…"` and curly `“…”` quotes, across both the sync (`translate_plural`/`translate_all`) and async (`collect_batch`) paths.
- [x] Full `ai_translator_test.rb` suite green (34 runs, 0 failures); `test_returns_cleaned_translation` still pins the single-string cosmetic-quote stripping, so the fix has to be path-specific.
- [x] RuboCop clean.