### PR TITLE
Update Automattic-Tracks-iOS from 4.1.0 to 4.3.1

### DIFF
--- a/Modules/Package.resolved
+++ b/Modules/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "c2e10ed10ee110164398ea3c932567ca4423cd74961173a4a9cdb8702c735787",
+  "originHash" : "e9a0e7ab7d81fc80e7d9edea5811451d65ac1233ae7ae3e7963e34cbd873396e",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Automattic/Automattic-Tracks-iOS",
       "state" : {
-        "revision" : "7442def327dbbc9158c0d780382843e0b7a2e6c9",
-        "version" : "4.1.0"
+        "revision" : "cdc9348b2804af0b70a06d125fd4236d5c6f7f39",
+        "version" : "4.3.1"
       }
     },
     {
@@ -300,8 +300,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/jedisct1/swift-sodium",
       "state" : {
-        "revision" : "4f9164a0a2c9a6a7ff53a2833d54a5c79c957342",
-        "version" : "0.9.1"
+        "revision" : "cfd195c76882aa9b997560ca7cb95d72fbf5db00",
+        "version" : "0.11.0"
       }
     },
     {

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -35,7 +35,7 @@ let package = Package(
         .package(url: "https://github.com/AliSoftware/OHHTTPStubs", from: "9.1.0"),
         .package(url: "https://github.com/apple/swift-collections", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.5.2"),
-        .package(url: "https://github.com/Automattic/Automattic-Tracks-iOS", from: "4.1.0"),
+        .package(url: "https://github.com/Automattic/Automattic-Tracks-iOS", from: "4.3.1"),
         .package(url: "https://github.com/Automattic/AutomatticAbout-swift", from: "1.1.5"),
         .package(url: "https://github.com/Automattic/Gravatar-SDK-iOS", from: "3.4.0"),
         .package(url: "https://github.com/Automattic/Gridicons-iOS", branch: "develop"),


### PR DESCRIPTION
## Description

Minimal upgrade of `Automattic-Tracks-iOS` from `4.1.0` to `4.3.1` (the latest release), with no app-side code changes. Bumps the dependency floor in `Modules/Package.swift` and re-resolves `Modules/Package.resolved`.

There are **no breaking API changes** across the bump. Changelog:

- **4.3.1** — Made `ExPlat.shared` lifecycle thread-safe to fix a crash.
- **4.3.0** — Track whether Lockdown Mode is enabled as a device property (`device_info_lockdown_mode_enabled`); tvOS support.
- **4.2.1** — Fix non-public `UIApplication` API usage on watchOS (App Store rejection 90338).
- **4.2.0** — Fix `logID` setter silently failing when `event.extra` is nil, causing Sentry crash reports to intermittently miss the encrypted log UUID; watchOS compatibility.

### Transitive change

Tracks 4.3.1 raised its `swift-sodium` floor to `0.10.0`, so re-resolving bumped `swift-sodium` `0.9.1` → `0.11.0` — the newest in-range. `0.11.0` shipped 2026-05-04, *before* Tracks 4.3.1 (2026-06-26), so it's the version Tracks 4.3.1 itself builds against. `swift-sodium` is transitive-only — used inside Tracks, the app imports no Sodium APIs directly — and `0.11.0` is additive (ML-KEM bindings, libsodium refresh, header/packaging cleanup). `sentry-cocoa` is **unchanged** at `9.4.0`.

Package graph re-resolved cleanly with the repo-pinned Xcode 26.6 toolchain.

## Testing instructions

- [ ] CI green — full build + unit tests.
- [ ] App launches and analytics events still fire (Tracks initialization unchanged).

No app-code or user-facing behavior changes, so there is nothing to test manually beyond confirming the app builds and events are still tracked.