### PR TITLE
fix: Jetpack prologue top gradient fade disappears after backgrounding

### DIFF
--- a/WordPress/Classes/Jetpack/NUX/JetpackPrologueViewController.swift
+++ b/WordPress/Classes/Jetpack/NUX/JetpackPrologueViewController.swift
@@ -107,6 +107,7 @@ class JetpackPrologueViewController: UIViewController {
         gradientLayer.removeFromSuperlayer()
         gradientLayer = makeGradientLayer()
         view.layer.insertSublayer(gradientLayer, above: jetpackAnimatedView.layer)
+        gradientLayer.frame = view.bounds
     }
 
     override func viewDidLayoutSubviews() {


### PR DESCRIPTION
## Description

Fixes the Jetpack prologue top gradient fade disappearing after the app is backgrounded and returns (issue #25651). When the interface style changes, the gradient layer is removed and recreated, but the recreated layer was inserted without a frame, so it had zero bounds until the next layout pass and the fade was not visible. This sets `gradientLayer.frame = view.bounds` immediately after reinserting the layer, matching what `viewDidLayoutSubviews` already does, so the fade renders right away.

## Testing instructions

1. Launch the app to the Jetpack prologue screen.
2. Background the app and reopen it (or toggle the system appearance between light and dark, which triggers the interface-style change path).
3. Confirm the top gradient fade over the animation is still visible after returning, in both light and dark mode and in both orientations.

Before this change, the gradient fade vanished after the interface-style change until an unrelated layout pass restored it.

Fixes #25651
