### PR TITLE
Fix Blogging Reminders text color in dark mode

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,7 +4,7 @@
 * [*] [internal] In-app updates: guard the flexible update notice against double-posting when two update checks race [#25666]
 * [*] [build tooling] Add a String Catalog localization pipeline (plurals + build-free catalog generation) with a CI coverage gate [#25688]
 * [*] [internal] Stats widgets: migrate the site picker from SiriKit to App Intents [#25753]
-
+* [*] Fix Blogging Reminders text color in dark mode [#25780]
 
 27.0
 -----

--- a/Tests/KeystoneTests/Tests/Features/Blog/BloggingRemindersScheduleFormatterTests.swift
+++ b/Tests/KeystoneTests/Tests/Features/Blog/BloggingRemindersScheduleFormatterTests.swift
@@ -1,0 +1,25 @@
+import Testing
+import UIKit
+
+@testable import WordPress
+
+struct BloggingRemindersScheduleFormatterTests {
+
+    @Test @MainActor func longDescriptionPreservesEmphasisWithoutSpecifyingForegroundColor() {
+        let description = BloggingRemindersScheduleFormatter()
+            .longScheduleDescription(
+                for: .weekdays([.monday]),
+                time: "10:00 AM"
+            )
+
+        var containsBoldText = false
+        description.enumerateAttributes(in: NSRange(location: 0, length: description.length)) { attributes, _, _ in
+            #expect(attributes[.foregroundColor] == nil)
+            if let font = attributes[.font] as? UIFont {
+                containsBoldText = containsBoldText || font.fontDescriptor.symbolicTraits.contains(.traitBold)
+            }
+        }
+
+        #expect(containsBoldText)
+    }
+}

--- a/WordPress/Classes/Utility/Blogging Reminders/BloggingRemindersScheduleFormatter.swift
+++ b/WordPress/Classes/Utility/Blogging Reminders/BloggingRemindersScheduleFormatter.swift
@@ -4,16 +4,21 @@ struct BloggingRemindersScheduleFormatter {
     private let calendar: Calendar
 
     init(calendar: Calendar? = nil) {
-        self.calendar = calendar ?? {
-            var calendar = Calendar.current
-            calendar.locale = Locale.autoupdatingCurrent
-            return calendar
-        }()
+        self.calendar =
+            calendar
+            ?? {
+                var calendar = Calendar.current
+                calendar.locale = Locale.autoupdatingCurrent
+                return calendar
+            }()
     }
 
     /// Attributed short description string of the current schedule for the specified blog.
     ///
-    func shortScheduleDescription(for schedule: BloggingRemindersScheduler.Schedule, time: String? = nil) -> NSAttributedString {
+    func shortScheduleDescription(
+        for schedule: BloggingRemindersScheduler.Schedule,
+        time: String? = nil
+    ) -> NSAttributedString {
         switch schedule {
         case .none:
             return Self.stringToAttributedString(TextContent.shortNoRemindersDescription)
@@ -28,7 +33,8 @@ struct BloggingRemindersScheduleFormatter {
 
     /// Attributed long description string of the current schedule for the specified blog.
     ///
-    func longScheduleDescription(for schedule: BloggingRemindersScheduler.Schedule, time: String) -> NSAttributedString {
+    func longScheduleDescription(for schedule: BloggingRemindersScheduler.Schedule, time: String) -> NSAttributedString
+    {
         switch schedule {
         case .none:
             return NSAttributedString(string: TextContent.longNoRemindersDescription)
@@ -47,17 +53,26 @@ struct BloggingRemindersScheduleFormatter {
             }
 
             let markedUpDays: [String] = sortedDays.compactMap({ day in
-                return "<strong>\(self.calendar.weekdaySymbols[day.rawValue])</strong>"
+                "<strong>\(self.calendar.weekdaySymbols[day.rawValue])</strong>"
             })
 
             let text: String
 
             if days.count == 1 {
-                text = String(format: TextContent.oneReminderLongDescriptionWithTime, markedUpDays.first ?? "", "<strong>\(time)</strong>")
+                text = String(
+                    format: TextContent.oneReminderLongDescriptionWithTime,
+                    markedUpDays.first ?? "",
+                    "<strong>\(time)</strong>"
+                )
             } else {
                 let formatter = ListFormatter()
                 let formattedDays = formatter.string(from: markedUpDays) ?? ""
-                text = String(format: TextContent.manyRemindersLongDescriptionWithTime, "<strong>\(days.count)</strong>", formattedDays, "<strong>\(time)</strong>")
+                text = String(
+                    format: TextContent.manyRemindersLongDescriptionWithTime,
+                    "<strong>\(days.count)</strong>",
+                    formattedDays,
+                    "<strong>\(time)</strong>"
+                )
             }
 
             return Self.stringToAttributedString(text)
@@ -83,7 +98,8 @@ private extension BloggingRemindersScheduleFormatter {
             case 2:
                 return String(format: TextContent.twoRemindersShortDescriptionWithTime, time)
             case 7:
-                return "<strong>" + String(format: TextContent.everydayRemindersShortDescriptionWithTime, time) + "</strong>"
+                return "<strong>" + String(format: TextContent.everydayRemindersShortDescriptionWithTime, time)
+                    + "</strong>"
             default:
                 return String(format: TextContent.manyRemindersShortDescriptionWithTime, days, time)
             }
@@ -119,19 +135,28 @@ private extension BloggingRemindersScheduleFormatter {
         }
 
         let htmlData = NSString(string: string).data(using: String.Encoding.unicode.rawValue) ?? Data()
-        let options: [NSAttributedString.DocumentReadingOptionKey: Any] = [.documentType: NSAttributedString.DocumentType.html]
+        let options: [NSAttributedString.DocumentReadingOptionKey: Any] = [
+            .documentType: NSAttributedString.DocumentType.html
+        ]
 
-        let attributedString = (try? NSMutableAttributedString(data: htmlData,
-                                                               options: options,
-                                                               documentAttributes: nil)) ?? NSMutableAttributedString()
+        let attributedString =
+            (try? NSMutableAttributedString(
+                data: htmlData,
+                options: options,
+                documentAttributes: nil
+            )) ?? NSMutableAttributedString()
 
         // This loop applies the default font to the whole text, while keeping any symbolic attributes the previous font may
         // have had (such as bold style).
-        attributedString.enumerateAttribute(.font, in: NSRange(location: 0, length: attributedString.length)) { value, range, _ in
+        attributedString.enumerateAttribute(.font, in: NSRange(location: 0, length: attributedString.length)) {
+            value,
+            range,
+            _ in
 
             guard let oldFont = value as? UIFont,
-                  let newDescriptor = UIFontDescriptor.preferredFontDescriptor(withTextStyle: .body)
-                    .withSymbolicTraits(oldFont.fontDescriptor.symbolicTraits) else {
+                let newDescriptor = UIFontDescriptor.preferredFontDescriptor(withTextStyle: .body)
+                    .withSymbolicTraits(oldFont.fontDescriptor.symbolicTraits)
+            else {
 
                 return
             }
@@ -145,40 +170,75 @@ private extension BloggingRemindersScheduleFormatter {
     }
 
     enum TextContent {
-        static let shortNoRemindersDescription = NSLocalizedString("None set", comment: "Title shown on table row where no blogging reminders have been set up yet")
+        static let shortNoRemindersDescription = NSLocalizedString(
+            "None set",
+            comment: "Title shown on table row where no blogging reminders have been set up yet"
+        )
 
-        static let longNoRemindersDescription = NSLocalizedString("You have no reminders set.", comment: "Text shown to the user when setting up blogging reminders, if they complete the flow and have chosen not to add any reminders.")
+        static let longNoRemindersDescription = NSLocalizedString(
+            "You have no reminders set.",
+            comment:
+                "Text shown to the user when setting up blogging reminders, if they complete the flow and have chosen not to add any reminders."
+        )
 
         // Ideally we should use stringsdict to translate plurals, but GlotPress currently doesn't support this.
-        static let oneReminderLongDescriptionWithTime = NSLocalizedString("You'll get a reminder to blog <strong>once</strong> a week on %@ at %@.",
-                                                              comment: "Blogging Reminders description confirming a user's choices. The placeholder will be replaced at runtime with a day of the week. The HTML markup is used to bold the word 'once'.")
+        static let oneReminderLongDescriptionWithTime = NSLocalizedString(
+            "You'll get a reminder to blog <strong>once</strong> a week on %@ at %@.",
+            comment:
+                "Blogging Reminders description confirming a user's choices. The placeholder will be replaced at runtime with a day of the week. The HTML markup is used to bold the word 'once'."
+        )
 
-        static let manyRemindersLongDescriptionWithTime = NSLocalizedString("You'll get reminders to blog %@ times a week on %@.",
-                                                              comment: "Blogging Reminders description confirming a user's choices. The first placeholder will be populated with a count of the number of times a week they'll be reminded. The second will be a formatted list of days. For example: 'You'll get reminders to blog 2 times a week on Monday and Tuesday.")
+        static let manyRemindersLongDescriptionWithTime = NSLocalizedString(
+            "You'll get reminders to blog %@ times a week on %@.",
+            comment:
+                "Blogging Reminders description confirming a user's choices. The first placeholder will be populated with a count of the number of times a week they'll be reminded. The second will be a formatted list of days. For example: 'You'll get reminders to blog 2 times a week on Monday and Tuesday."
+        )
 
-        static let oneReminderShortDescriptionWithTime = NSLocalizedString("<strong>Once</strong> a week at %@",
-                                                                            comment: "Short title telling the user they will receive a blogging reminder once per week. The word for 'once' should be surrounded by <strong> HTML tags.")
+        static let oneReminderShortDescriptionWithTime = NSLocalizedString(
+            "<strong>Once</strong> a week at %@",
+            comment:
+                "Short title telling the user they will receive a blogging reminder once per week. The word for 'once' should be surrounded by <strong> HTML tags."
+        )
 
-        static let twoRemindersShortDescriptionWithTime = NSLocalizedString("<strong>Twice</strong> a week at %@",
-                                                                            comment: "Short title telling the user they will receive a blogging reminder two times a week. The word for 'twice' should be surrounded by <strong> HTML tags.")
+        static let twoRemindersShortDescriptionWithTime = NSLocalizedString(
+            "<strong>Twice</strong> a week at %@",
+            comment:
+                "Short title telling the user they will receive a blogging reminder two times a week. The word for 'twice' should be surrounded by <strong> HTML tags."
+        )
 
-        static let manyRemindersShortDescriptionWithTime = NSLocalizedString("<strong>%d</strong> times a week at %@",
-                                                                             comment: "A short description of how many times a week the user will receive a blogging reminder. The '%d' placeholder will be populated with a count of the number of times a week they'll be reminded, and should be surrounded by <strong> HTML tags.")
+        static let manyRemindersShortDescriptionWithTime = NSLocalizedString(
+            "<strong>%d</strong> times a week at %@",
+            comment:
+                "A short description of how many times a week the user will receive a blogging reminder. The '%d' placeholder will be populated with a count of the number of times a week they'll be reminded, and should be surrounded by <strong> HTML tags."
+        )
 
-        static let everydayRemindersShortDescriptionWithTime = NSLocalizedString("Every day at %@",
-                                                                                 comment: "Short title telling the user they will receive a blogging reminder every day of the week.")
+        static let everydayRemindersShortDescriptionWithTime = NSLocalizedString(
+            "Every day at %@",
+            comment: "Short title telling the user they will receive a blogging reminder every day of the week."
+        )
 
-        static let oneReminderShortDescription = NSLocalizedString("<strong>Once</strong> a week",
-                                                                            comment: "Short title telling the user they will receive a blogging reminder once per week. The word for 'once' should be surrounded by <strong> HTML tags.")
+        static let oneReminderShortDescription = NSLocalizedString(
+            "<strong>Once</strong> a week",
+            comment:
+                "Short title telling the user they will receive a blogging reminder once per week. The word for 'once' should be surrounded by <strong> HTML tags."
+        )
 
-        static let twoRemindersShortDescription = NSLocalizedString("<strong>Twice</strong> a week",
-                                                                            comment: "Short title telling the user they will receive a blogging reminder two times a week. The word for 'twice' should be surrounded by <strong> HTML tags.")
+        static let twoRemindersShortDescription = NSLocalizedString(
+            "<strong>Twice</strong> a week",
+            comment:
+                "Short title telling the user they will receive a blogging reminder two times a week. The word for 'twice' should be surrounded by <strong> HTML tags."
+        )
 
-        static let manyRemindersShortDescription = NSLocalizedString("<strong>%d</strong> times a week",
-                                                                             comment: "A short description of how many times a week the user will receive a blogging reminder. The '%d' placeholder will be populated with a count of the number of times a week they'll be reminded, and should be surrounded by <strong> HTML tags.")
+        static let manyRemindersShortDescription = NSLocalizedString(
+            "<strong>%d</strong> times a week",
+            comment:
+                "A short description of how many times a week the user will receive a blogging reminder. The '%d' placeholder will be populated with a count of the number of times a week they'll be reminded, and should be surrounded by <strong> HTML tags."
+        )
 
-        static let everydayRemindersShortDescription = NSLocalizedString("Every day",
-                                                                                 comment: "Short title telling the user they will receive a blogging reminder every day of the week.")
+        static let everydayRemindersShortDescription = NSLocalizedString(
+            "Every day",
+            comment: "Short title telling the user they will receive a blogging reminder every day of the week."
+        )
     }
 }
 

--- a/WordPress/Classes/Utility/Blogging Reminders/BloggingRemindersScheduleFormatter.swift
+++ b/WordPress/Classes/Utility/Blogging Reminders/BloggingRemindersScheduleFormatter.swift
@@ -33,8 +33,10 @@ struct BloggingRemindersScheduleFormatter {
 
     /// Attributed long description string of the current schedule for the specified blog.
     ///
-    func longScheduleDescription(for schedule: BloggingRemindersScheduler.Schedule, time: String) -> NSAttributedString
-    {
+    func longScheduleDescription(
+        for schedule: BloggingRemindersScheduler.Schedule,
+        time: String
+    ) -> NSAttributedString {
         switch schedule {
         case .none:
             return NSAttributedString(string: TextContent.longNoRemindersDescription)

--- a/WordPress/Classes/Utility/Blogging Reminders/BloggingRemindersScheduleFormatter.swift
+++ b/WordPress/Classes/Utility/Blogging Reminders/BloggingRemindersScheduleFormatter.swift
@@ -166,6 +166,13 @@ private extension BloggingRemindersScheduleFormatter {
             attributedString.addAttributes([.font: newFont], range: range)
         }
 
+        // HTML parsing adds an opaque black foreground color even when the source doesn't specify one.
+        // Remove it so callers can apply dynamic semantic colors.
+        attributedString.removeAttribute(
+            .foregroundColor,
+            range: NSRange(location: 0, length: attributedString.length)
+        )
+
         return attributedString
     }
 


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/CMM-2156

The second commit fixes the issue by removing the text color added by the `NSAttributedString` html parser API.
<img width="400" src="https://github.com/user-attachments/assets/ca0ea754-7996-4625-b606-85d741037793" />
