### PR TITLE
Show Reader profiles for post mentions

### DIFF
--- a/Modules/Sources/WordPressReader/ReaderPostParser.swift
+++ b/Modules/Sources/WordPressReader/ReaderPostParser.swift
@@ -95,8 +95,9 @@ public enum ReaderPostParser {
 
     private static func parseImage(from img: Element) -> GalleryImage? {
         guard let srcString = try? img.attr("src"),
-              !srcString.isEmpty,
-              let src = URL(string: srcString) else {
+            !srcString.isEmpty,
+            let src = URL(string: srcString)
+        else {
             return nil
         }
 
@@ -141,8 +142,9 @@ public enum ReaderPostParser {
     private static func parseSize(_ value: String) -> CGSize? {
         let parts = value.split(separator: ",")
         guard parts.count == 2,
-              let width = Double(parts[0].trimmingCharacters(in: .whitespaces)),
-              let height = Double(parts[1].trimmingCharacters(in: .whitespaces)) else {
+            let width = Double(parts[0].trimmingCharacters(in: .whitespaces)),
+            let height = Double(parts[1].trimmingCharacters(in: .whitespaces))
+        else {
             return nil
         }
         return CGSize(width: width, height: height)
@@ -150,16 +152,18 @@ public enum ReaderPostParser {
 
     /// Parses srcset string (e.g. "url1 300w, url2 600w") into entries.
     private static func parseSrcset(_ value: String) -> [SrcsetEntry] {
-        value.split(separator: ",").compactMap { entry in
-            let parts = entry.trimmingCharacters(in: .whitespaces).split(separator: " ")
-            guard parts.count == 2,
-                  let url = URL(string: String(parts[0])),
-                  let widthStr = parts[1].dropLast().description.nilIfEmpty,
-                  let width = Int(widthStr) else {
-                return nil
+        value.split(separator: ",")
+            .compactMap { entry in
+                let parts = entry.trimmingCharacters(in: .whitespaces).split(separator: " ")
+                guard parts.count == 2,
+                    let url = URL(string: String(parts[0])),
+                    let widthStr = parts[1].dropLast().description.nilIfEmpty,
+                    let width = Int(widthStr)
+                else {
+                    return nil
+                }
+                return SrcsetEntry(url: url, width: width)
             }
-            return SrcsetEntry(url: url, width: width)
-        }
     }
 }
 

--- a/Modules/Sources/WordPressReader/ReaderPostParser.swift
+++ b/Modules/Sources/WordPressReader/ReaderPostParser.swift
@@ -102,7 +102,8 @@ public enum ReaderPostParser {
             let href = try? anchor.attr("href"),
             !href.isEmpty,
             let url = URL(string: href),
-            url.scheme != nil
+            let scheme = url.scheme?.lowercased(),
+            scheme == "http" || scheme == "https"
         else {
             return nil
         }

--- a/Modules/Sources/WordPressReader/ReaderPostParser.swift
+++ b/Modules/Sources/WordPressReader/ReaderPostParser.swift
@@ -4,6 +4,12 @@ import SwiftSoup
 public enum ReaderPostParser {
     public enum InteractiveElement: Sendable {
         case gallery(Gallery)
+        case mention(Mention)
+    }
+
+    public struct Mention: Sendable {
+        public let handle: String
+        public let url: URL
     }
 
     public struct Gallery: Sendable {
@@ -53,13 +59,17 @@ public enum ReaderPostParser {
         public let width: Int
     }
 
-    /// Parses post HTML and returns interactive elements (galleries).
+    /// Parses post HTML and returns interactive elements.
     public static func parse(_ html: String) -> [InteractiveElement] {
         guard let document = try? SwiftSoup.parse(html) else {
             return []
         }
 
         var elements: [InteractiveElement] = []
+
+        if let anchors = try? document.select("a[data-type=fragment-mention][data-username][href]") {
+            elements.append(contentsOf: anchors.compactMap(parseMention(from:)).map(InteractiveElement.mention))
+        }
 
         // Supported gallery selectors (order matters for specificity)
         let selectors = [
@@ -84,6 +94,20 @@ public enum ReaderPostParser {
         }
 
         return elements
+    }
+
+    private static func parseMention(from anchor: Element) -> Mention? {
+        guard let handle = try? anchor.attr("data-username").trimmingCharacters(in: .whitespacesAndNewlines),
+            !handle.isEmpty,
+            let href = try? anchor.attr("href"),
+            !href.isEmpty,
+            let url = URL(string: href),
+            url.scheme != nil
+        else {
+            return nil
+        }
+
+        return Mention(handle: handle, url: url)
     }
 
     private static func parseImages(from container: Element) -> [GalleryImage] {

--- a/Modules/Tests/WordPressReaderTests/ReaderPostParserTests.swift
+++ b/Modules/Tests/WordPressReaderTests/ReaderPostParserTests.swift
@@ -298,6 +298,31 @@ struct ReaderPostParserTests {
         #expect(mention.url.absoluteString == "https://example.wordpress.com/mentions/example-user/")
     }
 
+    @Test func parseMentionOnlyAcceptsHTTPURLs() {
+        let html = """
+            <a href="http://example.wordpress.com/mentions/http/"
+               data-type="fragment-mention" data-username="http">@http</a>
+            <a href="HTTPS://example.wordpress.com/mentions/https/"
+               data-type="fragment-mention" data-username="https">@https</a>
+            <a href="ftp://example.com/mentions/ftp/"
+               data-type="fragment-mention" data-username="ftp">@ftp</a>
+            <a href="mailto:person@example.com"
+               data-type="fragment-mention" data-username="email">@email</a>
+            <a href="custom:person"
+               data-type="fragment-mention" data-username="custom">@custom</a>
+            """
+
+        let mentions = ReaderPostParser.parse(html)
+            .compactMap { element -> ReaderPostParser.Mention? in
+                guard case .mention(let mention) = element else {
+                    return nil
+                }
+                return mention
+            }
+
+        #expect(mentions.map(\.handle) == ["http", "https"])
+    }
+
     @Test func ignoreLinksWithoutCompleteMentionMetadata() {
         let html = """
             <p>@plain-text</p>

--- a/Modules/Tests/WordPressReaderTests/ReaderPostParserTests.swift
+++ b/Modules/Tests/WordPressReaderTests/ReaderPostParserTests.swift
@@ -9,42 +9,42 @@ struct ReaderPostParserTests {
 
     @Test func parseWPBlockGalleryWithThreeImages() {
         let html = """
-        <figure class="wp-block-gallery has-nested-images columns-3 is-cropped wp-block-gallery-1 is-layout-flex wp-block-gallery-is-layout-flex">
-            <figure class="wp-block-image size-large">
-                <img decoding="async" width="1024" height="768"
-                     data-id="2001"
-                     src="https://example.com/wp-content/uploads/photo1.jpg?w=1024"
-                     alt="Sunset over mountains"
-                     class="wp-image-2001"
-                     data-orig-file="https://example.com/wp-content/uploads/photo1.jpg"
-                     data-orig-size="4032,3024"
-                     srcset="https://example.com/wp-content/uploads/photo1.jpg?w=1024 1024w, https://example.com/wp-content/uploads/photo1.jpg?w=150 150w, https://example.com/wp-content/uploads/photo1.jpg?w=300 300w, https://example.com/wp-content/uploads/photo1.jpg?w=768 768w"
-                     data-image-description="<p>A beautiful sunset</p>"
-                     data-image-caption="<p>Sunset caption</p>" />
+            <figure class="wp-block-gallery has-nested-images columns-3 is-cropped wp-block-gallery-1 is-layout-flex wp-block-gallery-is-layout-flex">
+                <figure class="wp-block-image size-large">
+                    <img decoding="async" width="1024" height="768"
+                         data-id="2001"
+                         src="https://example.com/wp-content/uploads/photo1.jpg?w=1024"
+                         alt="Sunset over mountains"
+                         class="wp-image-2001"
+                         data-orig-file="https://example.com/wp-content/uploads/photo1.jpg"
+                         data-orig-size="4032,3024"
+                         srcset="https://example.com/wp-content/uploads/photo1.jpg?w=1024 1024w, https://example.com/wp-content/uploads/photo1.jpg?w=150 150w, https://example.com/wp-content/uploads/photo1.jpg?w=300 300w, https://example.com/wp-content/uploads/photo1.jpg?w=768 768w"
+                         data-image-description="<p>A beautiful sunset</p>"
+                         data-image-caption="<p>Sunset caption</p>" />
+                </figure>
+                <figure class="wp-block-image size-large">
+                    <img decoding="async" width="1024" height="768"
+                         data-id="2002"
+                         src="https://example.com/wp-content/uploads/photo2.jpg?w=1024"
+                         alt="Forest trail"
+                         class="wp-image-2002"
+                         data-orig-file="https://example.com/wp-content/uploads/photo2.jpg"
+                         data-orig-size="3000,2000"
+                         srcset="https://example.com/wp-content/uploads/photo2.jpg?w=1024 1024w, https://example.com/wp-content/uploads/photo2.jpg?w=300 300w"
+                         data-image-description=""
+                         data-image-caption="" />
+                </figure>
+                <figure class="wp-block-image size-large">
+                    <img decoding="async" width="768" height="1024"
+                         data-id="2003"
+                         src="https://example.com/wp-content/uploads/photo3.jpg?w=768"
+                         alt=""
+                         class="wp-image-2003"
+                         data-orig-file="https://example.com/wp-content/uploads/photo3.jpg"
+                         data-orig-size="3024,4032" />
+                </figure>
             </figure>
-            <figure class="wp-block-image size-large">
-                <img decoding="async" width="1024" height="768"
-                     data-id="2002"
-                     src="https://example.com/wp-content/uploads/photo2.jpg?w=1024"
-                     alt="Forest trail"
-                     class="wp-image-2002"
-                     data-orig-file="https://example.com/wp-content/uploads/photo2.jpg"
-                     data-orig-size="3000,2000"
-                     srcset="https://example.com/wp-content/uploads/photo2.jpg?w=1024 1024w, https://example.com/wp-content/uploads/photo2.jpg?w=300 300w"
-                     data-image-description=""
-                     data-image-caption="" />
-            </figure>
-            <figure class="wp-block-image size-large">
-                <img decoding="async" width="768" height="1024"
-                     data-id="2003"
-                     src="https://example.com/wp-content/uploads/photo3.jpg?w=768"
-                     alt=""
-                     class="wp-image-2003"
-                     data-orig-file="https://example.com/wp-content/uploads/photo3.jpg"
-                     data-orig-size="3024,4032" />
-            </figure>
-        </figure>
-        """
+            """
 
         let elements = ReaderPostParser.parse(html)
         #expect(elements.count == 1)
@@ -88,19 +88,19 @@ struct ReaderPostParserTests {
 
     @Test func parseJetpackTiledGalleryBlock() {
         let html = """
-        <figure class="wp-block-jetpack-tiled-gallery">
-            <div class="tiled-gallery__gallery">
-                <div class="tiled-gallery__row">
-                    <img src="https://example.com/photo-a.jpg"
-                         data-orig-file="https://example.com/photo-a-full.jpg"
-                         data-orig-size="2000,1500" />
-                    <img src="https://example.com/photo-b.jpg"
-                         data-orig-file="https://example.com/photo-b-full.jpg"
-                         data-orig-size="1800,1200" />
+            <figure class="wp-block-jetpack-tiled-gallery">
+                <div class="tiled-gallery__gallery">
+                    <div class="tiled-gallery__row">
+                        <img src="https://example.com/photo-a.jpg"
+                             data-orig-file="https://example.com/photo-a-full.jpg"
+                             data-orig-size="2000,1500" />
+                        <img src="https://example.com/photo-b.jpg"
+                             data-orig-file="https://example.com/photo-b-full.jpg"
+                             data-orig-size="1800,1200" />
+                    </div>
                 </div>
-            </div>
-        </figure>
-        """
+            </figure>
+            """
 
         let elements = ReaderPostParser.parse(html)
         #expect(elements.count == 1)
@@ -118,18 +118,18 @@ struct ReaderPostParserTests {
 
     @Test func parseJetpackTiledGalleryClassic() {
         let html = """
-        <div class="tiled-gallery type-rectangular">
-            <div class="gallery-row">
-                <div class="gallery-group">
-                    <img src="https://example.com/classic1.jpg"
-                         data-orig-file="https://example.com/classic1-full.jpg" />
-                </div>
-                <div class="gallery-group">
-                    <img src="https://example.com/classic2.jpg" />
+            <div class="tiled-gallery type-rectangular">
+                <div class="gallery-row">
+                    <div class="gallery-group">
+                        <img src="https://example.com/classic1.jpg"
+                             data-orig-file="https://example.com/classic1-full.jpg" />
+                    </div>
+                    <div class="gallery-group">
+                        <img src="https://example.com/classic2.jpg" />
+                    </div>
                 </div>
             </div>
-        </div>
-        """
+            """
 
         let elements = ReaderPostParser.parse(html)
         #expect(elements.count == 1)
@@ -147,21 +147,21 @@ struct ReaderPostParserTests {
 
     @Test func parseClassicGalleryShortcode() {
         let html = """
-        <div class="gallery gallery-columns-3">
-            <figure class="gallery-item">
-                <div class="gallery-icon landscape">
-                    <img src="https://example.com/shortcode1.jpg"
-                         data-orig-size="800,600" />
-                </div>
-            </figure>
-            <figure class="gallery-item">
-                <div class="gallery-icon portrait">
-                    <img src="https://example.com/shortcode2.jpg"
-                         data-orig-size="600,800" />
-                </div>
-            </figure>
-        </div>
-        """
+            <div class="gallery gallery-columns-3">
+                <figure class="gallery-item">
+                    <div class="gallery-icon landscape">
+                        <img src="https://example.com/shortcode1.jpg"
+                             data-orig-size="800,600" />
+                    </div>
+                </figure>
+                <figure class="gallery-item">
+                    <div class="gallery-icon portrait">
+                        <img src="https://example.com/shortcode2.jpg"
+                             data-orig-size="600,800" />
+                    </div>
+                </figure>
+            </div>
+            """
 
         let elements = ReaderPostParser.parse(html)
         #expect(elements.count == 1)
@@ -179,8 +179,8 @@ struct ReaderPostParserTests {
 
     @Test func parseHTMLWithNoGalleries() {
         let html = """
-        <p>Just a regular paragraph with an <img src="https://example.com/single.jpg" /> image.</p>
-        """
+            <p>Just a regular paragraph with an <img src="https://example.com/single.jpg" /> image.</p>
+            """
 
         let elements = ReaderPostParser.parse(html)
         #expect(elements.isEmpty)
@@ -190,28 +190,29 @@ struct ReaderPostParserTests {
 
     @Test func parseMultipleGalleries() throws {
         let html = """
-        <p>Some text</p>
-        <figure class="wp-block-gallery">
-            <figure class="wp-block-image">
-                <img src="https://example.com/gallery1-img1.jpg" />
+            <p>Some text</p>
+            <figure class="wp-block-gallery">
+                <figure class="wp-block-image">
+                    <img src="https://example.com/gallery1-img1.jpg" />
+                </figure>
             </figure>
-        </figure>
-        <p>More text</p>
-        <figure class="wp-block-gallery">
-            <figure class="wp-block-image">
-                <img src="https://example.com/gallery2-img1.jpg" />
+            <p>More text</p>
+            <figure class="wp-block-gallery">
+                <figure class="wp-block-image">
+                    <img src="https://example.com/gallery2-img1.jpg" />
+                </figure>
+                <figure class="wp-block-image">
+                    <img src="https://example.com/gallery2-img2.jpg" />
+                </figure>
             </figure>
-            <figure class="wp-block-image">
-                <img src="https://example.com/gallery2-img2.jpg" />
-            </figure>
-        </figure>
-        """
+            """
 
         let elements = ReaderPostParser.parse(html)
         try #require(elements.count == 2)
 
         guard case .gallery(let gallery1) = elements[0],
-              case .gallery(let gallery2) = elements[1] else {
+            case .gallery(let gallery2) = elements[1]
+        else {
             Issue.record("Expected gallery elements")
             return
         }
@@ -223,13 +224,13 @@ struct ReaderPostParserTests {
 
     @Test func parseSrcsetWithSingleEntry() {
         let html = """
-        <figure class="wp-block-gallery">
-            <figure class="wp-block-image">
-                <img src="https://example.com/photo.jpg"
-                     srcset="https://example.com/photo.jpg?w=800 800w" />
+            <figure class="wp-block-gallery">
+                <figure class="wp-block-image">
+                    <img src="https://example.com/photo.jpg"
+                         srcset="https://example.com/photo.jpg?w=800 800w" />
+                </figure>
             </figure>
-        </figure>
-        """
+            """
 
         let elements = ReaderPostParser.parse(html)
         guard case .gallery(let gallery) = elements.first else {
@@ -267,12 +268,12 @@ struct ReaderPostParserTests {
 
     @Test func parseImageWithMissingSrc() {
         let html = """
-        <figure class="wp-block-gallery">
-            <figure class="wp-block-image">
-                <img data-orig-file="https://example.com/photo.jpg" />
+            <figure class="wp-block-gallery">
+                <figure class="wp-block-image">
+                    <img data-orig-file="https://example.com/photo.jpg" />
+                </figure>
             </figure>
-        </figure>
-        """
+            """
         let elements = ReaderPostParser.parse(html)
         #expect(elements.isEmpty)
     }

--- a/Modules/Tests/WordPressReaderTests/ReaderPostParserTests.swift
+++ b/Modules/Tests/WordPressReaderTests/ReaderPostParserTests.swift
@@ -277,4 +277,78 @@ struct ReaderPostParserTests {
         let elements = ReaderPostParser.parse(html)
         #expect(elements.isEmpty)
     }
+
+    // MARK: - Mentions
+
+    @Test func parseMention() {
+        let html = """
+            <a href="https://example.wordpress.com/mentions/example-user/"
+               data-type="fragment-mention"
+               data-username="example-user">@example-user</a>
+            """
+
+        let elements = ReaderPostParser.parse(html)
+
+        guard case .mention(let mention) = elements.first else {
+            Issue.record("Expected mention element")
+            return
+        }
+        #expect(elements.count == 1)
+        #expect(mention.handle == "example-user")
+        #expect(mention.url.absoluteString == "https://example.wordpress.com/mentions/example-user/")
+    }
+
+    @Test func ignoreLinksWithoutCompleteMentionMetadata() {
+        let html = """
+            <p>@plain-text</p>
+            <a href="https://example.wordpress.com/mentions/url-only/">@url-only</a>
+            <a href="https://example.wordpress.com/mentions/wrong-type/"
+               data-type="other"
+               data-username="wrong-type">@wrong-type</a>
+            <a href="https://example.wordpress.com/mentions/empty-handle/"
+               data-type="fragment-mention"
+               data-username=" ">@empty-handle</a>
+            <a data-type="fragment-mention" data-username="missing-href">@missing-href</a>
+            <a href="relative-url"
+               data-type="fragment-mention"
+               data-username="relative-url">@relative-url</a>
+            """
+
+        #expect(ReaderPostParser.parse(html).isEmpty)
+    }
+
+    @Test func parseDuplicateMentionsAndMentionInsideGallery() {
+        let html = """
+            <a href="https://example.wordpress.com/mentions/person/"
+               data-type="fragment-mention"
+               data-username="person">@person</a>
+            <figure class="wp-block-gallery">
+                <figure class="wp-block-image">
+                    <img src="https://example.com/photo.jpg" />
+                    <figcaption>
+                        <a href="https://example.wordpress.com/mentions/person/"
+                           data-type="fragment-mention"
+                           data-username="person">@person</a>
+                    </figcaption>
+                </figure>
+            </figure>
+            """
+
+        let elements = ReaderPostParser.parse(html)
+        let mentions = elements.compactMap { element -> ReaderPostParser.Mention? in
+            guard case .mention(let mention) = element else {
+                return nil
+            }
+            return mention
+        }
+        let galleries = elements.compactMap { element -> ReaderPostParser.Gallery? in
+            guard case .gallery(let gallery) = element else {
+                return nil
+            }
+            return gallery
+        }
+
+        #expect(mentions.count == 2)
+        #expect(galleries.count == 1)
+    }
 }

--- a/Tests/KeystoneTests/Tests/Reader/ReaderDetailCoordinatorTests.swift
+++ b/Tests/KeystoneTests/Tests/Reader/ReaderDetailCoordinatorTests.swift
@@ -133,6 +133,37 @@ class ReaderDetailCoordinatorTests: CoreDataTestCase {
         XCTAssertTrue(presentedViewController is WebKitViewController)
     }
 
+    @MainActor
+    func testResolveMentionProfilesDeduplicatesHandles() async {
+        let post = makeMentionPost()
+        let profileService = ReaderUserProfileServiceMock()
+        let coordinator = ReaderDetailCoordinator(
+            readerUserProfileService: profileService,
+            view: ReaderDetailViewMock()
+        )
+        coordinator.post = post
+
+        await coordinator.resolveMentionProfiles(for: post)
+
+        XCTAssertEqual(profileService.requestedHandles, ["example-user"])
+    }
+
+    @MainActor
+    func testResolveMentionProfilesSkipsNonWordPressComPost() async {
+        let post = makeMentionPost()
+        post.isWPCom = false
+        let profileService = ReaderUserProfileServiceMock()
+        let coordinator = ReaderDetailCoordinator(
+            readerUserProfileService: profileService,
+            view: ReaderDetailViewMock()
+        )
+        coordinator.post = post
+
+        await coordinator.resolveMentionProfiles(for: post)
+
+        XCTAssertTrue(profileService.requestedHandles.isEmpty)
+    }
+
     /// Tell the view to scroll when URL is a hash link
     ///
     func testScrollWhenUrlIsHash() {
@@ -159,6 +190,24 @@ class ReaderDetailCoordinatorTests: CoreDataTestCase {
 
     func makeReaderPost() -> ReaderPost {
         ReaderPostBuilder(mainContext).build()
+    }
+
+    private var mentionURL: URL {
+        URL(string: "https://example.wordpress.com/mentions/example-user/")!
+    }
+
+    private func makeMentionPost() -> ReaderPost {
+        let post = makeReaderPost()
+        post.isWPCom = true
+        post.content = """
+            <a href="\(mentionURL.absoluteString)"
+               data-type="fragment-mention"
+               data-username="example-user">@example-user</a>
+            <a href="\(mentionURL.absoluteString)"
+               data-type="fragment-mention"
+               data-username="example-user">@example-user</a>
+            """
+        return post
     }
 }
 
@@ -200,6 +249,15 @@ private class ReaderPostServiceMock: ReaderPostService {
         }
 
         success(returnPost)
+    }
+}
+
+private final class ReaderUserProfileServiceMock: ReaderUserProfileService {
+    private(set) var requestedHandles: [String] = []
+
+    func fetchProfile(handle: String) async -> ReaderUserProfile? {
+        requestedHandles.append(handle)
+        return nil
     }
 }
 

--- a/Tests/KeystoneTests/Tests/Reader/ReaderDetailCoordinatorTests.swift
+++ b/Tests/KeystoneTests/Tests/Reader/ReaderDetailCoordinatorTests.swift
@@ -86,7 +86,11 @@ class ReaderDetailCoordinatorTests: CoreDataTestCase {
         let serviceMock = ReaderPostServiceMock()
         let viewMock = ReaderDetailViewMock()
         let postSharingControllerMock = PostSharingControllerMock()
-        let coordinator = ReaderDetailCoordinator(readerPostService: serviceMock, sharingController: postSharingControllerMock, view: viewMock)
+        let coordinator = ReaderDetailCoordinator(
+            readerPostService: serviceMock,
+            sharingController: postSharingControllerMock,
+            view: viewMock
+        )
         coordinator.post = post
 
         coordinator.share(fromView: button)
@@ -175,7 +179,13 @@ private class ReaderPostServiceMock: ReaderPostService {
         super.init(coreDataStack: ContextManager.forTesting())
     }
 
-    override func fetchPost(_ postID: UInt, forSite siteID: UInt, isFeed: Bool, success: ((ReaderPost?) -> Void)!, failure: ((Error?) -> Void)!) {
+    override func fetchPost(
+        _ postID: UInt,
+        forSite siteID: UInt,
+        isFeed: Bool,
+        success: ((ReaderPost?) -> Void)!,
+        failure: ((Error?) -> Void)!
+    ) {
         didCallFetchPostWithPostID = postID
         didCallFetchPostWithSiteID = siteID
         didCallFetchPostWithIsFeed = isFeed
@@ -208,7 +218,7 @@ private class ReaderDetailViewMock: UIViewController, ReaderDetailView {
         }
 
         get {
-            return _navigationController
+            _navigationController
         }
     }
 
@@ -232,15 +242,19 @@ private class ReaderDetailViewMock: UIViewController, ReaderDetailView {
         didCallScrollToWith = to
     }
 
-    func updateHeader() { }
+    func updateHeader() {}
 
     func updateLikesView(with viewModel: ReaderDetailLikesViewModel) {}
 
-    func updateComments(_ comments: [Comment], totalComments: Int) { }
+    func updateComments(_ comments: [Comment], totalComments: Int) {}
 
-    func renderRelatedPosts(_ posts: [RemoteReaderSimplePost]) { }
+    func renderRelatedPosts(_ posts: [RemoteReaderSimplePost]) {}
 
-    override func present(_ viewControllerToPresent: UIViewController, animated flag: Bool, completion: (() -> Void)? = nil) {
+    override func present(
+        _ viewControllerToPresent: UIViewController,
+        animated flag: Bool,
+        completion: (() -> Void)? = nil
+    ) {
         didCallPresentWith = viewControllerToPresent
     }
 }
@@ -250,7 +264,11 @@ private class PostSharingControllerMock: PostSharingController {
     var didCallShareReaderPostWithView: UIPopoverPresentationControllerSourceItem?
     var didCallShareReaderPostWithViewController: UIViewController?
 
-    override func shareReaderPost(_ post: ReaderPost, fromAnchor anchor: UIPopoverPresentationControllerSourceItem, inViewController viewController: UIViewController) {
+    override func shareReaderPost(
+        _ post: ReaderPost,
+        fromAnchor anchor: UIPopoverPresentationControllerSourceItem,
+        inViewController viewController: UIViewController
+    ) {
         didCallShareReaderPostWith = post
         didCallShareReaderPostWithView = anchor
         didCallShareReaderPostWithViewController = viewController

--- a/Tests/KeystoneTests/WordPressUnitTests.xctestplan
+++ b/Tests/KeystoneTests/WordPressUnitTests.xctestplan
@@ -78,6 +78,13 @@
     },
     {
       "target" : {
+        "containerPath" : "container:..\/Modules",
+        "identifier" : "WordPressReaderTests",
+        "name" : "WordPressReaderTests"
+      }
+    },
+    {
+      "target" : {
         "containerPath" : "container:WordPress.xcodeproj",
         "identifier" : "E16AB92914D978240047A2E5",
         "name" : "WordPressTest"

--- a/Tests/KeystoneTests/WordPressUnitTests.xctestplan
+++ b/Tests/KeystoneTests/WordPressUnitTests.xctestplan
@@ -68,6 +68,13 @@
     },
     {
       "target" : {
+        "containerPath" : "container:..\/Modules",
+        "identifier" : "WordPressReaderTests",
+        "name" : "WordPressReaderTests"
+      }
+    },
+    {
+      "target" : {
         "containerPath" : "container:WordPress.xcodeproj",
         "identifier" : "E16AB92914D978240047A2E5",
         "name" : "WordPressTest"

--- a/WordPress/Classes/ViewRelated/Comments/Views/Detail/CommentContentTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Comments/Views/Detail/CommentContentTableViewCell.swift
@@ -4,7 +4,6 @@ import WordPressUI
 import WordPressReader
 import Gravatar
 import Combine
-import SwiftUI
 
 final class CommentContentTableViewCell: UITableViewCell, NibReusable {
     // all the available images for the accessory button.
@@ -575,16 +574,10 @@ private extension CommentContentTableViewCell {
             return
         }
         let viewModel = ReaderUserProfileViewModel(comment: comment)
-        let profileVC = UIHostingController(rootView: ReaderUserProfileView(viewModel: viewModel))
-        let navigationVC = UINavigationController(rootViewController: profileVC)
-        profileVC.navigationItem.leftBarButtonItem = UIBarButtonItem(
-            systemItem: .close,
-            primaryAction: .init { [weak profileVC] _ in
-                profileVC?.presentingViewController?.dismiss(animated: true)
-            }
-        )
-        navigationVC.sheetPresentationController?.detents = [.medium()]
-        window?.topmostPresentedViewController?.present(navigationVC, animated: true)
+        guard let presentingViewController = window?.topmostPresentedViewController else {
+            return
+        }
+        ReaderUserProfilePresenter.present(viewModel, from: presentingViewController)
     }
 
     @objc func accessoryButtonTapped() {

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailCoordinator.swift
@@ -37,8 +37,9 @@ class ReaderDetailCoordinator {
         // Comment fragments have the form #comment-50484
         // If one is present, we'll extract the ID and return it.
         if let fragment = postURL?.fragment,
-           fragment.hasPrefix("comment-"),
-           let idString = fragment.components(separatedBy: "comment-").last {
+            fragment.hasPrefix("comment-"),
+            let idString = fragment.components(separatedBy: "comment-").last
+        {
             return Int(idString)
         }
 
@@ -96,7 +97,7 @@ class ReaderDetailCoordinator {
 
     /// Reader View Controller
     private var viewController: UIViewController? {
-        return view as? UIViewController
+        view as? UIViewController
     }
 
     /// A post ID to fetch
@@ -123,14 +124,16 @@ class ReaderDetailCoordinator {
     /// Initialize the Reader Detail Coordinator
     ///
     /// - Parameter service: a Reader Post Service
-    init(coreDataStack: CoreDataStack = ContextManager.shared,
-         readerPostService: ReaderPostService = ReaderPostService(coreDataStack: ContextManager.shared),
-         topicService: ReaderTopicService = ReaderTopicService(coreDataStack: ContextManager.shared),
-         postService: PostService = PostService(managedObjectContext: ContextManager.shared.mainContext),
-         commentService: CommentService = CommentService(coreDataStack: ContextManager.shared),
-         sharingController: PostSharingController = PostSharingController(),
-         readerLinkRouter: UniversalLinkRouter = UniversalLinkRouter(routes: UniversalLinkRouter.readerRoutes),
-         view: ReaderDetailView) {
+    init(
+        coreDataStack: CoreDataStack = ContextManager.shared,
+        readerPostService: ReaderPostService = ReaderPostService(coreDataStack: ContextManager.shared),
+        topicService: ReaderTopicService = ReaderTopicService(coreDataStack: ContextManager.shared),
+        postService: PostService = PostService(managedObjectContext: ContextManager.shared.mainContext),
+        commentService: CommentService = CommentService(coreDataStack: ContextManager.shared),
+        sharingController: PostSharingController = PostSharingController(),
+        readerLinkRouter: UniversalLinkRouter = UniversalLinkRouter(routes: UniversalLinkRouter.readerRoutes),
+        view: ReaderDetailView
+    ) {
         self.coreDataStack = coreDataStack
         self.readerPostService = readerPostService
         self.topicService = topicService
@@ -174,22 +177,28 @@ class ReaderDetailCoordinator {
 
         // Fetch a full page of Likes but only return the `maxAvatarsDisplayed` number.
         // That way the first page will already be cached if the user displays the full Likes list.
-        postService.getLikesFor(postID: postID, siteID: siteID, success: { [weak self] users, _, _ in
-            guard let self else { return }
+        postService.getLikesFor(
+            postID: postID,
+            siteID: siteID,
+            success: { [weak self] users, _, _ in
+                guard let self else { return }
 
-            var filteredUsers = users
-            if let account = try? WPAccount.lookupDefaultWordPressComAccount(in: ContextManager.shared.mainContext),
-               let userID = account.userID?.int64Value,
-               let userIndex = filteredUsers.firstIndex(where: { $0.userID == userID }) {
-                filteredUsers.remove(at: userIndex)
+                var filteredUsers = users
+                if let account = try? WPAccount.lookupDefaultWordPressComAccount(in: ContextManager.shared.mainContext),
+                    let userID = account.userID?.int64Value,
+                    let userIndex = filteredUsers.firstIndex(where: { $0.userID == userID })
+                {
+                    filteredUsers.remove(at: userIndex)
+                }
+
+                self.likesAvatarURLs = filteredUsers.prefix(ReaderDetailLikesView.maxAvatarsDisplayed).map(\.avatarUrl)
+                self.updateLikesView()
+                self.startObservingLikes()
+            },
+            failure: { error in
+                DDLogError("Error fetching Likes for post detail: \(String(describing: error?.localizedDescription))")
             }
-
-            self.likesAvatarURLs = filteredUsers.prefix(ReaderDetailLikesView.maxAvatarsDisplayed).map(\.avatarUrl)
-            self.updateLikesView()
-            self.startObservingLikes()
-        }, failure: { error in
-            DDLogError("Error fetching Likes for post detail: \(String(describing: error?.localizedDescription))")
-        })
+        )
     }
 
     private func startObservingLikes() {
@@ -197,12 +206,14 @@ class ReaderDetailCoordinator {
             return wpAssertionFailure("post missing")
         }
 
-        likesObserver = Publishers.CombineLatest(
-            post.publisher(for: \.likeCount, options: [.new]).removeDuplicates(),
-            post.publisher(for: \.isLiked, options: [.new]).removeDuplicates()
-        ).sink { [weak self] _, _ in
-            self?.updateLikesView()
-        }
+        likesObserver =
+            Publishers.CombineLatest(
+                post.publisher(for: \.likeCount, options: [.new]).removeDuplicates(),
+                post.publisher(for: \.isLiked, options: [.new]).removeDuplicates()
+            )
+            .sink { [weak self] _, _ in
+                self?.updateLikesView()
+            }
     }
 
     private func updateLikesView() {
@@ -211,7 +222,9 @@ class ReaderDetailCoordinator {
         let viewModel = ReaderDetailLikesViewModel(
             likeCount: post.likeCount?.intValue ?? 0,
             avatarURLs: likesAvatarURLs,
-            selfLikeAvatarURL: post.isLiked ? try? WPAccount.lookupDefaultWordPressComAccount(in: ContextManager.shared.mainContext)?.avatarURL : nil
+            selfLikeAvatarURL: post.isLiked
+                ? try? WPAccount.lookupDefaultWordPressComAccount(in: ContextManager.shared.mainContext)?.avatarURL
+                : nil
         )
         view?.updateLikesView(with: viewModel)
     }
@@ -219,13 +232,16 @@ class ReaderDetailCoordinator {
     /// Fetch Comments for the current post.
     ///
     func fetchComments(for post: ReaderPost) {
-        commentService.syncHierarchicalComments(for: post,
-                                   topLevelComments: commentsDisplayed,
-                                            success: { [weak self] _, totalComments in
-                                                self?.updateCommentsFor(post: post, totalComments: totalComments?.intValue ?? 0)
-                                            }, failure: { error in
-                                                DDLogError("Failed fetching post detail comments: \(String(describing: error))")
-                                            })
+        commentService.syncHierarchicalComments(
+            for: post,
+            topLevelComments: commentsDisplayed,
+            success: { [weak self] _, totalComments in
+                self?.updateCommentsFor(post: post, totalComments: totalComments?.intValue ?? 0)
+            },
+            failure: { error in
+                DDLogError("Failed fetching post detail comments: \(String(describing: error))")
+            }
+        )
     }
 
     func updateCommentsFor(post: ReaderPost, totalComments: Int) {
@@ -275,7 +291,10 @@ class ReaderDetailCoordinator {
 
         if let blogID = sourceAttribution.blogID {
             let controller = ReaderStreamViewController.controllerWithSiteID(blogID, isFeed: false)
-            controller.trackingContext.source = ScreenTrackingSource(ScreenID.Reader.article, component: ElementID.Reader.articleHeaderSiteName)
+            controller.trackingContext.source = ScreenTrackingSource(
+                ScreenID.Reader.article,
+                component: ElementID.Reader.articleHeaderSiteName
+            )
             viewController?.navigationController?.pushViewController(controller, animated: true)
             return
         }
@@ -308,7 +327,8 @@ class ReaderDetailCoordinator {
         let urlString = url.absoluteString
         for element in interactiveElements {
             if case .gallery(let gallery) = element,
-               let index = gallery.images.firstIndex(where: { $0.src.absoluteString == urlString }) {
+                let index = gallery.images.firstIndex(where: { $0.src.absoluteString == urlString })
+            {
                 return (gallery, index)
             }
         }
@@ -318,7 +338,9 @@ class ReaderDetailCoordinator {
     private func presentGallery(_ gallery: ReaderPostParser.Gallery, startingAt index: Int) {
         WPAnalytics.trackReader(.readerArticleImageTapped)
         let host = post.map(MediaHost.init)
-        let maxDimension = Int(max(UIScreen.main.bounds.width, UIScreen.main.bounds.height) * min(UIScreen.main.scale, 2))
+        let maxDimension = Int(
+            max(UIScreen.main.bounds.width, UIScreen.main.bounds.height) * min(UIScreen.main.scale, 2)
+        )
         let assets = gallery.images.map { image in
             let sourceURL = image.bestURL(maxDimension: maxDimension) ?? image.originalFileURL ?? image.src
             let previewURL = image.srcset.min(by: { $0.width < $1.width })?.url
@@ -357,7 +379,8 @@ class ReaderDetailCoordinator {
     /// - Parameter completion: a completion block
     func storeAuthenticationCookies(in webView: WKWebView, completion: @escaping () -> Void) {
         guard let authenticator,
-            let postURL = permaLinkURL else {
+            let postURL = permaLinkURL
+        else {
             completion()
             return
         }
@@ -374,16 +397,19 @@ class ReaderDetailCoordinator {
     /// - Parameter siteID: a site identification
     /// - Parameter isFeed: a Boolean indicating if the site is an external feed (not hosted at WPcom and not using Jetpack)
     private func fetch(postID: NSNumber, siteID: NSNumber, isFeed: Bool) {
-        readerPostService.fetchPost(postID.uintValue,
-                                    forSite: siteID.uintValue,
-                                    isFeed: isFeed,
-                                    success: { [weak self] post in
-                                        self?.post = post
-                                        self?.renderPostAndBumpStats()
-                                    }, failure: { [weak self] error in
-                                        self?.postURL == nil ? self?.showError(error: error) : self?.view?.showErrorWithWebAction(error: error)
-                                        self?.reportPostLoadFailure()
-                                    })
+        readerPostService.fetchPost(
+            postID.uintValue,
+            forSite: siteID.uintValue,
+            isFeed: isFeed,
+            success: { [weak self] post in
+                self?.post = post
+                self?.renderPostAndBumpStats()
+            },
+            failure: { [weak self] error in
+                self?.postURL == nil ? self?.showError(error: error) : self?.view?.showErrorWithWebAction(error: error)
+                self?.reportPostLoadFailure()
+            }
+        )
     }
 
     /// Requests a ReaderPost from the service and updates the View.
@@ -392,11 +418,12 @@ class ReaderDetailCoordinator {
     /// - Parameter url: a post URL
     private func fetch(_ url: URL) {
         readerPostService.resolvePostUrl(url) { [weak self] resolvedPost in
-            self?.fetch(
-                postID: NSNumber(value: resolvedPost.postId),
-                siteID: NSNumber(value: resolvedPost.siteId),
-                isFeed: false
-            )
+            self?
+                .fetch(
+                    postID: NSNumber(value: resolvedPost.postId),
+                    siteID: NSNumber(value: resolvedPost.siteId),
+                    isFeed: false
+                )
         } failure: { [weak self] error in
             DDLogError("Error fetching post for detail: \(String(describing: error.localizedDescription))")
             self?.showError(error: error)
@@ -407,8 +434,9 @@ class ReaderDetailCoordinator {
     private func showError(error: Error?) {
         let errorMessage: String? = {
             guard let error = error as? NSError,
-                  error.domain == WordPressComRestApiEndpointError.errorDomain,
-                  error.code == WordPressComRestApiErrorCode.authorizationRequired.rawValue else {
+                error.domain == WordPressComRestApiEndpointError.errorDomain,
+                error.code == WordPressComRestApiErrorCode.authorizationRequired.rawValue
+            else {
                 return nil
             }
             return Strings.fetchDetailFromPrivateBlogErrorMessage
@@ -433,11 +461,17 @@ class ReaderDetailCoordinator {
             return
         }
 
-        readerPostService.toggleSeen(for: post, success: {
-            NotificationCenter.default.post(name: .ReaderPostSeenToggled,
-                                            object: nil,
-                                            userInfo: [ReaderNotificationKeys.post: post])
-        }, failure: nil)
+        readerPostService.toggleSeen(
+            for: post,
+            success: {
+                NotificationCenter.default.post(
+                    name: .ReaderPostSeenToggled,
+                    object: nil,
+                    userInfo: [ReaderNotificationKeys.post: post]
+                )
+            },
+            failure: nil
+        )
     }
 
     /// If the loaded URL contains a hash/anchor then jump to that spot in the post content
@@ -462,7 +496,10 @@ class ReaderDetailCoordinator {
         }
 
         let controller = ReaderStreamViewController.controllerWithSiteID(siteID, isFeed: post.isExternal)
-        controller.trackingContext.source = ScreenTrackingSource(ScreenID.Reader.article, component: ElementID.Reader.articleHeaderSiteName)
+        controller.trackingContext.source = ScreenTrackingSource(
+            ScreenID.Reader.article,
+            component: ElementID.Reader.articleHeaderSiteName
+        )
         viewController?.navigationController?.pushViewController(controller, animated: true)
 
         let properties = ReaderHelpers.statsPropertiesForPost(post, andValue: post.blogURL as AnyObject?, forKey: "URL")
@@ -471,7 +508,10 @@ class ReaderDetailCoordinator {
 
     func showTopic(_ topic: String) {
         let controller = ReaderStreamViewController.controllerWithTagSlug(topic)
-        controller.trackingContext.source = ScreenTrackingSource(ScreenID.Reader.article, component: ElementID.Reader.tagChip)
+        controller.trackingContext.source = ScreenTrackingSource(
+            ScreenID.Reader.article,
+            component: ElementID.Reader.tagChip
+        )
         viewController?.navigationController?.pushViewController(controller, animated: true)
     }
 
@@ -488,10 +528,17 @@ class ReaderDetailCoordinator {
         }
 
         let controller = ReaderStreamViewController.controllerWithTagSlug(primaryTagSlug)
-        controller.trackingContext.source = ScreenTrackingSource(ScreenID.Reader.article, component: ElementID.Reader.tagChip)
+        controller.trackingContext.source = ScreenTrackingSource(
+            ScreenID.Reader.article,
+            component: ElementID.Reader.tagChip
+        )
         viewController?.navigationController?.pushViewController(controller, animated: true)
 
-        let properties = ReaderHelpers.statsPropertiesForPost(post, andValue: post.primaryTagSlug as AnyObject?, forKey: "tag")
+        let properties = ReaderHelpers.statsPropertiesForPost(
+            post,
+            andValue: post.primaryTagSlug as AnyObject?,
+            forKey: "tag"
+        )
         WPAppAnalytics.track(.readerTagPreviewed, withProperties: properties)
     }
 
@@ -509,15 +556,15 @@ class ReaderDetailCoordinator {
         // post URL or the webview's baseURL, scroll within the document.
         // In-document anchors (e.g. footnotes) resolve against the baseURL,
         // so we need to check both.
-        let isInDocumentAnchor = permaLinkURL?.isHostAndPathEqual(to: url) == true || ReaderWebView.baseURL.isHostAndPathEqual(to: url)
+        let isInDocumentAnchor =
+            permaLinkURL?.isHostAndPathEqual(to: url) == true || ReaderWebView.baseURL.isHostAndPathEqual(to: url)
         if let hash = URLComponents(url: url, resolvingAgainstBaseURL: true)?.fragment, isInDocumentAnchor {
             view?.scroll(to: hash)
         } else if let (gallery, index) = findGallery(containing: url) {
             presentGallery(gallery, startingAt: index)
-        } else if url.pathExtension.contains("gif") ||
-                    url.pathExtension.contains("jpg") ||
-                    url.pathExtension.contains("jpeg") ||
-                    url.pathExtension.contains("png") {
+        } else if url.pathExtension.contains("gif") || url.pathExtension.contains("jpg")
+            || url.pathExtension.contains("jpeg") || url.pathExtension.contains("png")
+        {
             presentImage(url)
         } else if url.query?.contains("wp-story") ?? false {
             presentWebViewController(url)
@@ -542,18 +589,21 @@ class ReaderDetailCoordinator {
             return
         }
 
-        ReaderFollowAction().execute(with: post,
-                                     context: coreDataStack.mainContext,
-                                     completion: { [weak self] follow in
-                                        ReaderHelpers.dispatchToggleFollowSiteMessage(post: post, follow: follow, success: true)
-                                        self?.view?.updateHeader()
-                                        completion()
-                                     },
-                                     failure: { [weak self] follow, _ in
-                                        ReaderHelpers.dispatchToggleFollowSiteMessage(post: post, follow: follow, success: false)
-                                        self?.view?.updateHeader()
-                                        completion()
-                                     })
+        ReaderFollowAction()
+            .execute(
+                with: post,
+                context: coreDataStack.mainContext,
+                completion: { [weak self] follow in
+                    ReaderHelpers.dispatchToggleFollowSiteMessage(post: post, follow: follow, success: true)
+                    self?.view?.updateHeader()
+                    completion()
+                },
+                failure: { [weak self] follow, _ in
+                    ReaderHelpers.dispatchToggleFollowSiteMessage(post: post, follow: follow, success: false)
+                    self?.view?.updateHeader()
+                    completion()
+                }
+            )
     }
 
     private func selectedUrlIsCrossPost(_ url: URL) -> Bool {
@@ -561,10 +611,11 @@ class ReaderDetailCoordinator {
         let characterSet = CharacterSet(charactersIn: "/")
 
         guard let post,
-              post.isCrossPost,
-              let crossPostMeta = post.crossPostMeta,
-              let crossPostURL = URL(string: crossPostMeta.postURL.trimmingCharacters(in: characterSet)),
-              let selectedURL = URL(string: url.absoluteString.trimmingCharacters(in: characterSet)) else {
+            post.isCrossPost,
+            let crossPostMeta = post.crossPostMeta,
+            let crossPostURL = URL(string: crossPostMeta.postURL.trimmingCharacters(in: characterSet)),
+            let selectedURL = URL(string: url.absoluteString.trimmingCharacters(in: characterSet))
+        else {
             return false
         }
 
@@ -636,7 +687,9 @@ class ReaderDetailCoordinator {
         }
 
         let isOfflineView = ReachabilityUtils.isInternetReachable() ? "no" : "yes"
-        let detailType = readerPost.topic?.type == ReaderSiteTopic.TopicType ? DetailAnalyticsConstants.TypePreviewSite : DetailAnalyticsConstants.TypeNormal
+        let detailType =
+            readerPost.topic?.type == ReaderSiteTopic.TopicType
+            ? DetailAnalyticsConstants.TypePreviewSite : DetailAnalyticsConstants.TypeNormal
 
         var properties = ReaderHelpers.statsPropertiesForPost(readerPost, andValue: nil, forKey: nil)
         properties[DetailAnalyticsConstants.TypeKey] = detailType
@@ -645,12 +698,12 @@ class ReaderDetailCoordinator {
         // Track related post tapped
         if let simplePost = remoteSimplePost {
             switch simplePost.postType {
-                case .local:
-                    WPAnalytics.track(.readerRelatedPostFromSameSiteClicked, properties: properties)
-                case .global:
-                    WPAnalytics.track(.readerRelatedPostFromOtherSiteClicked, properties: properties)
-                default:
-                    DDLogError("Unknown related post type: \(String(describing: simplePost.postType))")
+            case .local:
+                WPAnalytics.track(.readerRelatedPostFromSameSiteClicked, properties: properties)
+            case .global:
+                WPAnalytics.track(.readerRelatedPostFromOtherSiteClicked, properties: properties)
+            default:
+                DDLogError("Unknown related post type: \(String(describing: simplePost.postType))")
             }
         }
 

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailCoordinator.swift
@@ -58,6 +58,8 @@ class ReaderDetailCoordinator {
         return ReaderPostParser.parse(content)
     }()
 
+    private var mentionProfiles: [String: ReaderUserProfile] = [:]
+
     private var likesAvatarURLs: [String]?
 
     /// An authenticator to ensure any request made to WP sites is properly authenticated
@@ -91,6 +93,9 @@ class ReaderDetailCoordinator {
 
     /// Reader Link Router
     private let readerLinkRouter: UniversalLinkRouter
+
+    /// Reader User Profile Service
+    private let readerUserProfileService: ReaderUserProfileService
 
     /// Reader View
     private weak var view: ReaderDetailView?
@@ -132,6 +137,7 @@ class ReaderDetailCoordinator {
         commentService: CommentService = CommentService(coreDataStack: ContextManager.shared),
         sharingController: PostSharingController = PostSharingController(),
         readerLinkRouter: UniversalLinkRouter = UniversalLinkRouter(routes: UniversalLinkRouter.readerRoutes),
+        readerUserProfileService: ReaderUserProfileService? = nil,
         view: ReaderDetailView
     ) {
         self.coreDataStack = coreDataStack
@@ -141,6 +147,9 @@ class ReaderDetailCoordinator {
         self.commentService = commentService
         self.sharingController = sharingController
         self.readerLinkRouter = readerLinkRouter
+        self.readerUserProfileService =
+            readerUserProfileService
+            ?? WordPressComReaderUserProfileService(coreDataStack: coreDataStack)
         self.view = view
     }
 
@@ -199,6 +208,34 @@ class ReaderDetailCoordinator {
                 DDLogError("Error fetching Likes for post detail: \(String(describing: error?.localizedDescription))")
             }
         )
+    }
+
+    @MainActor
+    func resolveMentionProfiles(for post: ReaderPost) async {
+        guard post.isWPCom, let content = post.content else {
+            return
+        }
+
+        let mentions = ReaderPostParser.parse(content)
+            .compactMap { element -> ReaderPostParser.Mention? in
+                guard case .mention(let mention) = element else {
+                    return nil
+                }
+                return mention
+            }
+
+        var requestedHandles = Set<String>()
+        // Posts typically have few mentions, so resolving them sequentially keeps this simple without meaningful delay.
+        for mention in mentions {
+            let key = Self.normalizedMentionHandle(mention.handle)
+            guard mentionProfiles[key] == nil, requestedHandles.insert(key).inserted else {
+                continue
+            }
+
+            if let profile = await readerUserProfileService.fetchProfile(handle: mention.handle) {
+                mentionProfiles[key] = profile
+            }
+        }
     }
 
     private func startObservingLikes() {
@@ -333,6 +370,26 @@ class ReaderDetailCoordinator {
             }
         }
         return nil
+    }
+
+    private func findMention(matching url: URL) -> ReaderPostParser.Mention? {
+        let urlString = url.absoluteString
+        for element in interactiveElements {
+            if case .mention(let mention) = element, mention.url.absoluteString == urlString {
+                return mention
+            }
+        }
+        return nil
+    }
+
+    private func presentMentionProfile(_ profile: ReaderUserProfile) {
+        guard let viewController else {
+            return
+        }
+        ReaderUserProfilePresenter.present(
+            ReaderUserProfileViewModel(profile: profile),
+            from: viewController
+        )
     }
 
     private func presentGallery(_ gallery: ReaderPostParser.Gallery, startingAt index: Int) {
@@ -560,6 +617,13 @@ class ReaderDetailCoordinator {
             permaLinkURL?.isHostAndPathEqual(to: url) == true || ReaderWebView.baseURL.isHostAndPathEqual(to: url)
         if let hash = URLComponents(url: url, resolvingAgainstBaseURL: true)?.fragment, isInDocumentAnchor {
             view?.scroll(to: hash)
+        } else if let mention = findMention(matching: url) {
+            if let profile = mentionProfiles[Self.normalizedMentionHandle(mention.handle)] {
+                presentMentionProfile(profile)
+            } else {
+                WPAnalytics.trackReader(.readerArticleLinkTapped)
+                presentWebViewController(url)
+            }
         } else if let (gallery, index) = findGallery(containing: url) {
             presentGallery(gallery, startingAt: index)
         } else if url.pathExtension.contains("gif") || url.pathExtension.contains("jpg")
@@ -577,6 +641,10 @@ class ReaderDetailCoordinator {
 
             presentWebViewController(url)
         }
+    }
+
+    private static func normalizedMentionHandle(_ handle: String) -> String {
+        handle.lowercased()
     }
 
     /// Called after the webView fully loads

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailCoordinator.swift
@@ -34,8 +34,9 @@ class ReaderDetailCoordinator {
         // Comment fragments have the form #comment-50484
         // If one is present, we'll extract the ID and return it.
         if let fragment = postURL?.fragment,
-           fragment.hasPrefix("comment-"),
-           let idString = fragment.components(separatedBy: "comment-").last {
+            fragment.hasPrefix("comment-"),
+            let idString = fragment.components(separatedBy: "comment-").last
+        {
             return Int(idString)
         }
 
@@ -93,7 +94,7 @@ class ReaderDetailCoordinator {
 
     /// Reader View Controller
     private var viewController: UIViewController? {
-        return view as? UIViewController
+        view as? UIViewController
     }
 
     /// A post ID to fetch
@@ -120,14 +121,16 @@ class ReaderDetailCoordinator {
     /// Initialize the Reader Detail Coordinator
     ///
     /// - Parameter service: a Reader Post Service
-    init(coreDataStack: CoreDataStack = ContextManager.shared,
-         readerPostService: ReaderPostService = ReaderPostService(coreDataStack: ContextManager.shared),
-         topicService: ReaderTopicService = ReaderTopicService(coreDataStack: ContextManager.shared),
-         postService: PostService = PostService(managedObjectContext: ContextManager.shared.mainContext),
-         commentService: CommentService = CommentService(coreDataStack: ContextManager.shared),
-         sharingController: PostSharingController = PostSharingController(),
-         readerLinkRouter: UniversalLinkRouter = UniversalLinkRouter(routes: UniversalLinkRouter.readerRoutes),
-         view: ReaderDetailView) {
+    init(
+        coreDataStack: CoreDataStack = ContextManager.shared,
+        readerPostService: ReaderPostService = ReaderPostService(coreDataStack: ContextManager.shared),
+        topicService: ReaderTopicService = ReaderTopicService(coreDataStack: ContextManager.shared),
+        postService: PostService = PostService(managedObjectContext: ContextManager.shared.mainContext),
+        commentService: CommentService = CommentService(coreDataStack: ContextManager.shared),
+        sharingController: PostSharingController = PostSharingController(),
+        readerLinkRouter: UniversalLinkRouter = UniversalLinkRouter(routes: UniversalLinkRouter.readerRoutes),
+        view: ReaderDetailView
+    ) {
         self.coreDataStack = coreDataStack
         self.readerPostService = readerPostService
         self.topicService = topicService
@@ -171,22 +174,28 @@ class ReaderDetailCoordinator {
 
         // Fetch a full page of Likes but only return the `maxAvatarsDisplayed` number.
         // That way the first page will already be cached if the user displays the full Likes list.
-        postService.getLikesFor(postID: postID, siteID: siteID, success: { [weak self] users, _, _ in
-            guard let self else { return }
+        postService.getLikesFor(
+            postID: postID,
+            siteID: siteID,
+            success: { [weak self] users, _, _ in
+                guard let self else { return }
 
-            var filteredUsers = users
-            if let account = try? WPAccount.lookupDefaultWordPressComAccount(in: ContextManager.shared.mainContext),
-               let userID = account.userID?.int64Value,
-               let userIndex = filteredUsers.firstIndex(where: { $0.userID == userID }) {
-                filteredUsers.remove(at: userIndex)
+                var filteredUsers = users
+                if let account = try? WPAccount.lookupDefaultWordPressComAccount(in: ContextManager.shared.mainContext),
+                    let userID = account.userID?.int64Value,
+                    let userIndex = filteredUsers.firstIndex(where: { $0.userID == userID })
+                {
+                    filteredUsers.remove(at: userIndex)
+                }
+
+                self.likesAvatarURLs = filteredUsers.prefix(ReaderDetailLikesView.maxAvatarsDisplayed).map(\.avatarUrl)
+                self.updateLikesView()
+                self.startObservingLikes()
+            },
+            failure: { error in
+                DDLogError("Error fetching Likes for post detail: \(String(describing: error?.localizedDescription))")
             }
-
-            self.likesAvatarURLs = filteredUsers.prefix(ReaderDetailLikesView.maxAvatarsDisplayed).map(\.avatarUrl)
-            self.updateLikesView()
-            self.startObservingLikes()
-        }, failure: { error in
-            DDLogError("Error fetching Likes for post detail: \(String(describing: error?.localizedDescription))")
-        })
+        )
     }
 
     private func startObservingLikes() {
@@ -194,12 +203,14 @@ class ReaderDetailCoordinator {
             return wpAssertionFailure("post missing")
         }
 
-        likesObserver = Publishers.CombineLatest(
-            post.publisher(for: \.likeCount, options: [.new]).removeDuplicates(),
-            post.publisher(for: \.isLiked, options: [.new]).removeDuplicates()
-        ).sink { [weak self] _, _ in
-            self?.updateLikesView()
-        }
+        likesObserver =
+            Publishers.CombineLatest(
+                post.publisher(for: \.likeCount, options: [.new]).removeDuplicates(),
+                post.publisher(for: \.isLiked, options: [.new]).removeDuplicates()
+            )
+            .sink { [weak self] _, _ in
+                self?.updateLikesView()
+            }
     }
 
     private func updateLikesView() {
@@ -208,7 +219,9 @@ class ReaderDetailCoordinator {
         let viewModel = ReaderDetailLikesViewModel(
             likeCount: post.likeCount?.intValue ?? 0,
             avatarURLs: likesAvatarURLs,
-            selfLikeAvatarURL: post.isLiked ? try? WPAccount.lookupDefaultWordPressComAccount(in: ContextManager.shared.mainContext)?.avatarURL : nil
+            selfLikeAvatarURL: post.isLiked
+                ? try? WPAccount.lookupDefaultWordPressComAccount(in: ContextManager.shared.mainContext)?.avatarURL
+                : nil
         )
         view?.updateLikesView(with: viewModel)
     }
@@ -216,13 +229,16 @@ class ReaderDetailCoordinator {
     /// Fetch Comments for the current post.
     ///
     func fetchComments(for post: ReaderPost) {
-        commentService.syncHierarchicalComments(for: post,
-                                   topLevelComments: commentsDisplayed,
-                                            success: { [weak self] _, totalComments in
-                                                self?.updateCommentsFor(post: post, totalComments: totalComments?.intValue ?? 0)
-                                            }, failure: { error in
-                                                DDLogError("Failed fetching post detail comments: \(String(describing: error))")
-                                            })
+        commentService.syncHierarchicalComments(
+            for: post,
+            topLevelComments: commentsDisplayed,
+            success: { [weak self] _, totalComments in
+                self?.updateCommentsFor(post: post, totalComments: totalComments?.intValue ?? 0)
+            },
+            failure: { error in
+                DDLogError("Failed fetching post detail comments: \(String(describing: error))")
+            }
+        )
     }
 
     func updateCommentsFor(post: ReaderPost, totalComments: Int) {
@@ -272,7 +288,10 @@ class ReaderDetailCoordinator {
 
         if let blogID = sourceAttribution.blogID {
             let controller = ReaderStreamViewController.controllerWithSiteID(blogID, isFeed: false)
-            controller.trackingContext.source = ScreenTrackingSource(ScreenID.Reader.article, component: ElementID.Reader.articleHeaderSiteName)
+            controller.trackingContext.source = ScreenTrackingSource(
+                ScreenID.Reader.article,
+                component: ElementID.Reader.articleHeaderSiteName
+            )
             viewController?.navigationController?.pushViewController(controller, animated: true)
             return
         }
@@ -305,7 +324,8 @@ class ReaderDetailCoordinator {
         let urlString = url.absoluteString
         for element in interactiveElements {
             if case .gallery(let gallery) = element,
-               let index = gallery.images.firstIndex(where: { $0.src.absoluteString == urlString }) {
+                let index = gallery.images.firstIndex(where: { $0.src.absoluteString == urlString })
+            {
                 return (gallery, index)
             }
         }
@@ -315,7 +335,9 @@ class ReaderDetailCoordinator {
     private func presentGallery(_ gallery: ReaderPostParser.Gallery, startingAt index: Int) {
         WPAnalytics.trackReader(.readerArticleImageTapped)
         let host = post.map(MediaHost.init)
-        let maxDimension = Int(max(UIScreen.main.bounds.width, UIScreen.main.bounds.height) * min(UIScreen.main.scale, 2))
+        let maxDimension = Int(
+            max(UIScreen.main.bounds.width, UIScreen.main.bounds.height) * min(UIScreen.main.scale, 2)
+        )
         let assets = gallery.images.map { image in
             let sourceURL = image.bestURL(maxDimension: maxDimension) ?? image.originalFileURL ?? image.src
             let previewURL = image.srcset.min(by: { $0.width < $1.width })?.url
@@ -354,7 +376,8 @@ class ReaderDetailCoordinator {
     /// - Parameter completion: a completion block
     func storeAuthenticationCookies(in webView: WKWebView, completion: @escaping () -> Void) {
         guard let authenticator,
-            let postURL = permaLinkURL else {
+            let postURL = permaLinkURL
+        else {
             completion()
             return
         }
@@ -371,16 +394,19 @@ class ReaderDetailCoordinator {
     /// - Parameter siteID: a site identification
     /// - Parameter isFeed: a Boolean indicating if the site is an external feed (not hosted at WPcom and not using Jetpack)
     private func fetch(postID: NSNumber, siteID: NSNumber, isFeed: Bool) {
-        readerPostService.fetchPost(postID.uintValue,
-                                    forSite: siteID.uintValue,
-                                    isFeed: isFeed,
-                                    success: { [weak self] post in
-                                        self?.post = post
-                                        self?.renderPostAndBumpStats()
-                                    }, failure: { [weak self] error in
-                                        self?.postURL == nil ? self?.showError(error: error) : self?.view?.showErrorWithWebAction(error: error)
-                                        self?.reportPostLoadFailure()
-                                    })
+        readerPostService.fetchPost(
+            postID.uintValue,
+            forSite: siteID.uintValue,
+            isFeed: isFeed,
+            success: { [weak self] post in
+                self?.post = post
+                self?.renderPostAndBumpStats()
+            },
+            failure: { [weak self] error in
+                self?.postURL == nil ? self?.showError(error: error) : self?.view?.showErrorWithWebAction(error: error)
+                self?.reportPostLoadFailure()
+            }
+        )
     }
 
     /// Requests a ReaderPost from the service and updates the View.
@@ -389,11 +415,12 @@ class ReaderDetailCoordinator {
     /// - Parameter url: a post URL
     private func fetch(_ url: URL) {
         readerPostService.resolvePostUrl(url) { [weak self] resolvedPost in
-            self?.fetch(
-                postID: NSNumber(value: resolvedPost.postId),
-                siteID: NSNumber(value: resolvedPost.siteId),
-                isFeed: false
-            )
+            self?
+                .fetch(
+                    postID: NSNumber(value: resolvedPost.postId),
+                    siteID: NSNumber(value: resolvedPost.siteId),
+                    isFeed: false
+                )
         } failure: { [weak self] error in
             DDLogError("Error fetching post for detail: \(String(describing: error.localizedDescription))")
             self?.showError(error: error)
@@ -404,8 +431,9 @@ class ReaderDetailCoordinator {
     private func showError(error: Error?) {
         let errorMessage: String? = {
             guard let error = error as? NSError,
-                  error.domain == WordPressComRestApiEndpointError.errorDomain,
-                  error.code == WordPressComRestApiErrorCode.authorizationRequired.rawValue else {
+                error.domain == WordPressComRestApiEndpointError.errorDomain,
+                error.code == WordPressComRestApiErrorCode.authorizationRequired.rawValue
+            else {
                 return nil
             }
             return Strings.fetchDetailFromPrivateBlogErrorMessage
@@ -430,11 +458,17 @@ class ReaderDetailCoordinator {
             return
         }
 
-        readerPostService.toggleSeen(for: post, success: {
-            NotificationCenter.default.post(name: .ReaderPostSeenToggled,
-                                            object: nil,
-                                            userInfo: [ReaderNotificationKeys.post: post])
-        }, failure: nil)
+        readerPostService.toggleSeen(
+            for: post,
+            success: {
+                NotificationCenter.default.post(
+                    name: .ReaderPostSeenToggled,
+                    object: nil,
+                    userInfo: [ReaderNotificationKeys.post: post]
+                )
+            },
+            failure: nil
+        )
     }
 
     /// If the loaded URL contains a hash/anchor then jump to that spot in the post content
@@ -459,7 +493,10 @@ class ReaderDetailCoordinator {
         }
 
         let controller = ReaderStreamViewController.controllerWithSiteID(siteID, isFeed: post.isExternal)
-        controller.trackingContext.source = ScreenTrackingSource(ScreenID.Reader.article, component: ElementID.Reader.articleHeaderSiteName)
+        controller.trackingContext.source = ScreenTrackingSource(
+            ScreenID.Reader.article,
+            component: ElementID.Reader.articleHeaderSiteName
+        )
         viewController?.navigationController?.pushViewController(controller, animated: true)
 
         let properties = ReaderHelpers.statsPropertiesForPost(post, andValue: post.blogURL as AnyObject?, forKey: "URL")
@@ -468,7 +505,10 @@ class ReaderDetailCoordinator {
 
     private func showTopic(_ topic: String) {
         let controller = ReaderStreamViewController.controllerWithTagSlug(topic)
-        controller.trackingContext.source = ScreenTrackingSource(ScreenID.Reader.article, component: ElementID.Reader.tagChip)
+        controller.trackingContext.source = ScreenTrackingSource(
+            ScreenID.Reader.article,
+            component: ElementID.Reader.tagChip
+        )
         viewController?.navigationController?.pushViewController(controller, animated: true)
     }
 
@@ -485,10 +525,17 @@ class ReaderDetailCoordinator {
         }
 
         let controller = ReaderStreamViewController.controllerWithTagSlug(primaryTagSlug)
-        controller.trackingContext.source = ScreenTrackingSource(ScreenID.Reader.article, component: ElementID.Reader.tagChip)
+        controller.trackingContext.source = ScreenTrackingSource(
+            ScreenID.Reader.article,
+            component: ElementID.Reader.tagChip
+        )
         viewController?.navigationController?.pushViewController(controller, animated: true)
 
-        let properties = ReaderHelpers.statsPropertiesForPost(post, andValue: post.primaryTagSlug as AnyObject?, forKey: "tag")
+        let properties = ReaderHelpers.statsPropertiesForPost(
+            post,
+            andValue: post.primaryTagSlug as AnyObject?,
+            forKey: "tag"
+        )
         WPAppAnalytics.track(.readerTagPreviewed, withProperties: properties)
     }
 
@@ -506,15 +553,15 @@ class ReaderDetailCoordinator {
         // post URL or the webview's baseURL, scroll within the document.
         // In-document anchors (e.g. footnotes) resolve against the baseURL,
         // so we need to check both.
-        let isInDocumentAnchor = permaLinkURL?.isHostAndPathEqual(to: url) == true || ReaderWebView.baseURL.isHostAndPathEqual(to: url)
+        let isInDocumentAnchor =
+            permaLinkURL?.isHostAndPathEqual(to: url) == true || ReaderWebView.baseURL.isHostAndPathEqual(to: url)
         if let hash = URLComponents(url: url, resolvingAgainstBaseURL: true)?.fragment, isInDocumentAnchor {
             view?.scroll(to: hash)
         } else if let (gallery, index) = findGallery(containing: url) {
             presentGallery(gallery, startingAt: index)
-        } else if url.pathExtension.contains("gif") ||
-                    url.pathExtension.contains("jpg") ||
-                    url.pathExtension.contains("jpeg") ||
-                    url.pathExtension.contains("png") {
+        } else if url.pathExtension.contains("gif") || url.pathExtension.contains("jpg")
+            || url.pathExtension.contains("jpeg") || url.pathExtension.contains("png")
+        {
             presentImage(url)
         } else if url.query?.contains("wp-story") ?? false {
             presentWebViewController(url)
@@ -539,18 +586,21 @@ class ReaderDetailCoordinator {
             return
         }
 
-        ReaderFollowAction().execute(with: post,
-                                     context: coreDataStack.mainContext,
-                                     completion: { [weak self] follow in
-                                        ReaderHelpers.dispatchToggleFollowSiteMessage(post: post, follow: follow, success: true)
-                                        self?.view?.updateHeader()
-                                        completion()
-                                     },
-                                     failure: { [weak self] follow, _ in
-                                        ReaderHelpers.dispatchToggleFollowSiteMessage(post: post, follow: follow, success: false)
-                                        self?.view?.updateHeader()
-                                        completion()
-                                     })
+        ReaderFollowAction()
+            .execute(
+                with: post,
+                context: coreDataStack.mainContext,
+                completion: { [weak self] follow in
+                    ReaderHelpers.dispatchToggleFollowSiteMessage(post: post, follow: follow, success: true)
+                    self?.view?.updateHeader()
+                    completion()
+                },
+                failure: { [weak self] follow, _ in
+                    ReaderHelpers.dispatchToggleFollowSiteMessage(post: post, follow: follow, success: false)
+                    self?.view?.updateHeader()
+                    completion()
+                }
+            )
     }
 
     private func selectedUrlIsCrossPost(_ url: URL) -> Bool {
@@ -558,10 +608,11 @@ class ReaderDetailCoordinator {
         let characterSet = CharacterSet(charactersIn: "/")
 
         guard let post,
-              post.isCrossPost,
-              let crossPostMeta = post.crossPostMeta,
-              let crossPostURL = URL(string: crossPostMeta.postURL.trimmingCharacters(in: characterSet)),
-              let selectedURL = URL(string: url.absoluteString.trimmingCharacters(in: characterSet)) else {
+            post.isCrossPost,
+            let crossPostMeta = post.crossPostMeta,
+            let crossPostURL = URL(string: crossPostMeta.postURL.trimmingCharacters(in: characterSet)),
+            let selectedURL = URL(string: url.absoluteString.trimmingCharacters(in: characterSet))
+        else {
             return false
         }
 
@@ -631,7 +682,9 @@ class ReaderDetailCoordinator {
         }
 
         let isOfflineView = ReachabilityUtils.isInternetReachable() ? "no" : "yes"
-        let detailType = readerPost.topic?.type == ReaderSiteTopic.TopicType ? DetailAnalyticsConstants.TypePreviewSite : DetailAnalyticsConstants.TypeNormal
+        let detailType =
+            readerPost.topic?.type == ReaderSiteTopic.TopicType
+            ? DetailAnalyticsConstants.TypePreviewSite : DetailAnalyticsConstants.TypeNormal
 
         var properties = ReaderHelpers.statsPropertiesForPost(readerPost, andValue: nil, forKey: nil)
         properties[DetailAnalyticsConstants.TypeKey] = detailType
@@ -640,12 +693,12 @@ class ReaderDetailCoordinator {
         // Track related post tapped
         if let simplePost = remoteSimplePost {
             switch simplePost.postType {
-                case .local:
-                    WPAnalytics.track(.readerRelatedPostFromSameSiteClicked, properties: properties)
-                case .global:
-                    WPAnalytics.track(.readerRelatedPostFromOtherSiteClicked, properties: properties)
-                default:
-                    DDLogError("Unknown related post type: \(String(describing: simplePost.postType))")
+            case .local:
+                WPAnalytics.track(.readerRelatedPostFromSameSiteClicked, properties: properties)
+            case .global:
+                WPAnalytics.track(.readerRelatedPostFromOtherSiteClicked, properties: properties)
+            default:
+                DDLogError("Unknown related post type: \(String(describing: simplePost.postType))")
             }
         }
 

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailCoordinator.swift
@@ -55,6 +55,8 @@ class ReaderDetailCoordinator {
         return ReaderPostParser.parse(content)
     }()
 
+    private var mentionProfiles: [String: ReaderUserProfile] = [:]
+
     private var likesAvatarURLs: [String]?
 
     /// An authenticator to ensure any request made to WP sites is properly authenticated
@@ -88,6 +90,9 @@ class ReaderDetailCoordinator {
 
     /// Reader Link Router
     private let readerLinkRouter: UniversalLinkRouter
+
+    /// Reader User Profile Service
+    private let readerUserProfileService: ReaderUserProfileService
 
     /// Reader View
     private weak var view: ReaderDetailView?
@@ -129,6 +134,7 @@ class ReaderDetailCoordinator {
         commentService: CommentService = CommentService(coreDataStack: ContextManager.shared),
         sharingController: PostSharingController = PostSharingController(),
         readerLinkRouter: UniversalLinkRouter = UniversalLinkRouter(routes: UniversalLinkRouter.readerRoutes),
+        readerUserProfileService: ReaderUserProfileService? = nil,
         view: ReaderDetailView
     ) {
         self.coreDataStack = coreDataStack
@@ -138,6 +144,9 @@ class ReaderDetailCoordinator {
         self.commentService = commentService
         self.sharingController = sharingController
         self.readerLinkRouter = readerLinkRouter
+        self.readerUserProfileService =
+            readerUserProfileService
+            ?? WordPressComReaderUserProfileService(coreDataStack: coreDataStack)
         self.view = view
     }
 
@@ -196,6 +205,34 @@ class ReaderDetailCoordinator {
                 DDLogError("Error fetching Likes for post detail: \(String(describing: error?.localizedDescription))")
             }
         )
+    }
+
+    @MainActor
+    func resolveMentionProfiles(for post: ReaderPost) async {
+        guard post.isWPCom, let content = post.content else {
+            return
+        }
+
+        let mentions = ReaderPostParser.parse(content)
+            .compactMap { element -> ReaderPostParser.Mention? in
+                guard case .mention(let mention) = element else {
+                    return nil
+                }
+                return mention
+            }
+
+        var requestedHandles = Set<String>()
+        // Posts typically have few mentions, so resolving them sequentially keeps this simple without meaningful delay.
+        for mention in mentions {
+            let key = Self.normalizedMentionHandle(mention.handle)
+            guard mentionProfiles[key] == nil, requestedHandles.insert(key).inserted else {
+                continue
+            }
+
+            if let profile = await readerUserProfileService.fetchProfile(handle: mention.handle) {
+                mentionProfiles[key] = profile
+            }
+        }
     }
 
     private func startObservingLikes() {
@@ -330,6 +367,26 @@ class ReaderDetailCoordinator {
             }
         }
         return nil
+    }
+
+    private func findMention(matching url: URL) -> ReaderPostParser.Mention? {
+        let urlString = url.absoluteString
+        for element in interactiveElements {
+            if case .mention(let mention) = element, mention.url.absoluteString == urlString {
+                return mention
+            }
+        }
+        return nil
+    }
+
+    private func presentMentionProfile(_ profile: ReaderUserProfile) {
+        guard let viewController else {
+            return
+        }
+        ReaderUserProfilePresenter.present(
+            ReaderUserProfileViewModel(profile: profile),
+            from: viewController
+        )
     }
 
     private func presentGallery(_ gallery: ReaderPostParser.Gallery, startingAt index: Int) {
@@ -557,6 +614,13 @@ class ReaderDetailCoordinator {
             permaLinkURL?.isHostAndPathEqual(to: url) == true || ReaderWebView.baseURL.isHostAndPathEqual(to: url)
         if let hash = URLComponents(url: url, resolvingAgainstBaseURL: true)?.fragment, isInDocumentAnchor {
             view?.scroll(to: hash)
+        } else if let mention = findMention(matching: url) {
+            if let profile = mentionProfiles[Self.normalizedMentionHandle(mention.handle)] {
+                presentMentionProfile(profile)
+            } else {
+                WPAnalytics.trackReader(.readerArticleLinkTapped)
+                presentWebViewController(url)
+            }
         } else if let (gallery, index) = findGallery(containing: url) {
             presentGallery(gallery, startingAt: index)
         } else if url.pathExtension.contains("gif") || url.pathExtension.contains("jpg")
@@ -574,6 +638,10 @@ class ReaderDetailCoordinator {
 
             presentWebViewController(url)
         }
+    }
+
+    private static func normalizedMentionHandle(_ handle: String) -> String {
+        handle.lowercased()
     }
 
     /// Called after the webView fully loads

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -262,6 +262,10 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
     }
 
     func render(_ post: ReaderPost) {
+        Task { @MainActor [weak coordinator] in
+            await coordinator?.resolveMentionProfiles(for: post)
+        }
+
         configureDiscoverAttribution(post)
 
         toolbar.configure(for: post, in: self)

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -104,7 +104,7 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
 
     /// The post being shown
     @objc var post: ReaderPost? {
-        return coordinator?.post
+        coordinator?.post
     }
 
     /// The URL to a post can change – we might set it when we instantiate the controller, but then when we fetch the details from the server, we know
@@ -123,7 +123,7 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
     }
 
     override var hidesBottomBarWhenPushed: Bool {
-        set { }
+        set {}
         get { true }
     }
 
@@ -206,13 +206,19 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
         navigationController?.interactivePopGestureRecognizer?.delegate = self
 
         // When comments are moderated or edited from the Comments view, update the Comments snippet here.
-        NotificationCenter.default.addObserver(self, selector: #selector(fetchComments), name: .ReaderCommentModifiedNotification, object: nil)
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(fetchComments),
+            name: .ReaderCommentModifiedNotification,
+            object: nil
+        )
 
         // In the `scrollViewDidScroll` function, "toolbar hidden" is toggled repeatedly when the scroll view in the
         // middle of scrolling animation. This debouncer is introduced to avoid toggling
         // `navigationController.toolbarHidden`, which causes inifity loops.
         // Sentry issue: https://a8c.sentry.io/issues/6884521550
-        toolbarHiddenDebounceCancellable = toolbarHiddenDebouncer
+        toolbarHiddenDebounceCancellable =
+            toolbarHiddenDebouncer
             .removeDuplicates()
             .debounce(for: .milliseconds(100), scheduler: DispatchQueue.main)
             .sink { [weak self] isHidden in
@@ -268,15 +274,17 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
         checkTranslationAvailability()
 
         if let postURLString = post.permaLink,
-           let postURL = URL(string: postURLString) {
+            let postURL = URL(string: postURLString)
+        {
             webView.postURL = postURL
         }
 
         webView.isP2 = post.isP2Type
 
-        coordinator?.storeAuthenticationCookies(in: webView) { [weak self] in
-            self?.showPostContent(post)
-        }
+        coordinator?
+            .storeAuthenticationCookies(in: webView) { [weak self] in
+                self?.showPostContent(post)
+            }
 
         navigateToCommentIfNecessary()
     }
@@ -313,17 +321,22 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
 
     private func navigateToCommentIfNecessary() {
         if let post,
-           let commentID = coordinator?.commentID,
-           !hasAutomaticallyTriggeredCommentAction {
+            let commentID = coordinator?.commentID,
+            !hasAutomaticallyTriggeredCommentAction
+        {
             hasAutomaticallyTriggeredCommentAction = true
 
-            ReaderCommentAction().execute(
-                post: post,
-                origin: self,
-                navigateToCommentID: commentID,
-                source: .postDetails,
-                trackingSource: ScreenTrackingSource(ScreenID.Reader.article, component: ElementID.Reader.commentsSection)
-            )
+            ReaderCommentAction()
+                .execute(
+                    post: post,
+                    origin: self,
+                    navigateToCommentID: commentID,
+                    source: .postDetails,
+                    trackingSource: ScreenTrackingSource(
+                        ScreenID.Reader.article,
+                        component: ElementID.Reader.commentsSection
+                    )
+                )
         }
     }
 
@@ -345,7 +358,7 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
             } else {
                 NSLayoutConstraint.activate([
                     activityIndicator.centerXAnchor.constraint(equalTo: webView.centerXAnchor),
-                    activityIndicator.topAnchor.constraint(equalTo: webView.topAnchor, constant: 64),
+                    activityIndicator.topAnchor.constraint(equalTo: webView.topAnchor, constant: 64)
                 ])
             }
             activityIndicator.startAnimating()
@@ -401,14 +414,17 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
     /// Scroll the content to a given #hash
     ///
     func scroll(to hash: String) {
-        webView.evaluateJavaScript("document.getElementById('\(hash)').offsetTop", completionHandler: { [weak self] height, _ in
-            guard let self, let height = height as? CGFloat else {
-                return
-            }
+        webView.evaluateJavaScript(
+            "document.getElementById('\(hash)').offsetTop",
+            completionHandler: { [weak self] height, _ in
+                guard let self, let height = height as? CGFloat else {
+                    return
+                }
 
-            let y = height + self.webView.frame.origin.y - self.scrollView.adjustedContentInset.top
-            self.scrollView.setContentOffset(CGPoint(x: 0, y: y), animated: true)
-        })
+                let y = height + self.webView.frame.origin.y - self.scrollView.adjustedContentInset.top
+                self.scrollView.setContentOffset(CGPoint(x: 0, y: y), animated: true)
+            }
+        )
     }
 
     func updateHeader() {
@@ -437,7 +453,7 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
 
         // Moderated comments could still be cached, so filter out non-approved comments.
         let approvedStatus = Comment.descriptionFor(.approved)
-        let approvedComments = comments.filter({ $0.status == approvedStatus})
+        let approvedComments = comments.filter({ $0.status == approvedStatus })
 
         // Set the delegate here so the table isn't shown until fetching is complete.
         commentsTableView.delegate = commentsTableViewDelegate
@@ -540,7 +556,8 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
     private func observeWebViewHeight() {
         scrollObserver = webView.scrollView.observe(\.contentSize, options: .new) { [weak self] _, change in
             guard let self,
-                  let height = change.newValue?.height else {
+                let height = change.newValue?.height
+            else {
                 return
             }
 
@@ -548,19 +565,22 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
             /// (except for a few times when it returns a very big weird number)
             /// We use that value so the content is not displayed with weird empty space at the bottom
             ///
-            self.webView.evaluateJavaScript("document.body.scrollHeight", completionHandler: { [weak self] webViewHeight, _ in
-                guard let self else { return }
-                guard let webViewHeight = webViewHeight as? CGFloat else {
-                    self.webViewHeight.constant = height
-                    return
-                }
+            self.webView.evaluateJavaScript(
+                "document.body.scrollHeight",
+                completionHandler: { [weak self] webViewHeight, _ in
+                    guard let self else { return }
+                    guard let webViewHeight = webViewHeight as? CGFloat else {
+                        self.webViewHeight.constant = height
+                        return
+                    }
 
-                /// The display setting's custom size is applied through the HTML's initial-scale property
-                /// in the meta tag. The `scrollHeight` value seems to return the height as if it's at 1.0 scale,
-                /// so we'll need to add the custom scale into account.
-                let scaledWebViewHeight = round(webViewHeight * self.displaySetting.size.scale)
-                self.webViewHeight.constant = min(scaledWebViewHeight, height)
-            })
+                    /// The display setting's custom size is applied through the HTML's initial-scale property
+                    /// in the meta tag. The `scrollHeight` value seems to return the height as if it's at 1.0 scale,
+                    /// so we'll need to add the custom scale into account.
+                    let scaledWebViewHeight = round(webViewHeight * self.displaySetting.size.scale)
+                    self.webViewHeight.constant = min(scaledWebViewHeight, height)
+                }
+            )
         }
     }
 
@@ -664,12 +684,18 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
     private func configureCommentsTable() {
         commentsTableView.separatorStyle = .none
         commentsTableView.backgroundColor = .clear
-        commentsTableView.register(ReaderDetailCommentsHeader.defaultNib,
-                                   forHeaderFooterViewReuseIdentifier: ReaderDetailCommentsHeader.defaultReuseID)
-        commentsTableView.register(CommentContentTableViewCell.defaultNib,
-                                   forCellReuseIdentifier: CommentContentTableViewCell.defaultReuseID)
-        commentsTableView.register(ReaderDetailNoCommentCell.defaultNib,
-                                   forCellReuseIdentifier: ReaderDetailNoCommentCell.defaultReuseID)
+        commentsTableView.register(
+            ReaderDetailCommentsHeader.defaultNib,
+            forHeaderFooterViewReuseIdentifier: ReaderDetailCommentsHeader.defaultReuseID
+        )
+        commentsTableView.register(
+            CommentContentTableViewCell.defaultNib,
+            forCellReuseIdentifier: CommentContentTableViewCell.defaultReuseID
+        )
+        commentsTableView.register(
+            ReaderDetailNoCommentCell.defaultNib,
+            forCellReuseIdentifier: ReaderDetailNoCommentCell.defaultReuseID
+        )
     }
 
     // Translation framework doesn't support UIKit, so we have to jump through the hoops.
@@ -767,10 +793,14 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
         relatedPostsTableView.separatorStyle = .none
         relatedPostsTableView.backgroundColor = .clear
 
-        relatedPostsTableView.register(ReaderRelatedPostsCell.defaultNib,
-                           forCellReuseIdentifier: ReaderRelatedPostsCell.defaultReuseID)
-        relatedPostsTableView.register(ReaderRelatedPostsSectionHeaderView.defaultNib,
-                           forHeaderFooterViewReuseIdentifier: ReaderRelatedPostsSectionHeaderView.defaultReuseID)
+        relatedPostsTableView.register(
+            ReaderRelatedPostsCell.defaultNib,
+            forCellReuseIdentifier: ReaderRelatedPostsCell.defaultReuseID
+        )
+        relatedPostsTableView.register(
+            ReaderRelatedPostsSectionHeaderView.defaultNib,
+            forHeaderFooterViewReuseIdentifier: ReaderRelatedPostsSectionHeaderView.defaultReuseID
+        )
 
         relatedPostsTableView.dataSource = self
         relatedPostsTableView.delegate = self
@@ -807,15 +837,19 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
     }
 
     private func configureNotifications() {
-        NotificationCenter.default.addObserver(self,
-                                               selector: #selector(siteBlocked(_:)),
-                                               name: .ReaderSiteBlocked,
-                                               object: nil)
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(siteBlocked(_:)),
+            name: .ReaderSiteBlocked,
+            object: nil
+        )
 
-        NotificationCenter.default.addObserver(self,
-                                               selector: #selector(userBlocked(_:)),
-                                               name: .ReaderUserBlockingDidEnd,
-                                               object: nil)
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(userBlocked(_:)),
+            name: .ReaderUserBlockingDidEnd,
+            object: nil
+        )
     }
 
     @objc private func userBlocked(_ notification: Foundation.Notification) {
@@ -842,11 +876,14 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
     }
 
     @objc func didTapDisplaySettingButton() {
-        let viewController = ReaderDisplaySettingViewController(initialSetting: displaySetting,
-                                                                source: .readerPostNavBar) { [weak self] newSetting in
+        let viewController = ReaderDisplaySettingViewController(
+            initialSetting: displaySetting,
+            source: .readerPostNavBar
+        ) { [weak self] newSetting in
             // no need to refresh if there are no changes to the display setting.
             guard let self,
-                  newSetting != self.displaySetting else {
+                newSetting != self.displaySetting
+            else {
                 return
             }
 
@@ -870,7 +907,11 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
     /// - Parameter siteID: a site identification
     /// - Parameter isFeed: a Boolean indicating if the site is an external feed (not hosted at WPcom and not using Jetpack)
     /// - Returns: A `ReaderDetailViewController` instance
-    @objc class func controllerWithPostID(_ postID: NSNumber, siteID: NSNumber, isFeed: Bool = false) -> ReaderDetailViewController {
+    @objc class func controllerWithPostID(
+        _ postID: NSNumber,
+        siteID: NSNumber,
+        isFeed: Bool = false
+    ) -> ReaderDetailViewController {
         let controller = ReaderDetailViewController.loadFromStoryboard()
         let coordinator = ReaderDetailCoordinator(view: controller)
         coordinator.set(postID: postID, siteID: siteID, isFeed: isFeed)
@@ -925,9 +966,10 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
     /// - Returns: A `ReaderDetailViewController` instance
     @objc class func controllerWithPost(_ post: ReaderPost) -> ReaderDetailViewController {
         if post.sourceAttributionStyle() == .post,
-           let sourceAttribution = post.sourceAttribution,
-           let postID = sourceAttribution.postID,
-           let blogID = sourceAttribution.blogID {
+            let sourceAttribution = post.sourceAttribution,
+            let postID = sourceAttribution.postID,
+            let blogID = sourceAttribution.blogID
+        {
             return ReaderDetailViewController.controllerWithPostID(postID, siteID: blogID)
         } else if post.isCrossPost, let crossPostMeta = post.crossPostMeta {
             return ReaderDetailViewController.controllerWithPostID(crossPostMeta.postID, siteID: crossPostMeta.siteID)
@@ -950,10 +992,12 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
         guard let post else {
             return
         }
-        NotificationCenter.default.addObserver(self,
-                                               selector: #selector(handleObjectsChange(_:)),
-                                               name: NSNotification.Name.NSManagedObjectContextObjectsDidChange,
-                                               object: post.managedObjectContext)
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleObjectsChange(_:)),
+            name: NSNotification.Name.NSManagedObjectContextObjectsDidChange,
+            object: post.managedObjectContext
+        )
     }
 
     @objc func handleObjectsChange(_ notification: Foundation.Notification) {
@@ -1010,7 +1054,7 @@ extension ReaderDetailViewController: UIScrollViewDelegate {
 
 extension ReaderDetailViewController: StoryboardLoadable {
     static var defaultStoryboardName: String {
-        return "ReaderDetailViewController"
+        "ReaderDetailViewController"
     }
 }
 
@@ -1019,15 +1063,20 @@ extension ReaderDetailViewController: StoryboardLoadable {
 extension ReaderDetailViewController: UITableViewDataSource, UITableViewDelegate {
 
     func numberOfSections(in tableView: UITableView) -> Int {
-        return relatedPosts.count
+        relatedPosts.count
     }
 
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return relatedPosts[section].posts.count
+        relatedPosts[section].posts.count
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        guard let cell = tableView.dequeueReusableCell(withIdentifier: ReaderRelatedPostsCell.defaultReuseID, for: indexPath) as? ReaderRelatedPostsCell else {
+        guard
+            let cell = tableView.dequeueReusableCell(
+                withIdentifier: ReaderRelatedPostsCell.defaultReuseID,
+                for: indexPath
+            ) as? ReaderRelatedPostsCell
+        else {
             fatalError("Expected RelatedPostsTableViewCell with identifier: \(ReaderRelatedPostsCell.defaultReuseID)")
         }
 
@@ -1049,12 +1098,15 @@ extension ReaderDetailViewController: UITableViewDataSource, UITableViewDelegate
     }
 
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-        return UITableView.automaticDimension
+        UITableView.automaticDimension
     }
 
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
         guard let title = getSectionTitle(for: relatedPosts[section].postType),
-              let header = tableView.dequeueReusableHeaderFooterView(withIdentifier: ReaderRelatedPostsSectionHeaderView.defaultReuseID) as? ReaderRelatedPostsSectionHeaderView else {
+            let header = tableView.dequeueReusableHeaderFooterView(
+                withIdentifier: ReaderRelatedPostsSectionHeaderView.defaultReuseID
+            ) as? ReaderRelatedPostsSectionHeaderView
+        else {
             return UIView(frame: .zero)
         }
 
@@ -1072,7 +1124,7 @@ extension ReaderDetailViewController: UITableViewDataSource, UITableViewDelegate
     }
 
     func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-        return ReaderRelatedPostsSectionHeaderView.height
+        ReaderRelatedPostsSectionHeaderView.height
     }
 
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
@@ -1083,7 +1135,11 @@ extension ReaderDetailViewController: UITableViewDataSource, UITableViewDelegate
         guard let controller = ReaderDetailViewController.controllerWithSimplePost(post) else {
             return
         }
-        controller.trackingContext.source = ScreenTrackingSource(ScreenID.Reader.article, component: ElementID.Reader.relatedPosts, position: indexPath.row)
+        controller.trackingContext.source = ScreenTrackingSource(
+            ScreenID.Reader.article,
+            component: ElementID.Reader.relatedPosts,
+            position: indexPath.row
+        )
         navigationController?.pushViewController(controller, animated: true)
     }
 
@@ -1112,8 +1168,11 @@ extension ReaderDetailViewController: ReaderDisplaySettingStoreDelegate {
 
 // MARK: - UIGestureRecognizerDelegate
 extension ReaderDetailViewController: UIGestureRecognizerDelegate {
-    func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldBeRequiredToFailBy otherGestureRecognizer: UIGestureRecognizer) -> Bool {
-        return true
+    func gestureRecognizer(
+        _ gestureRecognizer: UIGestureRecognizer,
+        shouldBeRequiredToFailBy otherGestureRecognizer: UIGestureRecognizer
+    ) -> Bool {
+        true
     }
 }
 
@@ -1140,7 +1199,11 @@ extension ReaderDetailViewController: ReaderCardDiscoverAttributionViewDelegate 
 // MARK: - Transitioning Delegate
 
 extension ReaderDetailViewController: UIViewControllerTransitioningDelegate {
-    public func presentationController(forPresented presented: UIViewController, presenting: UIViewController?, source: UIViewController) -> UIPresentationController? {
+    public func presentationController(
+        forPresented presented: UIViewController,
+        presenting: UIViewController?,
+        source: UIViewController
+    ) -> UIPresentationController? {
         guard presented is FancyAlertViewController else {
             return nil
         }
@@ -1160,7 +1223,11 @@ extension ReaderDetailViewController: WKNavigationDelegate {
         hideLoading()
     }
 
-    func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
+    func webView(
+        _ webView: WKWebView,
+        decidePolicyFor navigationAction: WKNavigationAction,
+        decisionHandler: @escaping (WKNavigationActionPolicy) -> Void
+    ) {
         if navigationAction.navigationType == .linkActivated {
             if let url = navigationAction.request.url {
                 coordinator?.handle(url)
@@ -1205,8 +1272,14 @@ private extension ReaderDetailViewController {
     }
 
     struct LoadingText {
-        static let errorLoadingTitle = NSLocalizedString("Error Loading Post", comment: "Text displayed when load post fails.")
-        static let errorLoadingPostURLButtonTitle = NSLocalizedString("Open in browser", comment: "Button title to load a post in an in-app web view")
+        static let errorLoadingTitle = NSLocalizedString(
+            "Error Loading Post",
+            comment: "Text displayed when load post fails."
+        )
+        static let errorLoadingPostURLButtonTitle = NSLocalizedString(
+            "Open in browser",
+            comment: "Button title to load a post in an in-app web view"
+        )
     }
 }
 
@@ -1225,14 +1298,16 @@ private extension ReaderDetailViewController {
 
     func showTranslationSpinner() {
         guard var items = navigationItem.rightBarButtonItems,
-              !items.contains(translationSpinner) else { return }
+            !items.contains(translationSpinner)
+        else { return }
         items.append(translationSpinner)
         navigationItem.setRightBarButtonItems(items, animated: true)
     }
 
     func hideTranslationSpinner() {
         guard var items = navigationItem.rightBarButtonItems,
-              let index = items.firstIndex(of: translationSpinner) else { return }
+            let index = items.firstIndex(of: translationSpinner)
+        else { return }
         items.remove(at: index)
         navigationItem.setRightBarButtonItems(items, animated: true)
     }
@@ -1276,14 +1351,17 @@ private extension ReaderDetailViewController {
 
     func moreButtonItem(enabled: Bool = true) -> UIBarButtonItem? {
         let button = UIBarButtonItem(image: UIImage(systemName: "ellipsis"), menu: nil)
-        button.menu = UIMenu(options: .displayInline, children: [
-            UIDeferredMenuElement.uncached { [weak self, weak button] callback in
-                guard let self, let button else {
-                    return callback([])
+        button.menu = UIMenu(
+            options: .displayInline,
+            children: [
+                UIDeferredMenuElement.uncached { [weak self, weak button] callback in
+                    guard let self, let button else {
+                        return callback([])
+                    }
+                    callback(self.makeMoreMenu(button))
                 }
-                callback(self.makeMoreMenu(button))
-            }
-        ])
+            ]
+        )
         button.accessibilityLabel = Strings.moreButtonAccessibilityLabel
         button.isEnabled = enabled
         return button
@@ -1298,19 +1376,26 @@ private extension ReaderDetailViewController {
             topic: nil,
             anchor: anchor,
             viewController: self
-        ).makeMenu()
+        )
+        .makeMenu()
 
         if ReaderDisplaySettings.customizationEnabled {
-            elements.append(UIAction(title: Strings.displaySettingsLabel, image: UIImage(systemName: "textformat.size")) { [weak self] _ in
-                self?.didTapDisplaySettingButton()
-            })
+            elements.append(
+                UIAction(title: Strings.displaySettingsLabel, image: UIImage(systemName: "textformat.size")) {
+                    [weak self] _ in
+                    self?.didTapDisplaySettingButton()
+                }
+            )
         }
 
         return elements
     }
 
     func shareButtonItem(enabled: Bool = true) -> UIBarButtonItem? {
-        let button = barButtonItem(with: UIImage(named: "wpl-share") ?? UIImage(), action: #selector(didTapShareButton(_:)))
+        let button = barButtonItem(
+            with: UIImage(named: "wpl-share") ?? UIImage(),
+            action: #selector(didTapShareButton(_:))
+        )
         button.accessibilityLabel = SharedStrings.Button.share
         button.isEnabled = enabled
 
@@ -1347,7 +1432,8 @@ extension ReaderDetailViewController {
         static let displaySettingsLabel = NSLocalizedString(
             "readerDetail.displaySettingButton.displaySettingsLabel",
             value: "Reading Preferences",
-            comment: "Spoken accessibility label for the Reading Preferences menu.")
+            comment: "Spoken accessibility label for the Reading Preferences menu."
+        )
         static let safariButtonAccessibilityLabel = NSLocalizedString(
             "readerDetail.safariButton.accessibilityLabel",
             value: "Open in Safari",
@@ -1380,12 +1466,16 @@ extension ReaderDetailViewController: BorderedButtonTableViewCellDelegate {
             return
         }
 
-        ReaderCommentAction().execute(
-            post: post,
-            origin: self,
-            source: .postDetailsComments,
-            trackingSource: ScreenTrackingSource(ScreenID.Reader.article, component: ElementID.Reader.commentsSection)
-        )
+        ReaderCommentAction()
+            .execute(
+                post: post,
+                origin: self,
+                source: .postDetailsComments,
+                trackingSource: ScreenTrackingSource(
+                    ScreenID.Reader.article,
+                    component: ElementID.Reader.commentsSection
+                )
+            )
     }
 
     func buttonLeaveCommentTapped(replyingTo comment: Comment?) {

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -95,7 +95,7 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
 
     /// The post being shown
     @objc var post: ReaderPost? {
-        return coordinator?.post
+        coordinator?.post
     }
 
     /// The URL to a post can change – we might set it when we instantiate the controller, but then when we fetch the details from the server, we know
@@ -114,7 +114,7 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
     }
 
     override var hidesBottomBarWhenPushed: Bool {
-        set { }
+        set {}
         get { true }
     }
 
@@ -197,13 +197,19 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
         navigationController?.interactivePopGestureRecognizer?.delegate = self
 
         // When comments are moderated or edited from the Comments view, update the Comments snippet here.
-        NotificationCenter.default.addObserver(self, selector: #selector(fetchComments), name: .ReaderCommentModifiedNotification, object: nil)
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(fetchComments),
+            name: .ReaderCommentModifiedNotification,
+            object: nil
+        )
 
         // In the `scrollViewDidScroll` function, "toolbar hidden" is toggled repeatedly when the scroll view in the
         // middle of scrolling animation. This debouncer is introduced to avoid toggling
         // `navigationController.toolbarHidden`, which causes inifity loops.
         // Sentry issue: https://a8c.sentry.io/issues/6884521550
-        toolbarHiddenDebounceCancellable = toolbarHiddenDebouncer
+        toolbarHiddenDebounceCancellable =
+            toolbarHiddenDebouncer
             .removeDuplicates()
             .debounce(for: .milliseconds(100), scheduler: DispatchQueue.main)
             .sink { [weak self] isHidden in
@@ -257,15 +263,17 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
         checkTranslationAvailability()
 
         if let postURLString = post.permaLink,
-           let postURL = URL(string: postURLString) {
+            let postURL = URL(string: postURLString)
+        {
             webView.postURL = postURL
         }
 
         webView.isP2 = post.isP2Type
 
-        coordinator?.storeAuthenticationCookies(in: webView) { [weak self] in
-            self?.showPostContent(post)
-        }
+        coordinator?
+            .storeAuthenticationCookies(in: webView) { [weak self] in
+                self?.showPostContent(post)
+            }
 
         navigateToCommentIfNecessary()
     }
@@ -302,17 +310,22 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
 
     private func navigateToCommentIfNecessary() {
         if let post,
-           let commentID = coordinator?.commentID,
-           !hasAutomaticallyTriggeredCommentAction {
+            let commentID = coordinator?.commentID,
+            !hasAutomaticallyTriggeredCommentAction
+        {
             hasAutomaticallyTriggeredCommentAction = true
 
-            ReaderCommentAction().execute(
-                post: post,
-                origin: self,
-                navigateToCommentID: commentID,
-                source: .postDetails,
-                trackingSource: ScreenTrackingSource(ScreenID.Reader.article, component: ElementID.Reader.commentsSection)
-            )
+            ReaderCommentAction()
+                .execute(
+                    post: post,
+                    origin: self,
+                    navigateToCommentID: commentID,
+                    source: .postDetails,
+                    trackingSource: ScreenTrackingSource(
+                        ScreenID.Reader.article,
+                        component: ElementID.Reader.commentsSection
+                    )
+                )
         }
     }
 
@@ -334,7 +347,7 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
             } else {
                 NSLayoutConstraint.activate([
                     activityIndicator.centerXAnchor.constraint(equalTo: webView.centerXAnchor),
-                    activityIndicator.topAnchor.constraint(equalTo: webView.topAnchor, constant: 64),
+                    activityIndicator.topAnchor.constraint(equalTo: webView.topAnchor, constant: 64)
                 ])
             }
             activityIndicator.startAnimating()
@@ -390,14 +403,17 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
     /// Scroll the content to a given #hash
     ///
     func scroll(to hash: String) {
-        webView.evaluateJavaScript("document.getElementById('\(hash)').offsetTop", completionHandler: { [weak self] height, _ in
-            guard let self, let height = height as? CGFloat else {
-                return
-            }
+        webView.evaluateJavaScript(
+            "document.getElementById('\(hash)').offsetTop",
+            completionHandler: { [weak self] height, _ in
+                guard let self, let height = height as? CGFloat else {
+                    return
+                }
 
-            let y = height + self.webView.frame.origin.y - self.scrollView.adjustedContentInset.top
-            self.scrollView.setContentOffset(CGPoint(x: 0, y: y), animated: true)
-        })
+                let y = height + self.webView.frame.origin.y - self.scrollView.adjustedContentInset.top
+                self.scrollView.setContentOffset(CGPoint(x: 0, y: y), animated: true)
+            }
+        )
     }
 
     func updateHeader() {
@@ -425,7 +441,7 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
 
         // Moderated comments could still be cached, so filter out non-approved comments.
         let approvedStatus = Comment.descriptionFor(.approved)
-        let approvedComments = comments.filter({ $0.status == approvedStatus})
+        let approvedComments = comments.filter({ $0.status == approvedStatus })
 
         // Set the delegate here so the table isn't shown until fetching is complete.
         commentsTableView.delegate = commentsTableViewDelegate
@@ -524,7 +540,8 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
     private func observeWebViewHeight() {
         scrollObserver = webView.scrollView.observe(\.contentSize, options: .new) { [weak self] _, change in
             guard let self,
-                  let height = change.newValue?.height else {
+                let height = change.newValue?.height
+            else {
                 return
             }
 
@@ -532,19 +549,22 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
             /// (except for a few times when it returns a very big weird number)
             /// We use that value so the content is not displayed with weird empty space at the bottom
             ///
-            self.webView.evaluateJavaScript("document.body.scrollHeight", completionHandler: { [weak self] webViewHeight, _ in
-                guard let self else { return }
-                guard let webViewHeight = webViewHeight as? CGFloat else {
-                    self.webViewHeight.constant = height
-                    return
-                }
+            self.webView.evaluateJavaScript(
+                "document.body.scrollHeight",
+                completionHandler: { [weak self] webViewHeight, _ in
+                    guard let self else { return }
+                    guard let webViewHeight = webViewHeight as? CGFloat else {
+                        self.webViewHeight.constant = height
+                        return
+                    }
 
-                /// The display setting's custom size is applied through the HTML's initial-scale property
-                /// in the meta tag. The `scrollHeight` value seems to return the height as if it's at 1.0 scale,
-                /// so we'll need to add the custom scale into account.
-                let scaledWebViewHeight = round(webViewHeight * self.displaySetting.size.scale)
-                self.webViewHeight.constant = min(scaledWebViewHeight, height)
-            })
+                    /// The display setting's custom size is applied through the HTML's initial-scale property
+                    /// in the meta tag. The `scrollHeight` value seems to return the height as if it's at 1.0 scale,
+                    /// so we'll need to add the custom scale into account.
+                    let scaledWebViewHeight = round(webViewHeight * self.displaySetting.size.scale)
+                    self.webViewHeight.constant = min(scaledWebViewHeight, height)
+                }
+            )
         }
     }
 
@@ -597,12 +617,18 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
     private func configureCommentsTable() {
         commentsTableView.separatorStyle = .none
         commentsTableView.backgroundColor = .clear
-        commentsTableView.register(ReaderDetailCommentsHeader.defaultNib,
-                                   forHeaderFooterViewReuseIdentifier: ReaderDetailCommentsHeader.defaultReuseID)
-        commentsTableView.register(CommentContentTableViewCell.defaultNib,
-                                   forCellReuseIdentifier: CommentContentTableViewCell.defaultReuseID)
-        commentsTableView.register(ReaderDetailNoCommentCell.defaultNib,
-                                   forCellReuseIdentifier: ReaderDetailNoCommentCell.defaultReuseID)
+        commentsTableView.register(
+            ReaderDetailCommentsHeader.defaultNib,
+            forHeaderFooterViewReuseIdentifier: ReaderDetailCommentsHeader.defaultReuseID
+        )
+        commentsTableView.register(
+            CommentContentTableViewCell.defaultNib,
+            forCellReuseIdentifier: CommentContentTableViewCell.defaultReuseID
+        )
+        commentsTableView.register(
+            ReaderDetailNoCommentCell.defaultNib,
+            forCellReuseIdentifier: ReaderDetailNoCommentCell.defaultReuseID
+        )
     }
 
     // Translation framework doesn't support UIKit, so we have to jump through the hoops.
@@ -700,10 +726,14 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
         relatedPostsTableView.separatorStyle = .none
         relatedPostsTableView.backgroundColor = .clear
 
-        relatedPostsTableView.register(ReaderRelatedPostsCell.defaultNib,
-                           forCellReuseIdentifier: ReaderRelatedPostsCell.defaultReuseID)
-        relatedPostsTableView.register(ReaderRelatedPostsSectionHeaderView.defaultNib,
-                           forHeaderFooterViewReuseIdentifier: ReaderRelatedPostsSectionHeaderView.defaultReuseID)
+        relatedPostsTableView.register(
+            ReaderRelatedPostsCell.defaultNib,
+            forCellReuseIdentifier: ReaderRelatedPostsCell.defaultReuseID
+        )
+        relatedPostsTableView.register(
+            ReaderRelatedPostsSectionHeaderView.defaultNib,
+            forHeaderFooterViewReuseIdentifier: ReaderRelatedPostsSectionHeaderView.defaultReuseID
+        )
 
         relatedPostsTableView.dataSource = self
         relatedPostsTableView.delegate = self
@@ -740,15 +770,19 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
     }
 
     private func configureNotifications() {
-        NotificationCenter.default.addObserver(self,
-                                               selector: #selector(siteBlocked(_:)),
-                                               name: .ReaderSiteBlocked,
-                                               object: nil)
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(siteBlocked(_:)),
+            name: .ReaderSiteBlocked,
+            object: nil
+        )
 
-        NotificationCenter.default.addObserver(self,
-                                               selector: #selector(userBlocked(_:)),
-                                               name: .ReaderUserBlockingDidEnd,
-                                               object: nil)
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(userBlocked(_:)),
+            name: .ReaderUserBlockingDidEnd,
+            object: nil
+        )
     }
 
     @objc private func userBlocked(_ notification: Foundation.Notification) {
@@ -775,11 +809,14 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
     }
 
     @objc func didTapDisplaySettingButton() {
-        let viewController = ReaderDisplaySettingViewController(initialSetting: displaySetting,
-                                                                source: .readerPostNavBar) { [weak self] newSetting in
+        let viewController = ReaderDisplaySettingViewController(
+            initialSetting: displaySetting,
+            source: .readerPostNavBar
+        ) { [weak self] newSetting in
             // no need to refresh if there are no changes to the display setting.
             guard let self,
-                  newSetting != self.displaySetting else {
+                newSetting != self.displaySetting
+            else {
                 return
             }
 
@@ -803,7 +840,11 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
     /// - Parameter siteID: a site identification
     /// - Parameter isFeed: a Boolean indicating if the site is an external feed (not hosted at WPcom and not using Jetpack)
     /// - Returns: A `ReaderDetailViewController` instance
-    @objc class func controllerWithPostID(_ postID: NSNumber, siteID: NSNumber, isFeed: Bool = false) -> ReaderDetailViewController {
+    @objc class func controllerWithPostID(
+        _ postID: NSNumber,
+        siteID: NSNumber,
+        isFeed: Bool = false
+    ) -> ReaderDetailViewController {
         let controller = ReaderDetailViewController.loadFromStoryboard()
         let coordinator = ReaderDetailCoordinator(view: controller)
         coordinator.set(postID: postID, siteID: siteID, isFeed: isFeed)
@@ -858,9 +899,10 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
     /// - Returns: A `ReaderDetailViewController` instance
     @objc class func controllerWithPost(_ post: ReaderPost) -> ReaderDetailViewController {
         if post.sourceAttributionStyle() == .post,
-           let sourceAttribution = post.sourceAttribution,
-           let postID = sourceAttribution.postID,
-           let blogID = sourceAttribution.blogID {
+            let sourceAttribution = post.sourceAttribution,
+            let postID = sourceAttribution.postID,
+            let blogID = sourceAttribution.blogID
+        {
             return ReaderDetailViewController.controllerWithPostID(postID, siteID: blogID)
         } else if post.isCrossPost, let crossPostMeta = post.crossPostMeta {
             return ReaderDetailViewController.controllerWithPostID(crossPostMeta.postID, siteID: crossPostMeta.siteID)
@@ -883,10 +925,12 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
         guard let post else {
             return
         }
-        NotificationCenter.default.addObserver(self,
-                                               selector: #selector(handleObjectsChange(_:)),
-                                               name: NSNotification.Name.NSManagedObjectContextObjectsDidChange,
-                                               object: post.managedObjectContext)
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleObjectsChange(_:)),
+            name: NSNotification.Name.NSManagedObjectContextObjectsDidChange,
+            object: post.managedObjectContext
+        )
     }
 
     @objc func handleObjectsChange(_ notification: Foundation.Notification) {
@@ -943,7 +987,7 @@ extension ReaderDetailViewController: UIScrollViewDelegate {
 
 extension ReaderDetailViewController: StoryboardLoadable {
     static var defaultStoryboardName: String {
-        return "ReaderDetailViewController"
+        "ReaderDetailViewController"
     }
 }
 
@@ -952,15 +996,20 @@ extension ReaderDetailViewController: StoryboardLoadable {
 extension ReaderDetailViewController: UITableViewDataSource, UITableViewDelegate {
 
     func numberOfSections(in tableView: UITableView) -> Int {
-        return relatedPosts.count
+        relatedPosts.count
     }
 
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return relatedPosts[section].posts.count
+        relatedPosts[section].posts.count
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        guard let cell = tableView.dequeueReusableCell(withIdentifier: ReaderRelatedPostsCell.defaultReuseID, for: indexPath) as? ReaderRelatedPostsCell else {
+        guard
+            let cell = tableView.dequeueReusableCell(
+                withIdentifier: ReaderRelatedPostsCell.defaultReuseID,
+                for: indexPath
+            ) as? ReaderRelatedPostsCell
+        else {
             fatalError("Expected RelatedPostsTableViewCell with identifier: \(ReaderRelatedPostsCell.defaultReuseID)")
         }
 
@@ -982,12 +1031,15 @@ extension ReaderDetailViewController: UITableViewDataSource, UITableViewDelegate
     }
 
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-        return UITableView.automaticDimension
+        UITableView.automaticDimension
     }
 
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
         guard let title = getSectionTitle(for: relatedPosts[section].postType),
-              let header = tableView.dequeueReusableHeaderFooterView(withIdentifier: ReaderRelatedPostsSectionHeaderView.defaultReuseID) as? ReaderRelatedPostsSectionHeaderView else {
+            let header = tableView.dequeueReusableHeaderFooterView(
+                withIdentifier: ReaderRelatedPostsSectionHeaderView.defaultReuseID
+            ) as? ReaderRelatedPostsSectionHeaderView
+        else {
             return UIView(frame: .zero)
         }
 
@@ -1005,7 +1057,7 @@ extension ReaderDetailViewController: UITableViewDataSource, UITableViewDelegate
     }
 
     func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-        return ReaderRelatedPostsSectionHeaderView.height
+        ReaderRelatedPostsSectionHeaderView.height
     }
 
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
@@ -1016,7 +1068,11 @@ extension ReaderDetailViewController: UITableViewDataSource, UITableViewDelegate
         guard let controller = ReaderDetailViewController.controllerWithSimplePost(post) else {
             return
         }
-        controller.trackingContext.source = ScreenTrackingSource(ScreenID.Reader.article, component: ElementID.Reader.relatedPosts, position: indexPath.row)
+        controller.trackingContext.source = ScreenTrackingSource(
+            ScreenID.Reader.article,
+            component: ElementID.Reader.relatedPosts,
+            position: indexPath.row
+        )
         navigationController?.pushViewController(controller, animated: true)
     }
 
@@ -1045,8 +1101,11 @@ extension ReaderDetailViewController: ReaderDisplaySettingStoreDelegate {
 
 // MARK: - UIGestureRecognizerDelegate
 extension ReaderDetailViewController: UIGestureRecognizerDelegate {
-    func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldBeRequiredToFailBy otherGestureRecognizer: UIGestureRecognizer) -> Bool {
-        return true
+    func gestureRecognizer(
+        _ gestureRecognizer: UIGestureRecognizer,
+        shouldBeRequiredToFailBy otherGestureRecognizer: UIGestureRecognizer
+    ) -> Bool {
+        true
     }
 }
 
@@ -1061,7 +1120,11 @@ extension ReaderDetailViewController: ReaderCardDiscoverAttributionViewDelegate 
 // MARK: - Transitioning Delegate
 
 extension ReaderDetailViewController: UIViewControllerTransitioningDelegate {
-    public func presentationController(forPresented presented: UIViewController, presenting: UIViewController?, source: UIViewController) -> UIPresentationController? {
+    public func presentationController(
+        forPresented presented: UIViewController,
+        presenting: UIViewController?,
+        source: UIViewController
+    ) -> UIPresentationController? {
         guard presented is FancyAlertViewController else {
             return nil
         }
@@ -1081,7 +1144,11 @@ extension ReaderDetailViewController: WKNavigationDelegate {
         hideLoading()
     }
 
-    func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
+    func webView(
+        _ webView: WKWebView,
+        decidePolicyFor navigationAction: WKNavigationAction,
+        decisionHandler: @escaping (WKNavigationActionPolicy) -> Void
+    ) {
         if navigationAction.navigationType == .linkActivated {
             if let url = navigationAction.request.url {
                 coordinator?.handle(url)
@@ -1126,8 +1193,14 @@ private extension ReaderDetailViewController {
     }
 
     struct LoadingText {
-        static let errorLoadingTitle = NSLocalizedString("Error Loading Post", comment: "Text displayed when load post fails.")
-        static let errorLoadingPostURLButtonTitle = NSLocalizedString("Open in browser", comment: "Button title to load a post in an in-app web view")
+        static let errorLoadingTitle = NSLocalizedString(
+            "Error Loading Post",
+            comment: "Text displayed when load post fails."
+        )
+        static let errorLoadingPostURLButtonTitle = NSLocalizedString(
+            "Open in browser",
+            comment: "Button title to load a post in an in-app web view"
+        )
     }
 }
 
@@ -1146,14 +1219,16 @@ private extension ReaderDetailViewController {
 
     func showTranslationSpinner() {
         guard var items = navigationItem.rightBarButtonItems,
-              !items.contains(translationSpinner) else { return }
+            !items.contains(translationSpinner)
+        else { return }
         items.append(translationSpinner)
         navigationItem.setRightBarButtonItems(items, animated: true)
     }
 
     func hideTranslationSpinner() {
         guard var items = navigationItem.rightBarButtonItems,
-              let index = items.firstIndex(of: translationSpinner) else { return }
+            let index = items.firstIndex(of: translationSpinner)
+        else { return }
         items.remove(at: index)
         navigationItem.setRightBarButtonItems(items, animated: true)
     }
@@ -1197,14 +1272,17 @@ private extension ReaderDetailViewController {
 
     func moreButtonItem(enabled: Bool = true) -> UIBarButtonItem? {
         let button = UIBarButtonItem(image: UIImage(systemName: "ellipsis"), menu: nil)
-        button.menu = UIMenu(options: .displayInline, children: [
-            UIDeferredMenuElement.uncached { [weak self, weak button] callback in
-                guard let self, let button else {
-                    return callback([])
+        button.menu = UIMenu(
+            options: .displayInline,
+            children: [
+                UIDeferredMenuElement.uncached { [weak self, weak button] callback in
+                    guard let self, let button else {
+                        return callback([])
+                    }
+                    callback(self.makeMoreMenu(button))
                 }
-                callback(self.makeMoreMenu(button))
-            }
-        ])
+            ]
+        )
         button.accessibilityLabel = Strings.moreButtonAccessibilityLabel
         button.isEnabled = enabled
         return button
@@ -1219,19 +1297,26 @@ private extension ReaderDetailViewController {
             topic: nil,
             anchor: anchor,
             viewController: self
-        ).makeMenu()
+        )
+        .makeMenu()
 
         if ReaderDisplaySettings.customizationEnabled {
-            elements.append(UIAction(title: Strings.displaySettingsLabel, image: UIImage(systemName: "textformat.size")) { [weak self] _ in
-                self?.didTapDisplaySettingButton()
-            })
+            elements.append(
+                UIAction(title: Strings.displaySettingsLabel, image: UIImage(systemName: "textformat.size")) {
+                    [weak self] _ in
+                    self?.didTapDisplaySettingButton()
+                }
+            )
         }
 
         return elements
     }
 
     func shareButtonItem(enabled: Bool = true) -> UIBarButtonItem? {
-        let button = barButtonItem(with: UIImage(named: "wpl-share") ?? UIImage(), action: #selector(didTapShareButton(_:)))
+        let button = barButtonItem(
+            with: UIImage(named: "wpl-share") ?? UIImage(),
+            action: #selector(didTapShareButton(_:))
+        )
         button.accessibilityLabel = SharedStrings.Button.share
         button.isEnabled = enabled
 
@@ -1268,7 +1353,8 @@ extension ReaderDetailViewController {
         static let displaySettingsLabel = NSLocalizedString(
             "readerDetail.displaySettingButton.displaySettingsLabel",
             value: "Reading Preferences",
-            comment: "Spoken accessibility label for the Reading Preferences menu.")
+            comment: "Spoken accessibility label for the Reading Preferences menu."
+        )
         static let safariButtonAccessibilityLabel = NSLocalizedString(
             "readerDetail.safariButton.accessibilityLabel",
             value: "Open in Safari",
@@ -1301,12 +1387,16 @@ extension ReaderDetailViewController: BorderedButtonTableViewCellDelegate {
             return
         }
 
-        ReaderCommentAction().execute(
-            post: post,
-            origin: self,
-            source: .postDetailsComments,
-            trackingSource: ScreenTrackingSource(ScreenID.Reader.article, component: ElementID.Reader.commentsSection)
-        )
+        ReaderCommentAction()
+            .execute(
+                post: post,
+                origin: self,
+                source: .postDetailsComments,
+                trackingSource: ScreenTrackingSource(
+                    ScreenID.Reader.article,
+                    component: ElementID.Reader.commentsSection
+                )
+            )
     }
 
     func buttonLeaveCommentTapped(replyingTo comment: Comment?) {

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -253,6 +253,10 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
     }
 
     func render(_ post: ReaderPost) {
+        Task { @MainActor [weak coordinator] in
+            await coordinator?.resolveMentionProfiles(for: post)
+        }
+
         configureDiscoverAttribution(post)
 
         toolbar.configure(for: post, in: self)

--- a/WordPress/Classes/ViewRelated/Reader/User/ReaderUserProfileService.swift
+++ b/WordPress/Classes/ViewRelated/Reader/User/ReaderUserProfileService.swift
@@ -1,0 +1,77 @@
+import Foundation
+import WordPressData
+import WordPressKit
+
+struct ReaderUserProfile: Equatable {
+    let username: String
+    let displayName: String
+    let avatarURL: URL?
+    let siteURL: URL?
+}
+
+protocol ReaderUserProfileService {
+    func fetchProfile(handle: String) async -> ReaderUserProfile?
+}
+
+final class WordPressComReaderUserProfileService: ReaderUserProfileService {
+    private let wordPressComRestApi: WordPressComRestApi?
+
+    init(coreDataStack: CoreDataStack) {
+        self.wordPressComRestApi = coreDataStack.performQuery { context in
+            try? WPAccount.defaultWordPressComAccountRestAPI(in: context)
+        }
+    }
+
+    init(wordPressComRestApi: WordPressComRestApi?) {
+        self.wordPressComRestApi = wordPressComRestApi
+    }
+
+    func fetchProfile(handle: String) async -> ReaderUserProfile? {
+        guard let wordPressComRestApi,
+            let encodedHandle = handle.addingPercentEncoding(withAllowedCharacters: Self.handleAllowedCharacters)
+        else {
+            return nil
+        }
+
+        let result = await wordPressComRestApi.perform(
+            .get,
+            URLString: "rest/v1.1/users/\(encodedHandle)",
+            parameters: ["meta": "site"]
+        )
+        guard case .success(let response) = result else {
+            return nil
+        }
+        return Self.mapProfile(from: response.body, requestedHandle: handle)
+    }
+
+    private static let handleAllowedCharacters = CharacterSet.alphanumerics.union(
+        CharacterSet(charactersIn: "-._~")
+    )
+
+    private static func mapProfile(from response: AnyObject, requestedHandle: String) -> ReaderUserProfile? {
+        guard let response = response as? [String: Any],
+            let username = response["user_login"] as? String,
+            username.caseInsensitiveCompare(requestedHandle) == .orderedSame
+        else {
+            return nil
+        }
+
+        let displayName = (response["display_name"] as? String)?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let avatarURL = (response["avatar_URL"] as? String).flatMap(URL.init(string:))
+        let siteURL = (response["primary_blog"] as? [String: Any])?["URL"] as? String
+
+        return ReaderUserProfile(
+            username: username,
+            displayName: displayName?.nilIfEmpty ?? username,
+            avatarURL: avatarURL,
+            siteURL: siteURL.flatMap(URL.init(string:))
+        )
+    }
+}
+
+private extension String {
+    var nilIfEmpty: String? {
+        isEmpty ? nil : self
+    }
+}

--- a/WordPress/Classes/ViewRelated/Reader/User/ReaderUserProfileView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/User/ReaderUserProfileView.swift
@@ -32,7 +32,11 @@ struct ReaderUserProfileView: View {
 
     private var header: some View {
         VStack(spacing: 12) {
-            AvatarView(style: .single(viewModel.avatarURL), diameter: 72, placeholderImage: Image("gravatar").resizable())
+            AvatarView(
+                style: .single(viewModel.avatarURL),
+                diameter: 72,
+                placeholderImage: Image("gravatar").resizable()
+            )
 
             VStack(alignment: .leading, spacing: 3) {
                 HStack(alignment: .firstTextBaseline, spacing: 8) {

--- a/WordPress/Classes/ViewRelated/Reader/User/ReaderUserProfileView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/User/ReaderUserProfileView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import UIKit
 import WordPressData
 import WordPressUI
 
@@ -65,6 +66,27 @@ struct ReaderUserProfileViewModel {
         self.avatarURL = post.avatarURLForDisplay()
         self.name = post.authorForDisplay() ?? ""
         self.siteURL = post.blogURL.flatMap(URL.init(string:))
+    }
+
+    init(profile: ReaderUserProfile) {
+        self.avatarURL = profile.avatarURL
+        self.name = profile.displayName
+        self.siteURL = profile.siteURL
+    }
+}
+
+enum ReaderUserProfilePresenter {
+    static func present(_ viewModel: ReaderUserProfileViewModel, from presentingViewController: UIViewController) {
+        let profileViewController = UIHostingController(rootView: ReaderUserProfileView(viewModel: viewModel))
+        let navigationController = UINavigationController(rootViewController: profileViewController)
+        profileViewController.navigationItem.leftBarButtonItem = UIBarButtonItem(
+            systemItem: .close,
+            primaryAction: .init { [weak profileViewController] _ in
+                profileViewController?.presentingViewController?.dismiss(animated: true)
+            }
+        )
+        navigationController.sheetPresentationController?.detents = [.medium()]
+        presentingViewController.present(navigationController, animated: true)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Reader/User/ReaderUserProfileView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/User/ReaderUserProfileView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import UIKit
 import WordPressData
 import WordPressUI
 
@@ -59,6 +60,27 @@ struct ReaderUserProfileViewModel {
         self.avatarURL = comment.avatarURLForDisplay()
         self.name = comment.author
         self.siteURL = URL(string: comment.author_url)
+    }
+
+    init(profile: ReaderUserProfile) {
+        self.avatarURL = profile.avatarURL
+        self.name = profile.displayName
+        self.siteURL = profile.siteURL
+    }
+}
+
+enum ReaderUserProfilePresenter {
+    static func present(_ viewModel: ReaderUserProfileViewModel, from presentingViewController: UIViewController) {
+        let profileViewController = UIHostingController(rootView: ReaderUserProfileView(viewModel: viewModel))
+        let navigationController = UINavigationController(rootViewController: profileViewController)
+        profileViewController.navigationItem.leftBarButtonItem = UIBarButtonItem(
+            systemItem: .close,
+            primaryAction: .init { [weak profileViewController] _ in
+                profileViewController?.presentingViewController?.dismiss(animated: true)
+            }
+        )
+        navigationController.sheetPresentationController?.detents = [.medium()]
+        presentingViewController.present(navigationController, animated: true)
     }
 }
 


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/CMM-2158.

Tapping at-mentions now shows the `RreaderUserProfileView` sheet, which is the same as tapping comment author avatars.

For the sake of keeping the implementation simple, the solution is resolving the `<a>@username</a>` links to a user profile object when viewing the post. The expectations are 1) there will not be many mentions in regular posts and 2) it'd be pretty quick to resolve them, at least they should be resolved before user reading the post and tapping a mention link.