### PR TITLE
Fix Buildkite analysis pipeline secret interpolation

### DIFF
--- a/.buildkite/claude-analysis.yml
+++ b/.buildkite/claude-analysis.yml
@@ -18,8 +18,8 @@ steps:
       - "/tmp/buildkite_logs_${BUILDKITE_BUILD_ID}.txt"
     plugins:
       - $CLAUDE_PLUGIN:
-          api_key: "$ANTHROPIC_API_KEY"
-          buildkite_api_token: "$BUILDKITE_TOKEN_FOR_CLAUDE"
+          api_key: "$$ANTHROPIC_API_KEY"
+          buildkite_api_token: "$$BUILDKITE_TOKEN_FOR_CLAUDE"
           analysis_level: "build"
           build_log_mode: "failed"
           trigger: "on-failure"


### PR DESCRIPTION
I noticed some failing builds on `trunk` ([example](https://buildkite.com/automattic/wordpress-ios/builds/33160#019f63a4-c24f-4799-b70b-a45528a8eb81)), which then triggered the Claude analysis job which was also failing, basically due to a secret substitution.

So this PR:

- Defer analysis credentials until job runtime.
- Keep Buildkite secret rejection enabled.
