### PR TITLE
Remove a local feature flag `cptPostsAndPages`

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -27,7 +27,6 @@ public enum FeatureFlag: Int, CaseIterable {
     case nativeBlockInserter
     case statsAds
     case customPostTypes
-    case cptPostsAndPages
     case mediaLibraryV2
 
     /// Returns a boolean indicating if the feature is enabled.
@@ -88,8 +87,6 @@ public enum FeatureFlag: Int, CaseIterable {
             return BuildConfiguration.current == .debug
         case .customPostTypes:
             return BuildConfiguration.current == .debug
-        case .cptPostsAndPages:
-            return BuildConfiguration.current == .debug
         case .mediaLibraryV2:
             return BuildConfiguration.current == .debug
         }
@@ -135,7 +132,6 @@ extension FeatureFlag {
         case .nativeBlockInserter: "Native Block Inserter"
         case .statsAds: "Stats Ads Tab"
         case .customPostTypes: "Custom Post Types"
-        case .cptPostsAndPages: "Custom Post Types: Posts and Pages"
         case .mediaLibraryV2: "Media Library v2"
         }
     }

--- a/WordPress/Classes/ViewRelated/CustomPostTypes/CustomPostTypeService.swift
+++ b/WordPress/Classes/ViewRelated/CustomPostTypes/CustomPostTypeService.swift
@@ -62,9 +62,6 @@ class CustomPostTypeService {
                 if case .custom = details.toPostEndpointType(), details.slug != "attachment" {
                     return details
                 }
-                if FeatureFlag.cptPostsAndPages.enabled, [.posts, .pages].contains(details.toPostEndpointType()) {
-                    return details
-                }
                 return nil
             }
             .sorted(using: KeyPathComparator(\.name))


### PR DESCRIPTION
The feature flag was added for easier comparison between the exiting post list implementation and the new cpt one: the CPT ones show up along side with the existing ones when the feature flag is enabled.

We don't need the comparison anymore and the feature flag is removed as if it's disabled.
