### PR TITLE
Secure Claude workflows

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -12,21 +12,41 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-      id-token: write
     steps:
+      # issue_comment payloads identify PR comments, but do not include the PR
+      # head repo. Query the PR before allowing Claude to run on fork PRs.
+      - name: Check PR origin
+        id: pr-origin
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          head_repo="$(gh api "repos/${REPOSITORY}/pulls/${ISSUE_NUMBER}" --jq '.head.repo.full_name' 2>/dev/null || true)"
+
+          if [ "$head_repo" = "$REPOSITORY" ]; then
+            echo "is_internal=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_internal=false" >> "$GITHUB_OUTPUT"
+            echo "Skipping Claude for external PR from ${head_repo:-unknown}."
+          fi
+
       - name: Checkout repository
-        uses: actions/checkout@v5
+        if: steps.pr-origin.outputs.is_internal == 'true'
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 1
 
       - name: PR Review with Progress Tracking
-        uses: anthropics/claude-code-action@v1
+        if: steps.pr-origin.outputs.is_internal == 'true'
+        uses: anthropics/claude-code-action@6a838f847a10bc4b88da6ae796ff68e74cf9f4cc # v1.0.158
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           track_progress: true
           prompt: |
             REPO: ${{ github.repository }}
-            PR NUMBER: ${{ github.event.pull_request.number }}
+            PR NUMBER: ${{ github.event.issue.number }}
 
             Perform a comprehensive code review with the following focus areas:
 
@@ -56,7 +76,6 @@ jobs:
                - Check API documentation accuracy
 
             Provide detailed feedback using inline comments for specific issues.
-            Use top-level comments for general observations or praise.
 
           claude_args: |
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr diff:*),Bash(gh pr view:*)"


### PR DESCRIPTION
## Summary
- Skip Claude workflows on fork/external PRs before checkout or Claude execution.
- Remove unused OIDC permissions and pin mutable action references.
- Keep review feedback inline-only where the workflow does not grant issue-comment permissions.

## Testing
- Parsed edited workflow YAML with Ruby.
- Ran `git diff --check` for workflow changes.