### PR TITLE
App Intents: stop donating screen activities as Siri predictions

### DIFF
--- a/Modules/Sources/WordPressData/Swift/SearchableActivityConvertable.swift
+++ b/Modules/Sources/WordPressData/Swift/SearchableActivityConvertable.swift
@@ -31,7 +31,10 @@ extension WPActivityType {
         case .appSettings:
             return NSLocalizedString("WordPress App Settings", comment: "Siri Suggestion to open App Settings")
         case .notificationSettings:
-            return NSLocalizedString("WordPress Notification Settings", comment: "Siri Suggestion to open Notification Settings")
+            return NSLocalizedString(
+                "WordPress Notification Settings",
+                comment: "Siri Suggestion to open Notification Settings"
+            )
         case .support:
             return NSLocalizedString("WordPress Help", comment: "Siri Suggestion to open Support")
         case .notifications:
@@ -49,30 +52,30 @@ public enum WPActivityUserInfoKeys: String {
 @objc public protocol SearchableActivityConvertable {
     /// Type name used to uniquly indentify this activity.
     ///
-    @objc var activityType: String {get}
+    @objc var activityType: String { get }
 
     /// Activity title to be displayed in spotlight search.
     ///
-    @objc var activityTitle: String {get}
+    @objc var activityTitle: String { get }
 
     // MARK: Optional Vars
 
     /// A set of localized keywords that can help users find the activity in search results.
     ///
-    @objc optional var activityKeywords: Set<String>? {get}
+    @objc optional var activityKeywords: Set<String>? { get }
 
     /// The date after which the activity is no longer eligible for indexing. If not set,
     /// the expiration date will default to one week from the current date.
     ///
-    @objc optional var activityExpirationDate: Date? {get}
+    @objc optional var activityExpirationDate: Date? { get }
 
     /// A dictionary containing state information related to this indexed activity.
     ///
-    @objc optional var activityUserInfo: [String: String]? {get}
+    @objc optional var activityUserInfo: [String: String]? { get }
 
     /// Activity description
     ///
-    @objc optional var activityDescription: String? {get}
+    @objc optional var activityDescription: String? { get }
 }
 
 public extension SearchableActivityConvertable where Self: UIViewController {

--- a/Modules/Sources/WordPressData/Swift/SearchableActivityConvertable.swift
+++ b/Modules/Sources/WordPressData/Swift/SearchableActivityConvertable.swift
@@ -1,7 +1,5 @@
 import UIKit
 import CoreSpotlight
-import Intents
-import MobileCoreServices
 import UniformTypeIdentifiers
 
 /// Custom NSUSerActivity types for the WPiOS. Primarily used for navigation points.
@@ -15,32 +13,6 @@ public enum WPActivityType: String {
     case notificationSettings = "org.wordpress.me.notificationsettings"
     case support = "org.wordpress.me.support"
     case notifications = "org.wordpress.notifications"
-}
-
-extension WPActivityType {
-    var suggestedInvocationPhrase: String {
-        switch self {
-        case .siteList:
-            return NSLocalizedString("My Sites in WordPress", comment: "Siri Suggestion to open My Sites")
-        case .siteDetails:
-            return NSLocalizedString("WordPress Site Details", comment: "Siri Suggestion to open My Sites")
-        case .reader:
-            return NSLocalizedString("WordPress Reader", comment: "Siri Suggestion to open My Sites")
-        case .me:
-            return NSLocalizedString("WordPress Profile", comment: "Siri Suggestion to open Me tab")
-        case .appSettings:
-            return NSLocalizedString("WordPress App Settings", comment: "Siri Suggestion to open App Settings")
-        case .notificationSettings:
-            return NSLocalizedString(
-                "WordPress Notification Settings",
-                comment: "Siri Suggestion to open Notification Settings"
-            )
-        case .support:
-            return NSLocalizedString("WordPress Help", comment: "Siri Suggestion to open Support")
-        case .notifications:
-            return NSLocalizedString("WordPress Notifications", comment: "Siri Suggestion to open Notifications")
-        }
-    }
 }
 
 /// NSUserActivity userInfo keys
@@ -108,11 +80,6 @@ public extension SearchableActivityConvertable where Self: UIViewController {
 
         activity.isEligibleForSearch = true
         activity.isEligibleForHandoff = false
-        activity.isEligibleForPrediction = true
-
-        if let wpActivityType = WPActivityType(rawValue: activityType) {
-            activity.suggestedInvocationPhrase = wpActivityType.suggestedInvocationPhrase
-        }
 
         // Set the UIViewController's userActivity property, which is defined in UIResponder. Doing this allows
         // UIKit to automagically manage this user activity (e.g. making it current when needed)

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 27.3
 -----
 * [*] Stats: Improve performance when opening the Stats screen [#25938]
+* [*] [internal] Stop donating screen activities as Siri predictions now that App Shortcuts cover them [#25757]
 
 27.2
 -----

--- a/WordPress/Classes/System/WordPressAppDelegate.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate.swift
@@ -110,6 +110,7 @@ public class WordPressAppDelegate: UIResponder, UIApplicationDelegate {
 
         MemoryCache.shared.register()
         MediaImageService.migrateCacheIfNeeded()
+        purgeLegacySiriDonationsIfNeeded()
         PostCoordinator.shared.delegate = self
 
         // Start CrashLogging as soon as possible (in case a crash happens during startup)
@@ -413,6 +414,19 @@ public class WordPressAppDelegate: UIResponder, UIApplicationDelegate {
 
     private func mergeDuplicateAccountsIfNeeded() {
         AccountService(coreDataStack: ContextManager.shared).mergeDuplicatesIfNecessary()
+    }
+
+    /// Deletes the user activities donated as Siri predictions by earlier app versions,
+    /// because the app no longer donates predictions and the system keeps the old
+    /// suggestions until they are explicitly deleted.
+    // TODO: Remove this cleanup after a few releases.
+    private func purgeLegacySiriDonationsIfNeeded() {
+        let didPurgeKey = "did-purge-legacy-siri-donations"
+        guard !UserDefaults.standard.bool(forKey: didPurgeKey) else {
+            return
+        }
+        UserDefaults.standard.set(true, forKey: didPurgeKey)
+        NSUserActivity.deleteAllSavedUserActivities {}
     }
 
     private func setupPingHub() {

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -345,7 +345,6 @@ import WordPressShared
     case appSettingsImageQualityChanged
     case appSettingsClearMediaCacheTapped
     case appSettingsClearSpotlightIndexTapped
-    case appSettingsClearSiriSuggestionsTapped
     case appSettingsOpenDeviceSettingsTapped
     case experimentalFeatureToggled
 
@@ -1298,8 +1297,6 @@ import WordPressShared
             return "app_settings_clear_media_cache_tapped"
         case .appSettingsClearSpotlightIndexTapped:
             return "app_settings_clear_spotlight_index_tapped"
-        case .appSettingsClearSiriSuggestionsTapped:
-            return "app_settings_clear_siri_suggestions_tapped"
         case .appSettingsOpenDeviceSettingsTapped:
             return "app_settings_open_device_settings_tapped"
         case .appSettingsOptimizeImagesChanged:

--- a/WordPress/Classes/ViewRelated/Me/App Settings/AppSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/AppSettingsViewController.swift
@@ -354,19 +354,6 @@ class AppSettingsViewController: UITableViewController {
         }
     }
 
-    func clearSiriActivityDonations() -> ImmuTableAction {
-        return { [tableView] _ in
-            WPAnalytics.track(.appSettingsClearSiriSuggestionsTapped)
-
-            tableView?.deselectSelectedRowWithAnimation(true)
-
-            NSUserActivity.deleteAllSavedUserActivities {}
-
-            let notice = Notice(title: NSLocalizedString("Siri Reset Confirmation", value: "Successfully cleared Siri Shortcut Suggestions", comment: "Notice displayed to the user after clearing the Siri activity donations."), feedbackType: .success)
-            ActionDispatcher.dispatch(NoticeAction.post(notice))
-        }
-    }
-
     func clearSpotlightCache() -> ImmuTableAction {
         return { [weak self] _ in
             WPAnalytics.track(.appSettingsClearSpotlightIndexTapped)
@@ -531,13 +518,6 @@ private extension AppSettingsViewController {
             privacySettings,
             spotlightClearCacheRow
         ]
-
-        let siriClearCacheRow = BrandedNavigationRow(
-            title: NSLocalizedString("Siri Reset Prompt", value: "Clear Siri Shortcut Suggestions", comment: "Label for button that clears user activities donated to Siri."),
-            action: clearSiriActivityDonations(),
-            accessibilityIdentifier: "spotlightClearCacheButton")
-
-        tableRows.append(siriClearCacheRow)
 
         tableRows.append(mediaRemoveLocation)
         let removeLocationFooterText = NSLocalizedString("Removes location metadata from photos before uploading them to your site.", comment: "Explanatory text for removing the location from uploaded media.")


### PR DESCRIPTION
Since we have migrated from SiriKit to App Intents, these donating related code becomes redundant.