### PR TITLE
Avoid task delegates for background sessions

### DIFF
--- a/Modules/Sources/WordPressKit/HTTPClient.swift
+++ b/Modules/Sources/WordPressKit/HTTPClient.swift
@@ -67,12 +67,21 @@ extension URLSession {
         errorType: E.Type = E.self
     ) async -> WordPressAPIResult<HTTPAPIResponse<Data>, E> {
         if configuration.identifier != nil {
-            assert(delegate is BackgroundURLSessionDelegate, "Unexpected `URLSession` delegate type. See the `backgroundSession(configuration:)`")
+            assert(
+                delegate is BackgroundURLSessionDelegate,
+                "Unexpected `URLSession` delegate type. See the `backgroundSession(configuration:)`"
+            )
         }
 
         if let parentProgress {
-            assert(parentProgress.completedUnitCount == 0 && parentProgress.totalUnitCount > 0, "Invalid parent progress")
-            assert(parentProgress.cancellationHandler == nil, "The progress instance's cancellationHandler property must be nil")
+            assert(
+                parentProgress.completedUnitCount == 0 && parentProgress.totalUnitCount > 0,
+                "Invalid parent progress"
+            )
+            assert(
+                parentProgress.cancellationHandler == nil,
+                "The progress instance's cancellationHandler property must be nil"
+            )
         }
 
         let taskHolder = TaskHolder()
@@ -83,7 +92,11 @@ extension URLSession {
                         guard let task = await taskHolder.task as? URLSessionDataTask else { return }
 
                         if let data {
-                            (wpkURLSessionNotifyingDelegate as? URLSessionDataDelegate)?.urlSession?(self, dataTask: task, didReceive: data)
+                            (wpkURLSessionNotifyingDelegate as? URLSessionDataDelegate)?.urlSession?(
+                                self,
+                                dataTask: task,
+                                didReceive: data
+                            )
                         }
                         wpkURLSessionNotifyingDelegate?.urlSession?(self, task: task, didCompleteWithError: error)
                     }
@@ -146,7 +159,8 @@ extension URLSession {
         let callCompletionFromDelegate = delegate is BackgroundURLSessionDelegate
         let isBackgroundSession = configuration.identifier != nil
         let task: URLSessionTask
-        let body = try builder.encodeMultipartForm(request: &request, forceWriteToFile: isBackgroundSession)
+        let body =
+            try builder.encodeMultipartForm(request: &request, forceWriteToFile: isBackgroundSession)
             ?? builder.encodeXMLRPC(request: &request, forceWriteToFile: isBackgroundSession)
         var completion = originalCompletion
         if let body {
@@ -183,7 +197,10 @@ extension URLSession {
         }
 
         if callCompletionFromDelegate {
-            assert(delegate is BackgroundURLSessionDelegate, "Unexpected `URLSession` delegate type. See the `backgroundSession(configuration:)`")
+            assert(
+                delegate is BackgroundURLSessionDelegate,
+                "Unexpected `URLSession` delegate type. See the `backgroundSession(configuration:)`"
+            )
 
             set(completion: completion, forTaskWithIdentifier: task.taskIdentifier)
         }
@@ -230,7 +247,9 @@ extension WordPressAPIResult {
             do {
                 return try .success(transform(success))
             } catch {
-                return .failure(.unparsableResponse(response: success.response, body: success.body, underlyingError: error))
+                return .failure(
+                    .unparsableResponse(response: success.response, body: success.body, underlyingError: error)
+                )
             }
         }
     }
@@ -252,7 +271,8 @@ extension WordPressAPIResult {
                 do {
                     return try WordPressAPIError<E>.endpointError(transform(response, body))
                 } catch {
-                    return WordPressAPIError<E>.unparsableResponse(response: response, body: body, underlyingError: error)
+                    return WordPressAPIError<E>
+                        .unparsableResponse(response: response, body: body, underlyingError: error)
                 }
             }
             return error

--- a/Modules/Sources/WordPressKit/HTTPClient.swift
+++ b/Modules/Sources/WordPressKit/HTTPClient.swift
@@ -107,7 +107,11 @@ extension URLSession {
                     return
                 }
 
-                task.delegate = wpkURLSessionNotifyingDelegate
+                // Background tasks only support the delegate assigned to their session at creation time.
+                if configuration.identifier == nil, let delegate = wpkURLSessionNotifyingDelegate {
+                    task.delegate = delegate
+                }
+
                 task.resume()
                 taskCreated?(task.taskIdentifier)
                 Task { await taskHolder.assign(task) }

--- a/Modules/Sources/WordPressKit/HTTPClient.swift
+++ b/Modules/Sources/WordPressKit/HTTPClient.swift
@@ -66,7 +66,7 @@ extension URLSession {
         fulfilling parentProgress: Progress? = nil,
         errorType: E.Type = E.self
     ) async -> WordPressAPIResult<HTTPAPIResponse<Data>, E> {
-        if configuration.identifier != nil {
+        if isBackgroundSession() {
             assert(
                 delegate is BackgroundURLSessionDelegate,
                 "Unexpected `URLSession` delegate type. See the `backgroundSession(configuration:)`"
@@ -121,7 +121,7 @@ extension URLSession {
                 }
 
                 // Background tasks only support the delegate assigned to their session at creation time.
-                if configuration.identifier == nil, let delegate = wpkURLSessionNotifyingDelegate {
+                if !isBackgroundSession(), let delegate = wpkURLSessionNotifyingDelegate {
                     task.delegate = delegate
                 }
 
@@ -157,7 +157,7 @@ extension URLSession {
         //
         // In reality, `callCompletionFromDelegate` and `isBackgroundSession` have the same value.
         let callCompletionFromDelegate = delegate is BackgroundURLSessionDelegate
-        let isBackgroundSession = configuration.identifier != nil
+        let isBackgroundSession = self.isBackgroundSession()
         let task: URLSessionTask
         let body =
             try builder.encodeMultipartForm(request: &request, forceWriteToFile: isBackgroundSession)
@@ -206,6 +206,10 @@ extension URLSession {
         }
 
         return task
+    }
+
+    private func isBackgroundSession() -> Bool {
+        configuration.identifier != nil
     }
 
     private static func parseResponse<E: LocalizedError>(


### PR DESCRIPTION
## Description

I noticed this share extension crash in the App Store Connection crash reporter in Xcode.

<img width="605" src="https://github.com/user-attachments/assets/3bd236b0-1ac6-48f5-ad2b-7a7d82cc79b6" />
