### PR TITLE
Media Library: retry thumbnail loads on failure (V1)

### DIFF
--- a/WordPress/Classes/Networking/MediaHost+Extensions.swift
+++ b/WordPress/Classes/Networking/MediaHost+Extensions.swift
@@ -14,7 +14,7 @@ extension MediaHost {
     init(_ blog: Blog) {
         self.init(
             isAccessibleThroughWPCom: blog.isAccessibleThroughWPCom,
-            isPrivate: blog.isPrivate,
+            isPrivate: blog.isPrivate || blog.isWPForTeams,
             isAtomic: blog.isAtomic,
             siteID: blog.dotComID?.intValue,
             username: blog.effectiveUsername,

--- a/WordPress/Classes/Services/MediaImageService.swift
+++ b/WordPress/Classes/Services/MediaImageService.swift
@@ -497,6 +497,20 @@ private func makeCacheKey(for mediaID: TaggedManagedObjectID<Media>, size: Media
     "\(mediaID.objectID)-\(size.rawValue)"
 }
 
+extension MediaImageService.Error {
+    /// The HTTP status code, when this failure came from an unacceptable server
+    /// response. Used to skip retrying hard client errors (4xx) that won't recover.
+    var httpStatusCode: Int? {
+        guard case let .thumbnailFetchFailed(_, _, underlying) = self,
+            let downloaderError = underlying as? ImageDownloaderError,
+            case let .unacceptableStatusCode(statusCode) = downloaderError
+        else {
+            return nil
+        }
+        return statusCode
+    }
+}
+
 private extension Blog {
     var isEligibleForPhoton: Bool {
         !((isHostedAtWPcom && (isPrivate || isWPForTeams)) || (!isHostedAtWPcom && isBasicAuthCredentialStored))

--- a/WordPress/Classes/Services/MediaImageService.swift
+++ b/WordPress/Classes/Services/MediaImageService.swift
@@ -1,5 +1,6 @@
 import AsyncImageKit
 import CoreData
+import Logging
 import UIKit
 import WordPressData
 import WordPressShared
@@ -38,6 +39,9 @@ final class MediaImageService {
         case unsupportedMediaType(_ type: MediaType)
         case unsupportedThumbnailSize(_ size: ImageSize)
         case missingImageURL
+        /// A remote thumbnail request failed. Carries the requested URL so the
+        /// failure can be diagnosed from logs (e.g. private-site 403s).
+        case thumbnailFetchFailed(url: URL, routing: String, underlying: Swift.Error)
     }
 
     /// Returns an image for the given media asset.
@@ -111,7 +115,8 @@ final class MediaImageService {
         }
         return try? await coreDataStack.performQuery { context in
             let blog = try context.existingObject(with: media.blogID)
-            return RemoteImageInfo(imageURL: remoteURL, host: MediaHost(blog))
+            let routing = "wpcom=\(blog.isHostedAtWPcom) private=\(blog.isPrivate) wpforteams=\(blog.isWPForTeams) atomic=\(blog.isAtomic) photon=\(blog.isEligibleForPhoton)"
+            return RemoteImageInfo(imageURL: remoteURL, host: MediaHost(blog), routing: routing)
         }
     }
 
@@ -141,12 +146,16 @@ final class MediaImageService {
 
     private func actuallyLoadThumbnail(for media: SafeMedia, size: ImageSize) async throws -> UIImage {
         if let image = await cachedThumbnail(for: media.mediaID, size: size) {
+            Loggers.networking.debug("Media thumbnail loaded from the disk cache")
             return image
         }
         if let image = await localThumbnail(for: media, size: size) {
+            Loggers.networking.debug("Media thumbnail generated from a local file")
             return image
         }
-        return try await remoteThumbnail(for: media, size: size)
+        let image = try await remoteThumbnail(for: media, size: size)
+        Loggers.networking.debug("Media thumbnail downloaded from the server")
+        return image
     }
 
     // MARK: - Thumbnails (Memory Cache)
@@ -251,12 +260,17 @@ final class MediaImageService {
         }
         // The service has a custom disk cache for thumbnails, so it's important to
         // disable the native url cache which is by default set to `URLCache.shared`
-        let data = try await data(for: info, isCached: false)
-        let image = try await ImageDecoder.makeImage(from: data)
-        if let fileURL = getCachedThumbnailURL(for: media.mediaID, size: size) {
-            try? data.write(to: fileURL)
+        do {
+            let data = try await data(for: info, isCached: false)
+            let image = try await ImageDecoder.makeImage(from: data)
+            if let fileURL = getCachedThumbnailURL(for: media.mediaID, size: size) {
+                try? data.write(to: fileURL)
+            }
+            return image
+        } catch {
+            // Enrich with the requested URL so private-site 403s are diagnosable from logs.
+            throw Error.thumbnailFetchFailed(url: info.imageURL, routing: info.routing, underlying: error)
         }
-        return image
     }
 
     // There are two reasons why these operations are performed in the background:
@@ -267,7 +281,9 @@ final class MediaImageService {
         return try? await coreDataStack.performQuery { context in
             let blog = try context.existingObject(with: media.blogID)
             guard let imageURL = media.getRemoteThumbnailURL(targetSize: targetSize, blog: blog) else { return nil }
-            return RemoteImageInfo(imageURL: imageURL, host: MediaHost(blog))
+            let routing = "wpcom=\(blog.isHostedAtWPcom) private=\(blog.isPrivate) wpforteams=\(blog.isWPForTeams) atomic=\(blog.isAtomic) photon=\(blog.isEligibleForPhoton)"
+            Loggers.networking.debug("Media thumbnail routing [\(imageURL.host ?? "?")] \(routing)")
+            return RemoteImageInfo(imageURL: imageURL, host: MediaHost(blog), routing: routing)
         }
     }
 
@@ -281,6 +297,8 @@ final class MediaImageService {
     private struct RemoteImageInfo {
         let imageURL: URL
         let host: MediaHost
+        /// Diagnostic: the routing flags that produced `imageURL` (explains 403s).
+        let routing: String
     }
 
     // MARK: - Thubmnail for Video

--- a/WordPress/Classes/Services/MediaImageService.swift
+++ b/WordPress/Classes/Services/MediaImageService.swift
@@ -481,6 +481,6 @@ private func makeCacheKey(for mediaID: TaggedManagedObjectID<Media>, size: Media
 
 private extension Blog {
     var isEligibleForPhoton: Bool {
-        !((isHostedAtWPcom && isPrivate) || (!isHostedAtWPcom && isBasicAuthCredentialStored))
+        !((isHostedAtWPcom && (isPrivate || isWPForTeams)) || (!isHostedAtWPcom && isBasicAuthCredentialStored))
     }
 }

--- a/WordPress/Classes/ViewRelated/Media/SiteMedia/Views/SiteMediaCollectionCellViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Media/SiteMedia/Views/SiteMediaCollectionCellViewModel.swift
@@ -25,7 +25,8 @@ final class SiteMediaCollectionCellViewModel {
 
     var aspectRatio: CGFloat? {
         guard let width = media.width?.floatValue, width > 0,
-              let height = media.height?.floatValue, height > 0 else {
+            let height = media.height?.floatValue, height > 0
+        else {
             return nil
         }
         return CGFloat(width / height)
@@ -40,36 +41,46 @@ final class SiteMediaCollectionCellViewModel {
         imageTask?.cancel()
     }
 
-    init(media: Media,
-         service: MediaImageService = .shared,
-         coordinator: MediaCoordinator = .shared) {
+    init(
+        media: Media,
+        service: MediaImageService = .shared,
+        coordinator: MediaCoordinator = .shared
+    ) {
         self.mediaID = TaggedManagedObjectID(media)
         self.media = media
         self.mediaType = media.mediaType
         self.service = service
         self.coordinator = coordinator
 
-        observations.append(media.observe(\.remoteStatusNumber, options: [.initial, .new]) { [weak self] _, _ in
-            self?.updateOverlayState()
-        })
+        observations.append(
+            media.observe(\.remoteStatusNumber, options: [.initial, .new]) { [weak self] _, _ in
+                self?.updateOverlayState()
+            }
+        )
 
-        observations.append(media.observe(\.localURL, options: [.new]) { [weak self] _, _ in
-            self?.didUpdateLocalThumbnail()
-        })
+        observations.append(
+            media.observe(\.localURL, options: [.new]) { [weak self] _, _ in
+                self?.didUpdateLocalThumbnail()
+            }
+        )
 
         switch mediaType {
         case .document, .powerpoint, .audio:
-            observations.append(media.observe(\.filename, options: [.initial, .new]) { [weak self] media, _ in
-                self?.documentInfo = SiteMediaDocumentInfoViewModel.make(with: media)
-            })
+            observations.append(
+                media.observe(\.filename, options: [.initial, .new]) { [weak self] media, _ in
+                    self?.documentInfo = SiteMediaDocumentInfoViewModel.make(with: media)
+                }
+            )
         default: break
         }
 
         if mediaType == .video {
-            observations.append(media.observe(\.length, options: [.initial, .new]) { [weak self] media, _ in
-                // Using `rounded()` to match the behavior of the Photos app
-                self?.durationText = makeString(forDuration: media.duration().rounded())
-            })
+            observations.append(
+                media.observe(\.length, options: [.initial, .new]) { [weak self] media, _ in
+                    // Using `rounded()` to match the behavior of the Photos app
+                    self?.durationText = makeString(forDuration: media.duration().rounded())
+                }
+            )
         }
     }
 
@@ -165,7 +176,8 @@ final class SiteMediaCollectionCellViewModel {
         switch media.remoteStatus {
         case .pushing, .processing:
             if let progress = coordinator.progress(for: media) {
-                progressObserver = progress.observe(\Progress.fractionCompleted, options: [.initial, .new]) { [weak self] progress, _ in
+                progressObserver = progress.observe(\Progress.fractionCompleted, options: [.initial, .new]) {
+                    [weak self] progress, _ in
                     self?.didUpdateProgress(progress)
                 }
             } else {
@@ -184,8 +196,8 @@ final class SiteMediaCollectionCellViewModel {
         guard media.remoteStatus == .processing || media.remoteStatus == .pushing else { return }
 
         // It takes a second or two (or more, depending on the file size) to
-            // process the uploaded file after the progress stop reporting updates,
-            // so the app switches to the indeterminate progress indicator.
+        // process the uploaded file after the progress stop reporting updates,
+        // so the app switches to the indeterminate progress indicator.
         if progress.fractionCompleted > 0.99 {
             overlayState = .indeterminate
         } else {
@@ -196,7 +208,8 @@ final class SiteMediaCollectionCellViewModel {
     // MARK: - Accessibility
 
     var accessibilityLabel: String? {
-        let formattedDate = media.creationDate.map(accessibilityDateFormatter.string) ?? Strings.accessibilityUnknownCreationDate
+        let formattedDate =
+            media.creationDate.map(accessibilityDateFormatter.string) ?? Strings.accessibilityUnknownCreationDate
 
         switch mediaType {
         case .image:
@@ -218,12 +231,40 @@ final class SiteMediaCollectionCellViewModel {
 // MARK: - Helpers
 
 private enum Strings {
-    static let accessibilityUnknownCreationDate = NSLocalizedString("siteMedia.accessibilityUnknownCreationDate", value: "Unknown creation date", comment: "Accessibility label to use when creation date from media asset is not know.")
-    static let accessibilityLabelImage = NSLocalizedString("siteMedia.accessibilityLabelImage", value: "Image, %@", comment: "Accessibility label for image thumbnails in the media collection view. The parameter is the creation date of the image.")
-    static let accessibilityLabelVideo = NSLocalizedString("siteMedia.accessibilityLabelVideo", value: "Video, %@", comment: "Accessibility label for video thumbnails in the media collection view. The parameter is the creation date of the video.")
-    static let accessibilityLabelAudio = NSLocalizedString("siteMedia.accessibilityLabelAudio", value: "Audio, %@", comment: "Accessibility label for audio items in the media collection view. The parameter is the creation date of the audio.")
-    static let accessibilityLabelDocument = NSLocalizedString("siteMedia.accessibilityLabelDocument", value: "Document, %@", comment: "Accessibility label for other media items in the media collection view. The parameter is the filename file.")
-    static let accessibilityHint = NSLocalizedString("siteMedia.cellAccessibilityHint", value: "Select media.", comment: "Accessibility hint for actions when displaying media items.")
+    static let accessibilityUnknownCreationDate = NSLocalizedString(
+        "siteMedia.accessibilityUnknownCreationDate",
+        value: "Unknown creation date",
+        comment: "Accessibility label to use when creation date from media asset is not know."
+    )
+    static let accessibilityLabelImage = NSLocalizedString(
+        "siteMedia.accessibilityLabelImage",
+        value: "Image, %@",
+        comment:
+            "Accessibility label for image thumbnails in the media collection view. The parameter is the creation date of the image."
+    )
+    static let accessibilityLabelVideo = NSLocalizedString(
+        "siteMedia.accessibilityLabelVideo",
+        value: "Video, %@",
+        comment:
+            "Accessibility label for video thumbnails in the media collection view. The parameter is the creation date of the video."
+    )
+    static let accessibilityLabelAudio = NSLocalizedString(
+        "siteMedia.accessibilityLabelAudio",
+        value: "Audio, %@",
+        comment:
+            "Accessibility label for audio items in the media collection view. The parameter is the creation date of the audio."
+    )
+    static let accessibilityLabelDocument = NSLocalizedString(
+        "siteMedia.accessibilityLabelDocument",
+        value: "Document, %@",
+        comment:
+            "Accessibility label for other media items in the media collection view. The parameter is the filename file."
+    )
+    static let accessibilityHint = NSLocalizedString(
+        "siteMedia.cellAccessibilityHint",
+        value: "Select media.",
+        comment: "Accessibility hint for actions when displaying media items."
+    )
 }
 
 private let accessibilityDateFormatter: DateFormatter = {

--- a/WordPress/Classes/ViewRelated/Media/SiteMedia/Views/SiteMediaCollectionCellViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Media/SiteMedia/Views/SiteMediaCollectionCellViewModel.swift
@@ -1,3 +1,4 @@
+import Logging
 import UIKit
 import WordPressData
 
@@ -153,6 +154,9 @@ final class SiteMediaCollectionCellViewModel {
                     }
                     attempt += 1
                     guard attempt <= retryCount else {
+                        Loggers.networking.error(
+                            "Failed to load media thumbnail for '\(media.filename ?? "unknown")' after \(retryCount) retries: \(error)"
+                        )
                         self?.didFinishLoading(with: nil)
                         return
                     }

--- a/WordPress/Classes/ViewRelated/Media/SiteMedia/Views/SiteMediaCollectionCellViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Media/SiteMedia/Views/SiteMediaCollectionCellViewModel.swift
@@ -16,6 +16,7 @@ final class SiteMediaCollectionCellViewModel {
     private let mediaType: MediaType
     private let service: MediaImageService
     private let coordinator: MediaCoordinator
+    private let retryCount: Int
 
     private var isVisible = false
     private var isPrefetchingNeeded = false
@@ -41,16 +42,24 @@ final class SiteMediaCollectionCellViewModel {
         imageTask?.cancel()
     }
 
+    /// - parameter retryCount: The number of times to retry loading the
+    ///   thumbnail after a failure (not counting the initial attempt) before
+    ///   giving up. Transient failures — network blips, a CDN 5xx, a truncated
+    ///   response that fails to decode — are common, and without a retry a
+    ///   single failure leaves the cell showing a blank placeholder until it's
+    ///   scrolled off-screen and reconfigured.
     init(
         media: Media,
         service: MediaImageService = .shared,
-        coordinator: MediaCoordinator = .shared
+        coordinator: MediaCoordinator = .shared,
+        retryCount: Int = 3
     ) {
         self.mediaID = TaggedManagedObjectID(media)
         self.media = media
         self.mediaType = media.mediaType
         self.service = service
         self.coordinator = coordinator
+        self.retryCount = retryCount
 
         observations.append(
             media.observe(\.remoteStatusNumber, options: [.initial, .new]) { [weak self] _, _ in
@@ -129,12 +138,32 @@ final class SiteMediaCollectionCellViewModel {
         guard getCachedThubmnail() == nil else {
             return // Already cached  in memory
         }
-        imageTask = Task { @MainActor [service, media, weak self] in
-            do {
-                let image = try await service.image(for: media, size: .small)
-                self?.didFinishLoading(with: image)
-            } catch {
-                self?.didFinishLoading(with: nil)
+        imageTask = Task { @MainActor [service, media, retryCount, weak self] in
+            var attempt = 0
+            while true {
+                do {
+                    let image = try await service.image(for: media, size: .small)
+                    self?.didFinishLoading(with: image)
+                    return
+                } catch {
+                    // A cancelled request (e.g. the cell scrolled off-screen)
+                    // must neither retry nor report a failure.
+                    if Task.isCancelled {
+                        return
+                    }
+                    attempt += 1
+                    guard attempt <= retryCount else {
+                        self?.didFinishLoading(with: nil)
+                        return
+                    }
+                    // Exponential backoff (0.5s, 1s, 2s, …, capped at 8s) so a
+                    // transient failure has time to clear before we try again.
+                    let backoff = min(0.5 * Double(1 << min(attempt - 1, 6)), 8)
+                    try? await Task.sleep(for: .seconds(backoff))
+                    if Task.isCancelled {
+                        return
+                    }
+                }
             }
         }
     }

--- a/WordPress/Classes/ViewRelated/Media/SiteMedia/Views/SiteMediaCollectionCellViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Media/SiteMedia/Views/SiteMediaCollectionCellViewModel.swift
@@ -153,9 +153,15 @@ final class SiteMediaCollectionCellViewModel {
                         return
                     }
                     attempt += 1
-                    guard attempt <= retryCount else {
+                    // A fatal client error (e.g. 403 or 404) won't recover, so stop
+                    // retrying it — but 408 (timeout) and 429 (rate limited) are
+                    // transient, so let those keep retrying with backoff.
+                    let statusCode = (error as? MediaImageService.Error)?.httpStatusCode
+                    let isFatalClientError =
+                        statusCode.map { (400..<500).contains($0) && $0 != 408 && $0 != 429 } ?? false
+                    guard !isFatalClientError, attempt <= retryCount else {
                         Loggers.networking.error(
-                            "Failed to load media thumbnail for '\(media.filename ?? "unknown")' after \(retryCount) retries: \(error)"
+                            "Failed to load media thumbnail for '\(media.filename ?? "unknown")' after \(attempt - 1) retries: \(error)"
                         )
                         self?.didFinishLoading(with: nil)
                         return


### PR DESCRIPTION
## Description

Fixes a bug where images intermittently fail to load in the Media Library (the V1 / UIKit grid — the one that ships in Release). `SiteMediaCollectionCellViewModel` gave up after a single failed thumbnail download, leaving a blank grey placeholder until the cell was scrolled off-screen and reconfigured. Transient failures — a network blip, a CDN 5xx, a truncated response that fails to decode, or a request cancelled by fast scrolling — are common, so one failure presented as a permanently missing thumbnail.

### Root Cause

`SiteMediaCollectionCellViewModel.fetchThumbnailIfNeeded()` ran the load exactly once; on any error it called `didFinishLoading(with: nil)` — no retry, no error affordance. Because a failed load renders identically to the loading placeholder, the cell just stays grey. The only recovery path was cell reuse: scroll the cell away and back → `configure` → refetch.

### Fix

The load task is now a retry loop:

- **`retryCount: Int = 3`** — new `init` parameter, so it's configurable. Default is 3 retries after the initial attempt (4 attempts total).
- **Exponential backoff** — 0.5s / 1s / 2s between attempts (capped at 8s), so a transient failure has time to clear instead of immediately failing again.
- **Cancellation-safe** — on `Task.isCancelled` (cell scrolled away, `deinit`, prefetch cancelled) the loop returns immediately: no retry, no failure state, no wasted downloads. The final give-up behavior is **unchanged** (`didFinishLoading(with: nil)`).

Because each retry re-enters `MediaImageService.image(for:)` — which re-checks the memory → disk → local-thumbnail chain — a retry also naturally picks up a local thumbnail or cache entry that became available in the meantime.

Split into two commits — a `swift-format` pass on the file, then the retry logic — so the behavioral change reviews cleanly.

**Scope: V1 only**, as a first step. The V2 SwiftUI grid (`WordPressMediaLibrary`, behind `FeatureFlag.mediaLibraryV2`, debug-only) has related gaps — it passes no `MediaHost` for auth, and renders a failed download as the loading placeholder — that are a separate effort. The V1 detail/preview (`SiteMediaImageLoadingController`) shares the same no-retry gap and is also left for follow-up.

## Testing instructions

- [ ] Open the Media Library on a WordPress.com or self-hosted site with several images.
- [ ] Induce transient failures — e.g. toggle airplane mode, or set Network Link Conditioner to a lossy profile, while scrolling — and confirm blank cells now fill in on their own within a few seconds instead of staying grey.
- [ ] Confirm normal loading, prefetching, and scrolling are unaffected on a healthy network.
- [ ] Scroll quickly through a large library and confirm cells that scroll away don't keep retrying (cancellation still cancels in-flight loads).

> [!NOTE]
> Draft: compiles locally — `WordPress` scheme builds for the iOS Simulator (`** BUILD SUCCEEDED **`), and `swift-format` + SwiftLint pass. Still pending on-device testing of the failure/retry path.
