### PR TITLE
Sign a Simulator into WordPress.com from a launch-argument token

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,7 @@ WordPress-iOS uses a modular architecture with the main app and separate Swift p
 - The WordPress scheme uses `WordPressUnitTests.xctestplan` for the full unit test suite, including tests in the `Modules` Swift package.
 - Add every unit test target to `WordPressUnitTests.xctestplan`.
 - Run the full suite with `xcodebuild -workspace WordPress.xcworkspace -scheme WordPress -testPlan WordPressUnitTests test`. Do not use `swift test`.
-- To verify changes end-to-end on an iOS simulator, follow @docs/simulator-sign-in.md to sign in to the app.
+- To sign a Simulator into WordPress.com end-to-end, run `make sim-login` (it targets the running simulator; the WordPress.com token comes from `~/.wpcom-token` or `WPCOM_TOKEN`, and it prompts if none is set). See @docs/simulator-sign-in.md for options and self-hosted sign-in.
 
 ### Important Considerations
 - **Multi-site Support**: Code must handle both WordPress.com and self-hosted sites

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,7 @@ WordPress-iOS uses a modular architecture with the main app and separate Swift p
 - The WordPress scheme uses `WordPressUnitTests.xctestplan` for the full unit test suite, including tests in the `Modules` Swift package.
 - Add every unit test target to `WordPressUnitTests.xctestplan`.
 - Run the full suite with `xcodebuild -workspace WordPress.xcworkspace -scheme WordPress -testPlan WordPressUnitTests test`. Do not use `swift test`.
-- To sign a Simulator into WordPress.com end-to-end, run `make sim-login` (it targets the running simulator; the WordPress.com token comes from `~/.wpcom-token` or `WPCOM_TOKEN`, and it prompts if none is set). See @docs/simulator-sign-in.md for options and self-hosted sign-in.
+- To sign a Simulator into WordPress.com, run `make sim-login` (it targets the running simulator; the WordPress.com token comes from `~/.wpcom-token` or `WPCOM_TOKEN`, and it prompts if none is set). See @docs/simulator-sign-in.md for options and self-hosted sign-in.
 
 ### Important Considerations
 - **Multi-site Support**: Code must handle both WordPress.com and self-hosted sites

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,10 @@
-.PHONY: help dependencies
+.PHONY: help dependencies sim-login
 
 help: ## Show available targets
 	@grep -E '^[a-zA-Z_-]+:.*##' $(MAKEFILE_LIST) | awk -F ':.*## ' '{printf "  %-20s %s\n", $$1, $$2}'
 
 dependencies: ## Download and cache Gutenberg XCFrameworks
 	./Scripts/download-gutenberg-xcframeworks.sh
+
+sim-login: ## Sign an iOS Simulator into WordPress.com (vars: DEVICE, APP, RESET=1; token from ~/.wpcom-token)
+	./Scripts/sim-signin.sh $(if $(APP),--app $(APP)) $(if $(DEVICE),--device $(DEVICE)) $(if $(RESET),--reset) $(ARGS)

--- a/Scripts/sim-signin.sh
+++ b/Scripts/sim-signin.sh
@@ -27,6 +27,11 @@ Examples:
   Scripts/sim-signin.sh --wpcom-token <token>                 # Jetpack, booted simulator
   Scripts/sim-signin.sh --app wordpress --wpcom-token <token> # WordPress
   Scripts/sim-signin.sh --reset --wpcom-token <token>         # wipe existing state first
+
+Set the token once and omit it from the command line. Resolution order:
+  1. --wpcom-token (or positional)
+  2. WPCOM_TOKEN environment variable
+  3. ~/.wpcom-token file
 EOF
 }
 
@@ -63,8 +68,17 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
+# Fall back to a token set once elsewhere, so it needn't be passed every launch:
+# the WPCOM_TOKEN environment variable, then a ~/.wpcom-token file.
 if [[ -z "$token" ]]; then
-    echo "error: missing <bearer-token>" >&2
+    token="${WPCOM_TOKEN:-}"
+fi
+if [[ -z "$token" && -f "$HOME/.wpcom-token" ]]; then
+    token="$(tr -d '[:space:]' < "$HOME/.wpcom-token")"
+fi
+
+if [[ -z "$token" ]]; then
+    echo "error: no token — pass --wpcom-token <token>, set WPCOM_TOKEN, or write ~/.wpcom-token" >&2
     usage >&2
     exit 1
 fi

--- a/Scripts/sim-signin.sh
+++ b/Scripts/sim-signin.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+#
+# Sign an iOS Simulator into WordPress.com with a bearer token, in one command.
+#
+# Wraps `xcrun simctl launch`, passing the `-ui-test-wpcom-token` launch argument the app
+# reads on the login screen to finish WordPress.com sign-in automatically — no taps required.
+# Build and install the app on the simulator first (e.g. from Xcode).
+
+set -euo pipefail
+
+usage() {
+    cat <<'EOF'
+Sign an iOS Simulator into WordPress.com with a bearer token, in one command.
+
+Usage:
+  Scripts/sim-signin.sh [options] <bearer-token>
+
+Options:
+  -a, --app <jetpack|wordpress>  App to sign in (default: jetpack)
+  -d, --device <udid|booted>     Target simulator (default: booted)
+  -r, --reset                    Wipe existing app data before signing in
+  -h, --help                     Show this help
+
+Examples:
+  Scripts/sim-signin.sh <token>                    # Jetpack, booted simulator
+  Scripts/sim-signin.sh --app wordpress <token>    # WordPress
+  Scripts/sim-signin.sh --reset <token>            # wipe existing state first
+EOF
+}
+
+app="jetpack"
+device="booted"
+reset=false
+token=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -a|--app) app="${2:-}"; shift 2 ;;
+        -d|--device) device="${2:-}"; shift 2 ;;
+        -r|--reset) reset=true; shift ;;
+        -h|--help) usage; exit 0 ;;
+        -*) echo "error: unknown option '$1'" >&2; usage >&2; exit 1 ;;
+        *)
+            if [[ -n "$token" ]]; then
+                echo "error: unexpected argument '$1' (token already set)" >&2
+                exit 1
+            fi
+            token="$1"; shift ;;
+    esac
+done
+
+if [[ -z "$token" ]]; then
+    echo "error: missing <bearer-token>" >&2
+    usage >&2
+    exit 1
+fi
+
+case "$app" in
+    jetpack) bundle_id="com.automattic.jetpack" ;;
+    wordpress) bundle_id="org.wordpress" ;;
+    *) echo "error: unknown app '$app' (expected 'jetpack' or 'wordpress')" >&2; exit 1 ;;
+esac
+
+echo "Signing $app ($bundle_id) into WordPress.com on simulator '$device'…"
+
+if [[ "$reset" == true ]]; then
+    echo "Resetting app data…"
+    xcrun simctl launch --terminate-running-process "$device" "$bundle_id" -ui-test-reset-everything
+    # Give the app a moment to wipe Core Data + UserDefaults before relaunching.
+    sleep 2
+fi
+
+xcrun simctl launch --terminate-running-process "$device" "$bundle_id" -ui-test-wpcom-token "$token"
+
+echo "Done. The app signs in automatically from the login screen."

--- a/Scripts/sim-signin.sh
+++ b/Scripts/sim-signin.sh
@@ -13,18 +13,20 @@ usage() {
 Sign an iOS Simulator into WordPress.com with a bearer token, in one command.
 
 Usage:
-  Scripts/sim-signin.sh [options] <bearer-token>
+  Scripts/sim-signin.sh [options] --wpcom-token <token>
+  Scripts/sim-signin.sh [options] <token>
 
 Options:
+  -t, --wpcom-token <token>      WordPress.com bearer token (or pass it positionally)
   -a, --app <jetpack|wordpress>  App to sign in (default: jetpack)
   -d, --device <udid|booted>     Target simulator (default: booted)
   -r, --reset                    Wipe existing app data before signing in
   -h, --help                     Show this help
 
 Examples:
-  Scripts/sim-signin.sh <token>                    # Jetpack, booted simulator
-  Scripts/sim-signin.sh --app wordpress <token>    # WordPress
-  Scripts/sim-signin.sh --reset <token>            # wipe existing state first
+  Scripts/sim-signin.sh --wpcom-token <token>                 # Jetpack, booted simulator
+  Scripts/sim-signin.sh --app wordpress --wpcom-token <token> # WordPress
+  Scripts/sim-signin.sh --reset --wpcom-token <token>         # wipe existing state first
 EOF
 }
 
@@ -33,19 +35,31 @@ device="booted"
 reset=false
 token=""
 
+set_token() {
+    if [[ -n "$token" ]]; then
+        echo "error: token already set (got '$1')" >&2
+        exit 1
+    fi
+    token="$1"
+}
+
+require_value() {
+    # $1 = option name, $2 = remaining argument count ($#)
+    if [[ "$2" -lt 2 ]]; then
+        echo "error: $1 requires a value" >&2
+        exit 1
+    fi
+}
+
 while [[ $# -gt 0 ]]; do
     case "$1" in
-        -a|--app) app="${2:-}"; shift 2 ;;
-        -d|--device) device="${2:-}"; shift 2 ;;
+        -t|--wpcom-token) require_value "$1" "$#"; set_token "$2"; shift 2 ;;
+        -a|--app) require_value "$1" "$#"; app="$2"; shift 2 ;;
+        -d|--device) require_value "$1" "$#"; device="$2"; shift 2 ;;
         -r|--reset) reset=true; shift ;;
         -h|--help) usage; exit 0 ;;
         -*) echo "error: unknown option '$1'" >&2; usage >&2; exit 1 ;;
-        *)
-            if [[ -n "$token" ]]; then
-                echo "error: unexpected argument '$1' (token already set)" >&2
-                exit 1
-            fi
-            token="$1"; shift ;;
+        *) set_token "$1"; shift ;;
     esac
 done
 

--- a/Scripts/sim-signin.sh
+++ b/Scripts/sim-signin.sh
@@ -130,7 +130,21 @@ if [[ -z "$token" ]]; then
     read -rs token || true
     printf "\n" >&2
     token="$(printf '%s' "$token" | tr -d '[:space:]')"
-    [[ -n "$token" ]] && printf "Token received (%s chars).\n" "${#token}" >&2
+    if [[ -n "$token" ]]; then
+        printf "Token received (%s chars).\n" "${#token}" >&2
+        printf "Save it to ~/.wpcom-token for next time? [y/N] " >&2
+        read -r save_reply || true
+        if [[ "$save_reply" =~ ^[Yy]$ ]]; then
+            token_file="$HOME/.wpcom-token"
+            # umask keeps the new file owner-only; chmod covers an existing, looser file.
+            if (umask 077; printf '%s\n' "$token" > "$token_file"); then
+                chmod 600 "$token_file" 2>/dev/null || true
+                printf "Saved to %s (mode 600).\n" "$token_file" >&2
+            else
+                printf "warning: could not write %s; continuing without saving.\n" "$token_file" >&2
+            fi
+        fi
+    fi
 fi
 
 if [[ -z "$token" ]]; then

--- a/Scripts/sim-signin.sh
+++ b/Scripts/sim-signin.sh
@@ -2,8 +2,8 @@
 #
 # Sign an iOS Simulator into WordPress.com with a bearer token, in one command.
 #
-# Wraps `xcrun simctl launch`, passing the `-ui-test-wpcom-token` launch argument the app
-# reads on the login screen to finish WordPress.com sign-in automatically — no taps required.
+# Wraps `xcrun simctl launch`, passing the `-wpcom-token` launch argument the app reads on
+# the login screen to finish WordPress.com sign-in automatically — no taps required.
 # Build and install the app on the simulator first (e.g. from Xcode).
 
 set -euo pipefail
@@ -84,6 +84,6 @@ if [[ "$reset" == true ]]; then
     sleep 2
 fi
 
-xcrun simctl launch --terminate-running-process "$device" "$bundle_id" -ui-test-wpcom-token "$token"
+xcrun simctl launch --terminate-running-process "$device" "$bundle_id" -wpcom-token "$token"
 
 echo "Done. The app signs in automatically from the login screen."

--- a/Scripts/sim-signin.sh
+++ b/Scripts/sim-signin.sh
@@ -32,6 +32,7 @@ Set the token once and omit it from the command line. Resolution order:
   1. --wpcom-token (or positional)
   2. WPCOM_TOKEN environment variable
   3. ~/.wpcom-token file
+  4. otherwise the script prompts you to paste one
 EOF
 }
 
@@ -122,8 +123,18 @@ if [[ -z "$token" && -f "$HOME/.wpcom-token" ]]; then
     token="$(tr -d '[:space:]' < "$HOME/.wpcom-token")"
 fi
 
+# Nothing found anywhere — prompt for one. Input is hidden, since it's a secret.
 if [[ -z "$token" ]]; then
-    echo "error: no token — pass --wpcom-token <token>, set WPCOM_TOKEN, or write ~/.wpcom-token" >&2
+    printf "No WordPress.com token found (--wpcom-token / WPCOM_TOKEN / ~/.wpcom-token).\n" >&2
+    printf "Paste a bearer token (hidden), or press Return to cancel: " >&2
+    read -rs token || true
+    printf "\n" >&2
+    token="$(printf '%s' "$token" | tr -d '[:space:]')"
+    [[ -n "$token" ]] && printf "Token received (%s chars).\n" "${#token}" >&2
+fi
+
+if [[ -z "$token" ]]; then
+    echo "error: no token — pass --wpcom-token <token>, set WPCOM_TOKEN, write ~/.wpcom-token, or paste one when prompted" >&2
     usage >&2
     exit 1
 fi

--- a/Scripts/sim-signin.sh
+++ b/Scripts/sim-signin.sh
@@ -19,7 +19,7 @@ Usage:
 Options:
   -t, --wpcom-token <token>      WordPress.com bearer token (or pass it positionally)
   -a, --app <jetpack|wordpress>  App to sign in (default: jetpack)
-  -d, --device <udid|booted>     Target simulator (default: booted)
+  -d, --device <udid|name>       Target simulator (default: the running one; prompts if several)
   -r, --reset                    Wipe existing app data before signing in
   -h, --help                     Show this help
 
@@ -36,7 +36,7 @@ EOF
 }
 
 app="jetpack"
-device="booted"
+device=""
 reset=false
 token=""
 
@@ -54,6 +54,51 @@ require_value() {
         echo "error: $1 requires a value" >&2
         exit 1
     fi
+}
+
+resolve_device() {
+    # Set `device` to a booted simulator: the only one if just one is booted, otherwise
+    # prompt to choose. Errors if none are booted. Called only when --device was omitted.
+    local udids=() names=() line udid name
+    while IFS= read -r line; do
+        udid=$(printf '%s\n' "$line" | grep -oiE '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}' | head -1)
+        [[ -z "$udid" ]] && continue
+        name=$(printf '%s\n' "$line" | sed -E 's/^[[:space:]]*//; s/[[:space:]]*\([0-9A-Fa-f-]{36}\).*$//')
+        udids+=("$udid")
+        names+=("$name")
+    done < <(xcrun simctl list devices booted | grep -F "(Booted)")
+
+    local n=${#udids[@]}
+    if [[ "$n" -eq 0 ]]; then
+        echo "error: no booted simulator. Boot one (open Simulator, or 'xcrun simctl boot <udid>'), or pass --device <udid>." >&2
+        exit 1
+    fi
+    if [[ "$n" -eq 1 ]]; then
+        device="${udids[0]}"
+        echo "Using the only booted simulator: ${names[0]} (${device})"
+        return
+    fi
+
+    echo "Multiple simulators are booted — choose one:" >&2
+    local i
+    for (( i = 0; i < n; i++ )); do
+        printf "  %2d) %s (%s)\n" "$(( i + 1 ))" "${names[i]}" "${udids[i]}" >&2
+    done
+    local sel
+    while true; do
+        printf "Select a simulator [1-%d]: " "$n" >&2
+        if ! read -r sel; then
+            echo >&2
+            echo "error: no selection made; re-run with --device <udid>." >&2
+            exit 1
+        fi
+        if [[ "$sel" =~ ^[0-9]+$ ]] && [[ "$sel" -ge 1 ]] && [[ "$sel" -le "$n" ]]; then
+            device="${udids[sel - 1]}"
+            echo "Using ${names[sel - 1]} (${device})"
+            return
+        fi
+        echo "  not a valid choice: '$sel'" >&2
+    done
 }
 
 while [[ $# -gt 0 ]]; do
@@ -88,6 +133,11 @@ case "$app" in
     wordpress) bundle_id="org.wordpress" ;;
     *) echo "error: unknown app '$app' (expected 'jetpack' or 'wordpress')" >&2; exit 1 ;;
 esac
+
+# When no --device was given, target the running simulator (prompting if several are booted).
+if [[ -z "$device" ]]; then
+    resolve_device
+fi
 
 echo "Signing $app ($bundle_id) into WordPress.com on simulator '$device'…"
 

--- a/Scripts/sim-signin.sh
+++ b/Scripts/sim-signin.sh
@@ -13,26 +13,26 @@ usage() {
 Sign an iOS Simulator into WordPress.com with a bearer token, in one command.
 
 Usage:
-  Scripts/sim-signin.sh [options] --wpcom-token <token>
-  Scripts/sim-signin.sh [options] <token>
+  Scripts/sim-signin.sh [options]
 
 Options:
-  -t, --wpcom-token <token>      WordPress.com bearer token (or pass it positionally)
   -a, --app <jetpack|wordpress>  App to sign in (default: jetpack)
   -d, --device <udid|name>       Target simulator (default: the running one; prompts if several)
-  -r, --reset                    Wipe existing app data before signing in
+  -r, --reset                    Uninstall and reinstall the app first, for a clean slate
   -h, --help                     Show this help
 
 Examples:
-  Scripts/sim-signin.sh --wpcom-token <token>                 # Jetpack, booted simulator
-  Scripts/sim-signin.sh --app wordpress --wpcom-token <token> # WordPress
-  Scripts/sim-signin.sh --reset --wpcom-token <token>         # wipe existing state first
+  Scripts/sim-signin.sh                  # Jetpack, booted simulator
+  Scripts/sim-signin.sh --app wordpress  # WordPress
+  Scripts/sim-signin.sh --reset          # reinstall for a clean slate first
 
-Set the token once and omit it from the command line. Resolution order:
-  1. --wpcom-token (or positional)
-  2. WPCOM_TOKEN environment variable
-  3. ~/.wpcom-token file
-  4. otherwise the script prompts you to paste one
+The WordPress.com bearer token is read from (in order):
+  1. WPCOM_TOKEN environment variable
+  2. ~/.wpcom-token file
+  3. otherwise the script prompts you to paste one (and offers to save it to ~/.wpcom-token)
+
+It is deliberately NOT accepted as a command-line flag: a token passed on the command line
+would be saved in your shell history. Set WPCOM_TOKEN or write ~/.wpcom-token once.
 EOF
 }
 
@@ -40,14 +40,6 @@ app="jetpack"
 device=""
 reset=false
 token=""
-
-set_token() {
-    if [[ -n "$token" ]]; then
-        echo "error: token already set (got '$1')" >&2
-        exit 1
-    fi
-    token="$1"
-}
 
 require_value() {
     # $1 = option name, $2 = remaining argument count ($#)
@@ -62,7 +54,9 @@ resolve_device() {
     # prompt to choose. Errors if none are booted. Called only when --device was omitted.
     local udids=() names=() line udid name
     while IFS= read -r line; do
-        udid=$(printf '%s\n' "$line" | grep -oiE '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}' | head -1)
+        # `|| true` so a UUID-less line (or a SIGPIPE from `head` under `pipefail`) doesn't
+        # trip `set -e` and abort the whole script before the `continue` below can skip it.
+        udid=$(printf '%s\n' "$line" | grep -oiE '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}' | head -1 || true)
         [[ -z "$udid" ]] && continue
         name=$(printf '%s\n' "$line" | sed -E 's/^[[:space:]]*//; s/[[:space:]]*\([0-9A-Fa-f-]{36}\).*$//')
         udids+=("$udid")
@@ -102,20 +96,42 @@ resolve_device() {
     done
 }
 
+reset_app() {
+    # A clean slate: uninstall the app (which removes its entire data container — Core Data,
+    # UserDefaults, caches, cookies) and reinstall the same bundle. Unlike the in-app
+    # `-ui-test-reset-everything` wipe, `simctl install` is synchronous, so there's no window to
+    # race before the sign-in launch, and it clears more than just Core Data + UserDefaults.
+    local app_bundle bundle_name
+    app_bundle=$(xcrun simctl get_app_container "$device" "$bundle_id" app 2>/dev/null || true)
+    if [[ -z "$app_bundle" || ! -d "$app_bundle" ]]; then
+        echo "error: can't reset — $app ($bundle_id) isn't installed on '$device'. Build and install it first (e.g. from Xcode)." >&2
+        exit 1
+    fi
+    bundle_name=$(basename "$app_bundle")
+
+    # Uninstall deletes the installed bundle in place, so stage a copy to reinstall from.
+    # `reset_staging` is intentionally global so the EXIT trap can clean it up at script exit.
+    reset_staging=$(mktemp -d)
+    trap 'rm -rf "$reset_staging"' EXIT
+    cp -R "$app_bundle" "$reset_staging/$bundle_name"
+
+    echo "Resetting $app (uninstall + reinstall for a clean slate)…"
+    xcrun simctl uninstall "$device" "$bundle_id"
+    xcrun simctl install "$device" "$reset_staging/$bundle_name"
+}
+
 while [[ $# -gt 0 ]]; do
     case "$1" in
-        -t|--wpcom-token) require_value "$1" "$#"; set_token "$2"; shift 2 ;;
         -a|--app) require_value "$1" "$#"; app="$2"; shift 2 ;;
         -d|--device) require_value "$1" "$#"; device="$2"; shift 2 ;;
         -r|--reset) reset=true; shift ;;
         -h|--help) usage; exit 0 ;;
-        -*) echo "error: unknown option '$1'" >&2; usage >&2; exit 1 ;;
-        *) set_token "$1"; shift ;;
+        *) echo "error: unknown argument '$1'" >&2; usage >&2; exit 1 ;;
     esac
 done
 
-# Fall back to a token set once elsewhere, so it needn't be passed every launch:
-# the WPCOM_TOKEN environment variable, then a ~/.wpcom-token file.
+# The token is read from the WPCOM_TOKEN environment variable, then a ~/.wpcom-token file.
+# It is intentionally not a command-line argument, to keep it out of shell history.
 if [[ -z "$token" ]]; then
     token="${WPCOM_TOKEN:-}"
 fi
@@ -125,7 +141,7 @@ fi
 
 # Nothing found anywhere — prompt for one. Input is hidden, since it's a secret.
 if [[ -z "$token" ]]; then
-    printf "No WordPress.com token found (--wpcom-token / WPCOM_TOKEN / ~/.wpcom-token).\n" >&2
+    printf "No WordPress.com token found (WPCOM_TOKEN / ~/.wpcom-token).\n" >&2
     printf "Paste a bearer token (hidden), or press Return to cancel: " >&2
     read -rs token || true
     printf "\n" >&2
@@ -148,7 +164,7 @@ if [[ -z "$token" ]]; then
 fi
 
 if [[ -z "$token" ]]; then
-    echo "error: no token — pass --wpcom-token <token>, set WPCOM_TOKEN, write ~/.wpcom-token, or paste one when prompted" >&2
+    echo "error: no token — set WPCOM_TOKEN, write ~/.wpcom-token, or paste one when prompted" >&2
     usage >&2
     exit 1
 fi
@@ -167,10 +183,7 @@ fi
 echo "Signing $app ($bundle_id) into WordPress.com on simulator '$device'…"
 
 if [[ "$reset" == true ]]; then
-    echo "Resetting app data…"
-    xcrun simctl launch --terminate-running-process "$device" "$bundle_id" -ui-test-reset-everything
-    # Give the app a moment to wipe Core Data + UserDefaults before relaunching.
-    sleep 2
+    reset_app
 fi
 
 xcrun simctl launch --terminate-running-process "$device" "$bundle_id" -wpcom-token "$token"

--- a/WordPress/Classes/Login/WordPressDotComAuthenticator.swift
+++ b/WordPress/Classes/Login/WordPressDotComAuthenticator.swift
@@ -57,6 +57,15 @@ struct WordPressDotComAuthenticator {
         rawValue: "WordPressDotComAuthenticatorCallbackURL"
     )
 
+    /// A WordPress.com bearer token supplied as a launch argument, used to sign a Simulator in
+    /// without the web flow. Reads `-wpcom-token`, falling back to the legacy
+    /// `-ui-test-wpcom-token` argument for backward compatibility.
+    static var launchArgumentToken: String? {
+        let defaults = UserDefaults.standard
+        return defaults.string(forKey: "wpcom-token")
+            ?? defaults.string(forKey: "ui-test-wpcom-token")
+    }
+
     static func redirectURI(for scheme: String) -> String {
         "\(scheme)://oauth2-callback"
     }
@@ -131,7 +140,7 @@ struct WordPressDotComAuthenticator {
 
         let token: String
         do {
-            if let tokenLaunchArgument = UserDefaults.standard.string(forKey: "ui-test-wpcom-token") {
+            if let tokenLaunchArgument = Self.launchArgumentToken {
                 token = tokenLaunchArgument
             } else {
                 token = try await authenticate(

--- a/WordPress/Classes/System/Root View/RootViewCoordinator.swift
+++ b/WordPress/Classes/System/Root View/RootViewCoordinator.swift
@@ -92,6 +92,7 @@ class RootViewCoordinator {
         self.rootViewPresenter = nil
 
         WordPressAppDelegate.shared?.autoSignInUITestSite()
+        WordPressAppDelegate.shared?.autoSignInUITestWPComAccountIfNeeded()
     }
 
     private func createPresenter(_ appType: AppUIType) -> RootViewPresenter {

--- a/WordPress/Classes/System/Root View/RootViewCoordinator.swift
+++ b/WordPress/Classes/System/Root View/RootViewCoordinator.swift
@@ -92,7 +92,7 @@ class RootViewCoordinator {
         self.rootViewPresenter = nil
 
         WordPressAppDelegate.shared?.autoSignInUITestSite()
-        WordPressAppDelegate.shared?.autoSignInUITestWPComAccountIfNeeded()
+        WordPressAppDelegate.shared?.autoSignInWPComAccountFromLaunchArgumentIfNeeded()
     }
 
     private func createPresenter(_ appType: AppUIType) -> RootViewPresenter {

--- a/WordPress/Classes/System/WordPressAppDelegate.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate.swift
@@ -903,12 +903,12 @@ extension WordPressAppDelegate {
     }
 
     /// Completes WordPress.com sign-in automatically when a bearer token is supplied via the
-    /// `-ui-test-wpcom-token` launch argument, so a Simulator can be signed in with a single
+    /// `-wpcom-token` launch argument, so a Simulator can be signed in with a single
     /// `simctl launch` and no taps on the login screen.
     ///
     /// No-op when the argument is absent or a WordPress.com account is already signed in.
     func autoSignInUITestWPComAccountIfNeeded() {
-        guard UserDefaults.standard.string(forKey: "ui-test-wpcom-token") != nil else {
+        guard WordPressDotComAuthenticator.launchArgumentToken != nil else {
             return
         }
         guard (try? WPAccount.lookupDefaultWordPressComAccount(in: ContextManager.shared.mainContext)) == nil else {

--- a/WordPress/Classes/System/WordPressAppDelegate.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate.swift
@@ -901,4 +901,29 @@ extension WordPressAppDelegate {
             }
         )
     }
+
+    /// Completes WordPress.com sign-in automatically when a bearer token is supplied via the
+    /// `-ui-test-wpcom-token` launch argument, so a Simulator can be signed in with a single
+    /// `simctl launch` and no taps on the login screen.
+    ///
+    /// No-op when the argument is absent or a WordPress.com account is already signed in.
+    func autoSignInUITestWPComAccountIfNeeded() {
+        guard UserDefaults.standard.string(forKey: "ui-test-wpcom-token") != nil else {
+            return
+        }
+        guard (try? WPAccount.lookupDefaultWordPressComAccount(in: ContextManager.shared.mainContext)) == nil else {
+            return
+        }
+        guard let presenter = window?.topmostPresentedViewController else {
+            return
+        }
+        Task { @MainActor in
+            guard await WordPressDotComAuthenticator().signIn(from: presenter, context: .default) != nil else {
+                return
+            }
+            // Creating the account isn't enough on its own — without this the app stays on the
+            // login screen. Swap the window root to the signed-in app (no epilogue, so no taps).
+            windowManager.showUI()
+        }
+    }
 }

--- a/WordPress/Classes/System/WordPressAppDelegate.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate.swift
@@ -63,6 +63,10 @@ public class WordPressAppDelegate: UIResponder, UIApplicationDelegate {
     private let remoteFeatureFlagStore = RemoteFeatureFlagStore()
     private let remoteConfigStore = RemoteConfigStore()
 
+    /// Limits the `-wpcom-token` launch-argument sign-in to a single attempt per process,
+    /// so signing out (which returns to the login screen) doesn't immediately re-sign in.
+    private var didAttemptLaunchArgumentSignIn = false
+
     private var mainContext: NSManagedObjectContext {
         ContextManager.shared.mainContext
     }
@@ -906,9 +910,15 @@ extension WordPressAppDelegate {
     /// `-wpcom-token` launch argument, so a Simulator can be signed in with a single
     /// `simctl launch` and no taps on the login screen.
     ///
-    /// No-op when the argument is absent or a WordPress.com account is already signed in.
+    /// No-op when the argument is absent, a WordPress.com account is already signed in, or a
+    /// launch-argument sign-in was already attempted this process. The last case matters because
+    /// signing out returns to the login screen — without it, the still-present token would
+    /// immediately sign the account back in.
     func autoSignInWPComAccountFromLaunchArgumentIfNeeded() {
         guard WordPressDotComAuthenticator.launchArgumentToken != nil else {
+            return
+        }
+        guard !didAttemptLaunchArgumentSignIn else {
             return
         }
         guard (try? WPAccount.lookupDefaultWordPressComAccount(in: ContextManager.shared.mainContext)) == nil else {
@@ -917,6 +927,7 @@ extension WordPressAppDelegate {
         guard let presenter = window?.topmostPresentedViewController else {
             return
         }
+        didAttemptLaunchArgumentSignIn = true
         Task { @MainActor in
             guard await WordPressDotComAuthenticator().signIn(from: presenter, context: .default) != nil else {
                 return

--- a/WordPress/Classes/System/WordPressAppDelegate.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate.swift
@@ -907,7 +907,7 @@ extension WordPressAppDelegate {
     /// `simctl launch` and no taps on the login screen.
     ///
     /// No-op when the argument is absent or a WordPress.com account is already signed in.
-    func autoSignInUITestWPComAccountIfNeeded() {
+    func autoSignInWPComAccountFromLaunchArgumentIfNeeded() {
         guard WordPressDotComAuthenticator.launchArgumentToken != nil else {
             return
         }

--- a/docs/simulator-sign-in.md
+++ b/docs/simulator-sign-in.md
@@ -1,17 +1,23 @@
 # Simulator Sign-In
 
-Pass credentials as launch arguments, then tap through the sign-in screen to complete sign-in.
+Pass credentials as launch arguments. WordPress.com sign-in then completes automatically; the self-hosted flow still needs a couple of taps.
 
 ## WordPress.com account
 
-Launch with a bearer token:
+The quickest path is the helper script — it launches the app with the token and, optionally, resets first:
+
+```bash
+Scripts/sim-signin.sh <bearer-token>             # Jetpack, booted simulator
+Scripts/sim-signin.sh --app wordpress <token>    # WordPress
+Scripts/sim-signin.sh --reset <token>            # wipe existing state first
+```
+
+Or launch directly with the bearer token. The app finishes sign-in automatically while it sits on the login screen — no taps required:
 
 ```bash
 xcrun simctl launch --terminate-running-process booted org.wordpress \
   -ui-test-wpcom-token <bearer-token>
 ```
-
-On the sign-in screen, tap **"Continue with WordPress.com"**.
 
 ## Self-hosted site
 

--- a/docs/simulator-sign-in.md
+++ b/docs/simulator-sign-in.md
@@ -12,6 +12,8 @@ Scripts/sim-signin.sh --app wordpress --wpcom-token <token> # WordPress
 Scripts/sim-signin.sh --reset --wpcom-token <token>         # wipe existing state first
 ```
 
+To set the token once and drop it from the command line, export `WPCOM_TOKEN` (e.g. in `~/.zshrc`) or write it to `~/.wpcom-token`; the script uses either when `--wpcom-token` is omitted.
+
 Or launch directly with the bearer token. The app finishes sign-in automatically while it sits on the login screen — no taps required:
 
 ```bash

--- a/docs/simulator-sign-in.md
+++ b/docs/simulator-sign-in.md
@@ -12,7 +12,7 @@ Scripts/sim-signin.sh --app wordpress --wpcom-token <token> # WordPress
 Scripts/sim-signin.sh --reset --wpcom-token <token>         # wipe existing state first
 ```
 
-There's also a `make` shortcut that forwards to the script: `make sim-login DEVICE=<udid>`, with optional `APP=wordpress`, `RESET=1`, or `ARGS="…"` for any other flags.
+With no `--device`, the script targets the running simulator (and prompts if more than one is booted). There's also a `make` shortcut that forwards to it: `make sim-login`, with optional `DEVICE=<udid>`, `APP=wordpress`, `RESET=1`, or `ARGS="…"` for any other flags.
 
 To set the token once and drop it from the command line, export `WPCOM_TOKEN` (e.g. in `~/.zshrc`) or write it to `~/.wpcom-token`; the script uses either when `--wpcom-token` is omitted.
 

--- a/docs/simulator-sign-in.md
+++ b/docs/simulator-sign-in.md
@@ -14,7 +14,7 @@ Scripts/sim-signin.sh --reset --wpcom-token <token>         # wipe existing stat
 
 With no `--device`, the script targets the running simulator (and prompts if more than one is booted). There's also a `make` shortcut that forwards to it: `make sim-login`, with optional `DEVICE=<udid>`, `APP=wordpress`, `RESET=1`, or `ARGS="…"` for any other flags.
 
-To set the token once and drop it from the command line, export `WPCOM_TOKEN` (e.g. in `~/.zshrc`) or write it to `~/.wpcom-token`; the script uses either when `--wpcom-token` is omitted. If none is set, it prompts you to paste one.
+To set the token once and drop it from the command line, export `WPCOM_TOKEN` (e.g. in `~/.zshrc`) or write it to `~/.wpcom-token`; the script uses either when `--wpcom-token` is omitted. If none is set, it prompts you to paste one and offers to save it to `~/.wpcom-token` for next time.
 
 Or launch directly with the bearer token. The app finishes sign-in automatically while it sits on the login screen — no taps required:
 

--- a/docs/simulator-sign-in.md
+++ b/docs/simulator-sign-in.md
@@ -12,6 +12,8 @@ Scripts/sim-signin.sh --app wordpress --wpcom-token <token> # WordPress
 Scripts/sim-signin.sh --reset --wpcom-token <token>         # wipe existing state first
 ```
 
+There's also a `make` shortcut that forwards to the script: `make sim-login DEVICE=<udid>`, with optional `APP=wordpress`, `RESET=1`, or `ARGS="…"` for any other flags.
+
 To set the token once and drop it from the command line, export `WPCOM_TOKEN` (e.g. in `~/.zshrc`) or write it to `~/.wpcom-token`; the script uses either when `--wpcom-token` is omitted.
 
 Or launch directly with the bearer token. The app finishes sign-in automatically while it sits on the login screen — no taps required:

--- a/docs/simulator-sign-in.md
+++ b/docs/simulator-sign-in.md
@@ -4,17 +4,22 @@ Pass credentials as launch arguments. WordPress.com sign-in then completes autom
 
 ## WordPress.com account
 
-The quickest path is the helper script — it launches the app with the token and, optionally, resets first:
+The quickest path is **`make sim-login`** — it signs the running simulator into WordPress.com, prompting you to choose when more than one simulator is booted, and to paste a token if none is configured:
 
 ```bash
-Scripts/sim-signin.sh --wpcom-token <token>                 # Jetpack, booted simulator
-Scripts/sim-signin.sh --app wordpress --wpcom-token <token> # WordPress
-Scripts/sim-signin.sh --reset --wpcom-token <token>         # wipe existing state first
+make sim-login                # sign the running simulator into Jetpack
+make sim-login APP=wordpress  # WordPress instead of Jetpack
+make sim-login RESET=1        # wipe existing app state first
+make sim-login DEVICE=<udid>  # target a specific simulator
 ```
 
-With no `--device`, the script targets the running simulator (and prompts if more than one is booted). There's also a `make` shortcut that forwards to it: `make sim-login`, with optional `DEVICE=<udid>`, `APP=wordpress`, `RESET=1`, or `ARGS="…"` for any other flags.
+`make sim-login` forwards to `Scripts/sim-signin.sh`, which you can run directly with the same options as flags — `--app`, `--device`, `--reset`, `--wpcom-token` (or pass `ARGS="…"` through `make` for any flag without a dedicated variable):
 
-To set the token once and drop it from the command line, export `WPCOM_TOKEN` (e.g. in `~/.zshrc`) or write it to `~/.wpcom-token`; the script uses either when `--wpcom-token` is omitted. If none is set, it prompts you to paste one and offers to save it to `~/.wpcom-token` for next time.
+```bash
+Scripts/sim-signin.sh --app wordpress --reset
+```
+
+The token is resolved from `--wpcom-token`, then `WPCOM_TOKEN`, then `~/.wpcom-token`; if none is set it prompts you to paste one and offers to save it to `~/.wpcom-token` for next time. Set it once — export `WPCOM_TOKEN` in `~/.zshrc`, or write `~/.wpcom-token` — to skip the token entirely.
 
 Or launch directly with the bearer token. The app finishes sign-in automatically while it sits on the login screen — no taps required:
 

--- a/docs/simulator-sign-in.md
+++ b/docs/simulator-sign-in.md
@@ -14,7 +14,7 @@ Scripts/sim-signin.sh --reset --wpcom-token <token>         # wipe existing stat
 
 With no `--device`, the script targets the running simulator (and prompts if more than one is booted). There's also a `make` shortcut that forwards to it: `make sim-login`, with optional `DEVICE=<udid>`, `APP=wordpress`, `RESET=1`, or `ARGS="…"` for any other flags.
 
-To set the token once and drop it from the command line, export `WPCOM_TOKEN` (e.g. in `~/.zshrc`) or write it to `~/.wpcom-token`; the script uses either when `--wpcom-token` is omitted.
+To set the token once and drop it from the command line, export `WPCOM_TOKEN` (e.g. in `~/.zshrc`) or write it to `~/.wpcom-token`; the script uses either when `--wpcom-token` is omitted. If none is set, it prompts you to paste one.
 
 Or launch directly with the bearer token. The app finishes sign-in automatically while it sits on the login screen — no taps required:
 

--- a/docs/simulator-sign-in.md
+++ b/docs/simulator-sign-in.md
@@ -9,17 +9,19 @@ The quickest path is **`make sim-login`** — it signs the running simulator int
 ```bash
 make sim-login                # sign the running simulator into Jetpack
 make sim-login APP=wordpress  # WordPress instead of Jetpack
-make sim-login RESET=1        # wipe existing app state first
+make sim-login RESET=1        # reinstall the app first (clean slate)
 make sim-login DEVICE=<udid>  # target a specific simulator
 ```
 
-`make sim-login` forwards to `Scripts/sim-signin.sh`, which you can run directly with the same options as flags — `--app`, `--device`, `--reset`, `--wpcom-token` (or pass `ARGS="…"` through `make` for any flag without a dedicated variable):
+`make sim-login` forwards to `Scripts/sim-signin.sh`, which you can run directly with the same options as flags — `--app`, `--device`, `--reset`:
 
 ```bash
 Scripts/sim-signin.sh --app wordpress --reset
 ```
 
-The token is resolved from `--wpcom-token`, then `WPCOM_TOKEN`, then `~/.wpcom-token`; if none is set it prompts you to paste one and offers to save it to `~/.wpcom-token` for next time. Set it once — export `WPCOM_TOKEN` in `~/.zshrc`, or write `~/.wpcom-token` — to skip the token entirely.
+`--reset` uninstalls and reinstalls the app for a clean slate — more thorough than the in-app data wipe (it also clears caches and cookies) and race-free (the reinstall is synchronous). The app must already be installed.
+
+The token is resolved from `WPCOM_TOKEN`, then `~/.wpcom-token`; if none is set the script prompts you to paste one (hidden) and offers to save it to `~/.wpcom-token` for next time. There's deliberately no command-line token flag — a token passed as an argument would be saved in your shell history. Set it once (export `WPCOM_TOKEN` in `~/.zshrc`, or write `~/.wpcom-token`) and you never pass it again.
 
 Or launch directly with the bearer token. The app finishes sign-in automatically while it sits on the login screen — no taps required:
 
@@ -29,6 +31,8 @@ xcrun simctl launch --terminate-running-process booted org.wordpress \
 ```
 
 The legacy `-ui-test-wpcom-token` argument is still accepted for backward compatibility.
+
+This raw form also saves the token in your shell history — `make sim-login` avoids that, since you never type the token. (Either way the token appears briefly in `ps` while `simctl launch` runs; that's inherent to passing it as a launch argument.)
 
 ## Self-hosted site
 

--- a/docs/simulator-sign-in.md
+++ b/docs/simulator-sign-in.md
@@ -7,9 +7,9 @@ Pass credentials as launch arguments. WordPress.com sign-in then completes autom
 The quickest path is the helper script — it launches the app with the token and, optionally, resets first:
 
 ```bash
-Scripts/sim-signin.sh <bearer-token>             # Jetpack, booted simulator
-Scripts/sim-signin.sh --app wordpress <token>    # WordPress
-Scripts/sim-signin.sh --reset <token>            # wipe existing state first
+Scripts/sim-signin.sh --wpcom-token <token>                 # Jetpack, booted simulator
+Scripts/sim-signin.sh --app wordpress --wpcom-token <token> # WordPress
+Scripts/sim-signin.sh --reset --wpcom-token <token>         # wipe existing state first
 ```
 
 Or launch directly with the bearer token. The app finishes sign-in automatically while it sits on the login screen — no taps required:

--- a/docs/simulator-sign-in.md
+++ b/docs/simulator-sign-in.md
@@ -16,8 +16,10 @@ Or launch directly with the bearer token. The app finishes sign-in automatically
 
 ```bash
 xcrun simctl launch --terminate-running-process booted org.wordpress \
-  -ui-test-wpcom-token <bearer-token>
+  -wpcom-token <bearer-token>
 ```
+
+The legacy `-ui-test-wpcom-token` argument is still accepted for backward compatibility.
 
 ## Self-hosted site
 


### PR DESCRIPTION
## Summary

- Adds `make sim-login` (wrapping `Scripts/sim-signin.sh`) to sign a booted Simulator into WordPress.com in one command — no taps.
- Introduces the `-wpcom-token` launch argument that finishes WordPress.com sign-in automatically; the legacy `-ui-test-wpcom-token` still works.
- Reads the token from `WPCOM_TOKEN` or `~/.wpcom-token` (never the command line), so it stays out of shell history.

## Background

`trunk` already reads a `-ui-test-wpcom-token` launch argument inside `WordPressDotComAuthenticator.attemptSignIn` — but only after the user taps **"Continue with WordPress.com"** on the login screen. Signing a Simulator in therefore still needed a manual tap. This is the launch-argument approach, chosen over device-to-device session transfer (#25795).

## Changes

### 1. `make sim-login` / `Scripts/sim-signin.sh`

```bash
make sim-login                # Jetpack, the booted simulator
make sim-login APP=wordpress  # WordPress instead
make sim-login RESET=1        # reinstall the app first, for a clean slate
make sim-login DEVICE=<udid>  # target a specific simulator
```

The script targets the booted simulator (prompting to choose when several are booted), maps `--app` to the bundle id (`com.automattic.jetpack` / `org.wordpress`), and launches it with `-wpcom-token` so the app signs in from the login screen with no taps.

**The token never appears on the command line.** It resolves from `WPCOM_TOKEN`, then `~/.wpcom-token`, then a hidden prompt (which offers to save it, mode 600). A token passed as an argument would be saved to shell history, so there is deliberately no `--wpcom-token` flag.

**`--reset` uninstalls and reinstalls the app** instead of running the in-app `-ui-test-reset-everything` wipe. Reinstalling clears the whole data container — caches and cookies, not just Core Data and `UserDefaults` — and `simctl install` is synchronous, so nothing races an async wipe on a fixed sleep. The app must already be installed.

### 2. The `-wpcom-token` launch argument

`WordPressDotComAuthenticator.launchArgumentToken` resolves the token from `-wpcom-token`, falling back to the legacy `-ui-test-wpcom-token`. Both the automatic sign-in and the existing `attemptSignIn` path read through it, so anything still passing the old argument keeps working.

### 3. Automatic sign-in

`WordPressAppDelegate.autoSignInWPComAccountFromLaunchArgumentIfNeeded()` mirrors the existing `autoSignInUITestSite()` hook and is called from `RootViewCoordinator.showSignInUI()`. It runs the real `signIn(context: .default)` flow, then swaps the window root with `windowManager.showUI()` — posting `WPSigninDidFinishNotification` alone creates the account but leaves the app on the login screen.

**It attempts at most once per process, and only when no account is signed in.** Without the once-per-process guard, signing out returns to the login screen where the still-present token would immediately sign the account back in — a logout could never reach a logged-out state.

## Test plan

Verified at the script level with a stubbed `xcrun` (the command sequence, not a real sign-in), on macOS's system bash 3.2:

- [x] `--reset` issues `get_app_container` → `uninstall` → `install <staged .app>` → `launch -wpcom-token`, in that order, and the staged copy is removed on exit.
- [x] A `--wpcom-token <token>` flag and a positional token are both rejected (`error: unknown argument`); the token resolves from `WPCOM_TOKEN` / `~/.wpcom-token`.
- [x] `--reset` with the app not installed fails with a clear "build and install it first" error.

On a booted Simulator (reviewer):

- [ ] Build and install the app, then `make sim-login` → the app signs in and lands on the site with no taps.
- [ ] Launching with the legacy `-ui-test-wpcom-token <token>` still signs in.
- [ ] `make sim-login RESET=1` against a signed-in app → the app is reinstalled, then signed in.
- [ ] Sign out after a token launch → the app stays on the login screen and does not auto sign back in.
- [ ] `make sim-login APP=wordpress` targets `org.wordpress`.

## Related

- Supersedes #25795 (device-to-device session transfer), closed in favour of this launch-argument approach.
