### PR TITLE
Keep initial tag loading task alive

### DIFF
--- a/WordPress/Classes/ViewRelated/Tags/TagsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Tags/TagsViewModel.swift
@@ -93,8 +93,9 @@ class TagsViewModel: ObservableObject {
     func onAppear() {
         guard response == nil else { return }
         Task {
-            async let _ = await loadInitialTags()
-            async let _ = await resolvePendingSelectedTerms()
+            async let initialTags: Void = loadInitialTags()
+            async let pendingSelectedTerms: Void = resolvePendingSelectedTerms()
+            _ = await (initialTags, pendingSelectedTerms)
         }
     }
 


### PR DESCRIPTION
Fix an issue where the initial display of "Post Settings -> Tags" may not display any tags.