### PR TITLE
Fix notification content navigation on iPad

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController/NotificationsViewController.swift
@@ -844,7 +844,14 @@ extension NotificationsViewController {
             navigationController?.pushViewController(controller, animated: true)
         } else if isSidebarModeEnabled {
             if let splitViewController {
-                splitViewController.setViewController(controller, for: .secondary)
+                // Give the details controller its own navigation stack. Content taps inside
+                // the notification (opening a post, comment, profile, etc.) push onto
+                // `controller.navigationController`; without this wrapper that is `nil` in the
+                // `.secondary` column and the taps silently do nothing. The column is expected
+                // to hold a `UINavigationController` — see `ReaderPresenter` and
+                // `SplitViewRootPresenter+Site`.
+                let navigationVC = UINavigationController(rootViewController: controller)
+                splitViewController.setViewController(navigationVC, for: .secondary)
             } else {
                 navigationController?.pushViewController(controller, animated: true)
             }


### PR DESCRIPTION
## Description

Fixes a pre-existing bug where **tapping content inside a notification does nothing on iPad** — opening a post, comment thread, user profile, stats, etc. from a notification silently fails. iPhone is unaffected.

### Root Cause

Content taps route `NotificationDetailsViewController` → `NotificationContentRouter` → `DefaultContentCoordinator`, which opens content by pushing onto the details controller's navigation stack:

```swift
controller?.navigationController?.pushViewController(readerViewController, animated: true)
```

On iPhone the details controller is pushed onto the notifications navigation stack, so `navigationController` is non-nil and the push works. On iPad (`shouldPushDetailsViewController == false`), `displayViewController(_:)` placed the details controller **directly** into the split view's `.secondary` column:

```swift
splitViewController.setViewController(controller, for: .secondary)
```

With no enclosing `UINavigationController`, `controller.navigationController` is `nil`, so the coordinator's optional-chained push is a silent no-op. Content opened with `present()` — the fullscreen-image lightbox and in-app web views — was unaffected; only pushed destinations were dead.

Notifications was the only presenter setting a bare `.secondary`; `ReaderPresenter` and `SplitViewRootPresenter+Site` already wrap their secondary content in a navigation controller.

### Fix

Wrap the details controller in a `UINavigationController` when populating the `.secondary` column, matching the other presenters. `NotificationDetailsViewController` (and the comment-detail controller) then has a navigation stack for the coordinator to push onto.

The iPhone push path and the `present()`-based content paths are **unchanged**. Scoped to the split-view `.secondary` path — the adaptive `showDetailViewController(_:sender:)` fallback is left as-is, since wrapping it would nest navigation controllers when compact.

Independent of the achievement-notification animation work (CMM-2157).

## Testing instructions

On an **iPad**:
- [ ] Open a notification, then tap content that navigates — a comment/post, a user profile, "view stats", a followed site, etc. It should now push into the secondary column. (Before this change: nothing happened.)
- [ ] Confirm the fullscreen image viewer and in-app web-view links still present correctly (unchanged `present()` path).
- [ ] Comment notifications navigate as well.

On an **iPhone**:
- [ ] Notification content navigation is unchanged.
