### PR TITLE
Remove dead internal app-icon versioning task

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,7 +60,6 @@ WordPress/WordPress.xcodeproj/xcuserdata
 WordPress/Derived Sources/
 # coverage.py
 */CoverageData/*
-WordPress/Images.xcassets/AppIcon-Internal.appiconset
 
 # Dependencies
 vendor
@@ -85,10 +84,6 @@ Scripts/fastlane/
 
 # CI Artifacts Location
 Artifacts
-
-# Generated Internal Icons
-WordPress/Resources/AppImages.xcassets/AppIcon-Internal.appiconset
-WordPress/Resources/Icons-Internal
 
 # All encrypted secrets should be stored under .configure-files
 # Everything without a .enc extension is ignored

--- a/Rakefile
+++ b/Rakefile
@@ -14,7 +14,7 @@ PROJECT_DIR = __dir__
 abort('Project directory contains one or more spaces – unable to continue.') if PROJECT_DIR.include?(' ')
 
 desc 'Install required dependencies'
-task dependencies: %w[dependencies:check assets:check dependencies:gutenberg_xcframeworks]
+task dependencies: %w[dependencies:check dependencies:gutenberg_xcframeworks]
 
 namespace :dependencies do
   task check: %w[ruby:check bundler:check bundle:check credentials:apply]
@@ -97,19 +97,6 @@ bundle exec fastlane run configure_apply force:true
   desc 'Download and extract Gutenberg xcframeworks'
   task :gutenberg_xcframeworks do
     sh("#{PROJECT_DIR}/Scripts/download-gutenberg-xcframeworks.sh")
-  end
-end
-
-namespace :assets do
-  task :check do
-    next unless Dir['WordPress/Resources/AppImages.xcassets/AppIcon-Internal.appiconset/*.png'].empty?
-
-    Dir.mktmpdir do |tmpdir|
-      puts 'Generate internal icon set'
-      if system("export PROJECT_DIR=#{Dir.pwd}/WordPress && export TEMP_DIR=#{tmpdir} && ./Scripts/BuildPhases/AddVersionToIcons.sh >/dev/null 2>&1") != 0
-        system("cp #{Dir.pwd}/WordPress/Resources/AppImages.xcassets/AppIcon.appiconset/*.png #{Dir.pwd}/WordPress/Resources/AppImages.xcassets/AppIcon-Internal.appiconset/")
-      end
-    end
   end
 end
 


### PR DESCRIPTION
## Summary

- Removes the orphaned `assets:check` Rake task that generated a version-stamped "internal" app icon.
- Fixes the spurious `cp: .../AppIcon.appiconset: No such file or directory` error printed during every `rake dependencies`.

## Root Cause

`assets:check` — wired into the top-level `dependencies` task — did three things, all now pointing at deleted paths:

1. **Skip guard**: `next unless Dir['WordPress/Resources/AppImages.xcassets/AppIcon-Internal.appiconset/*.png'].empty?`. That directory no longer exists, so the glob is always empty and the task body **always** ran.
2. **Generate**: ran `./Scripts/BuildPhases/AddVersionToIcons.sh`, which was deleted. Its non-zero exit was swallowed by `>/dev/null 2>&1`.
3. **Fallback**: `cp`'d `WordPress/Resources/AppImages.xcassets/AppIcon.appiconset/*.png` into the internal appiconset. That source was removed in #24410 when the app icons moved to `Sources/*/Resources/Assets.xcassets/AppIconLegacy.appiconset` — hence the `cp` error.

`configure_apply` succeeds independently; the error was purely this trailing dead step running afterward.

## Changes

- **Rakefile**: Remove the `namespace :assets` block and drop `assets:check` from the `dependencies` task list.
- **.gitignore**: Remove the three now-stale ignore entries for the generated internal-icon paths (two `AppIcon-Internal.appiconset` paths and `Icons-Internal`).

## What this deliberately leaves alone

ImageMagick, Ghostscript, and the `rmagick` gem **stay** — they aren't icon-overlay dependencies. They back the promo-screenshots lane (`fastlane/lanes/screenshots.rb` → `promo_screenshots`). The `brew install imagemagick`/`ghostscript` in `shared-set-up-distribution.sh` *may* now be unused by distribution builds — it predates and outlived the icon overlay — but confirming that needs a separate pass through the build lanes, so it's left out of scope here.

## Test plan

- [x] `ruby -c Rakefile` → `Syntax OK`
- [ ] `rake dependencies` completes without the `cp` error
- [ ] App builds and shows the correct icon (unchanged — targets use `AppIconLegacy`)
