### PR TITLE
Extract localizable strings from the Sources root

### DIFF
--- a/fastlane/lanes/localization.rb
+++ b/fastlane/lanes/localization.rb
@@ -211,6 +211,7 @@ platform :ios do
       paths: [
         'WordPress/',
         'Modules/Sources/',
+        'Sources/',
         gutenberg_path,
         *REMOTE_SWIFT_PACKAGES_TO_LOCALIZE.map { |name| File.join(derived_data_path, 'SourcePackages', 'checkouts', name, 'Sources') }
       ],

--- a/fastlane/lanes/localization_catalog.rb
+++ b/fastlane/lanes/localization_catalog.rb
@@ -32,7 +32,8 @@ LOCALIZABLE_CATALOG = File.join(PROJECT_ROOT_FOLDER, 'WordPress', 'Resources', '
 # Source roots to extract from — mirrors `generate_strings_file`'s genstrings inputs.
 CATALOG_SOURCE_ROOTS = [
   File.join(PROJECT_ROOT_FOLDER, 'WordPress'),
-  File.join(PROJECT_ROOT_FOLDER, 'Modules', 'Sources')
+  File.join(PROJECT_ROOT_FOLDER, 'Modules', 'Sources'),
+  File.join(PROJECT_ROOT_FOLDER, 'Sources')
 ].freeze
 
 # The custom localization routine to additionally extract (same as the genstrings `routines:` today).


### PR DESCRIPTION
When the stats widget code moved from WordPress/JetpackStatsWidgets to Sources/JetpackStatsWidgets in https://github.com/wordpress-mobile/WordPress-iOS/pull/24473, its 36 `widget.*` keys fell out of the genstrings scan roots, so the next code freeze dropped them from GlotPress (https://github.com/wordpress-mobile/WordPress-iOS/pull/24530) and the widget UI has shipped English-only since. Add the top-level Sources directory to the extraction paths and to the strings catalog roots that mirror them.
