### PR TITLE
Add app-specific accent colors

### DIFF
--- a/Sources/Jetpack/Resources/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/Sources/Jetpack/Resources/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.0000000000",
+          "blue" : "0.0313725490",
+          "green" : "0.6196078431",
+          "red" : "0.0235294118"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.0000000000",
+          "blue" : "0.1215686275",
+          "green" : "0.7058823529",
+          "red" : "0.1843137255"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Sources/WordPress/Resources/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/Sources/WordPress/Resources/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.0000000000",
+          "blue" : "0.9137254902",
+          "green" : "0.3450980392",
+          "red" : "0.2196078431"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.0000000000",
+          "blue" : "0.9529411765",
+          "green" : "0.4352941176",
+          "red" : "0.3294117647"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -517,6 +517,12 @@
 		0C5A651A2D9B21CE00C25301 /* Reader.debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Reader.debug.xcconfig; sourceTree = "<group>"; };
 		0C5A651B2D9B21CE00C25301 /* Reader.release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Reader.release.xcconfig; sourceTree = "<group>"; };
 		0C96AC202D92FC17000779B8 /* Common.release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Common.release.xcconfig; sourceTree = "<group>"; };
+		0CACC0012E6F000000000001 /* WordPressApp.debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = WordPressApp.debug.xcconfig; sourceTree = "<group>"; };
+		0CACC0012E6F000000000002 /* WordPressApp.release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = WordPressApp.release.xcconfig; sourceTree = "<group>"; };
+		0CACC0012E6F000000000003 /* WordPressApp.alpha.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = WordPressApp.alpha.xcconfig; sourceTree = "<group>"; };
+		0CACC0012E6F000000000004 /* JetpackApp.debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = JetpackApp.debug.xcconfig; sourceTree = "<group>"; };
+		0CACC0012E6F000000000005 /* JetpackApp.release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = JetpackApp.release.xcconfig; sourceTree = "<group>"; };
+		0CACC0012E6F000000000006 /* JetpackApp.alpha.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = JetpackApp.alpha.xcconfig; sourceTree = "<group>"; };
 		0CED01702D95B897003015CF /* WordPress.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = WordPress.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		1D30AB110D05D00D00671497 /* Foundation.framework */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		1D6058910D05DD3D006BFB54 /* WordPress.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = WordPress.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1501,9 +1507,15 @@
 				F14B5F70208E648200439554 /* WordPress.debug.xcconfig */,
 				F14B5F71208E648200439554 /* WordPress.release.xcconfig */,
 				F14B5F73208E648300439554 /* WordPress.alpha.xcconfig */,
+				0CACC0012E6F000000000001 /* WordPressApp.debug.xcconfig */,
+				0CACC0012E6F000000000002 /* WordPressApp.release.xcconfig */,
+				0CACC0012E6F000000000003 /* WordPressApp.alpha.xcconfig */,
 				24350E7C264DB76E009BB2B6 /* Jetpack.debug.xcconfig */,
 				24351059264DC1E2009BB2B6 /* Jetpack.release.xcconfig */,
 				2439B1DB264ECBDF00239130 /* Jetpack.alpha.xcconfig */,
+				0CACC0012E6F000000000004 /* JetpackApp.debug.xcconfig */,
+				0CACC0012E6F000000000005 /* JetpackApp.release.xcconfig */,
+				0CACC0012E6F000000000006 /* JetpackApp.alpha.xcconfig */,
 				0C5A651A2D9B21CE00C25301 /* Reader.debug.xcconfig */,
 				0C5A651B2D9B21CE00C25301 /* Reader.release.xcconfig */,
 				0C5A65192D9B21CE00C25301 /* Reader.alpha.xcconfig */,
@@ -3652,7 +3664,7 @@
 		};
 		1D6058940D05DD3E006BFB54 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = F14B5F70208E648200439554 /* WordPress.debug.xcconfig */;
+			baseConfigurationReference = 0CACC0012E6F000000000001 /* WordPressApp.debug.xcconfig */;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = NO;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIconLegacy;
@@ -3708,7 +3720,7 @@
 		};
 		1D6058950D05DD3E006BFB54 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = F14B5F71208E648200439554 /* WordPress.release.xcconfig */;
+			baseConfigurationReference = 0CACC0012E6F000000000002 /* WordPressApp.release.xcconfig */;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = NO;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIconLegacy;
@@ -4594,7 +4606,7 @@
 		};
 		8546B4441BEAD39700193C07 /* Release-Alpha */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = F14B5F73208E648300439554 /* WordPress.alpha.xcconfig */;
+			baseConfigurationReference = 0CACC0012E6F000000000003 /* WordPressApp.alpha.xcconfig */;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = NO;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIconLegacy;
@@ -5002,7 +5014,7 @@
 		};
 		FABB264E2602FC2C00C8785C /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 24350E7C264DB76E009BB2B6 /* Jetpack.debug.xcconfig */;
+			baseConfigurationReference = 0CACC0012E6F000000000004 /* JetpackApp.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIconLegacy;
 				CLANG_ENABLE_OBJC_ARC = YES;
@@ -5059,7 +5071,7 @@
 		};
 		FABB264F2602FC2C00C8785C /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 24351059264DC1E2009BB2B6 /* Jetpack.release.xcconfig */;
+			baseConfigurationReference = 0CACC0012E6F000000000005 /* JetpackApp.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIconLegacy;
 				CLANG_ENABLE_OBJC_ARC = YES;
@@ -5114,7 +5126,7 @@
 		};
 		FABB26512602FC2C00C8785C /* Release-Alpha */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 2439B1DB264ECBDF00239130 /* Jetpack.alpha.xcconfig */;
+			baseConfigurationReference = 0CACC0012E6F000000000006 /* JetpackApp.alpha.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIconLegacy;
 				CLANG_ENABLE_OBJC_ARC = YES;

--- a/config/JetpackApp.alpha.xcconfig
+++ b/config/JetpackApp.alpha.xcconfig
@@ -1,0 +1,3 @@
+#include "Jetpack.alpha.xcconfig"
+
+ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor

--- a/config/JetpackApp.debug.xcconfig
+++ b/config/JetpackApp.debug.xcconfig
@@ -1,0 +1,3 @@
+#include "Jetpack.debug.xcconfig"
+
+ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor

--- a/config/JetpackApp.release.xcconfig
+++ b/config/JetpackApp.release.xcconfig
@@ -1,0 +1,3 @@
+#include "Jetpack.release.xcconfig"
+
+ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor

--- a/config/WordPressApp.alpha.xcconfig
+++ b/config/WordPressApp.alpha.xcconfig
@@ -1,0 +1,3 @@
+#include "WordPress.alpha.xcconfig"
+
+ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor

--- a/config/WordPressApp.debug.xcconfig
+++ b/config/WordPressApp.debug.xcconfig
@@ -1,0 +1,3 @@
+#include "WordPress.debug.xcconfig"
+
+ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor

--- a/config/WordPressApp.release.xcconfig
+++ b/config/WordPressApp.release.xcconfig
@@ -1,0 +1,3 @@
+#include "WordPress.release.xcconfig"
+
+ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor


### PR DESCRIPTION
Add [accent color](https://developer.apple.com/documentation/xcode/specifying-your-apps-color-scheme) to the apps, so that code like `.foreground(.accentColor)` applies the correct color.