### PR TITLE
Move WPUserAgent to WordPressShared for cross-platform builds

### DIFF
--- a/Modules/Sources/WordPressData/Swift/Blog.swift
+++ b/Modules/Sources/WordPressData/Swift/Blog.swift
@@ -1,7 +1,6 @@
 import CoreData
 import WordPressKit
 import WordPressShared
-import WordPressSharedUI
 
 public enum SiteVisibility: Int {
     case `private` = -1

--- a/Modules/Sources/WordPressData/Swift/PostServiceRemoteFactory.swift
+++ b/Modules/Sources/WordPressData/Swift/PostServiceRemoteFactory.swift
@@ -2,7 +2,6 @@ import Foundation
 import CoreData
 import WordPressKit
 import WordPressShared
-import WordPressSharedUI
 
 @objc public class PostServiceRemoteFactory: NSObject {
     @objc public func forBlog(_ blog: Blog) -> PostServiceRemote? {

--- a/Modules/Sources/WordPressData/Swift/WPAccount+RestApi.swift
+++ b/Modules/Sources/WordPressData/Swift/WPAccount+RestApi.swift
@@ -1,7 +1,6 @@
 import WordPressKit
 import CoreData
 import WordPressShared
-import WordPressSharedUI
 
 extension WPAccount {
 

--- a/Modules/Sources/WordPressData/Swift/WordPressComRestApi+Defaults.swift
+++ b/Modules/Sources/WordPressData/Swift/WordPressComRestApi+Defaults.swift
@@ -2,7 +2,6 @@ import Foundation
 import CoreData
 import WordPressKit
 import WordPressShared
-import WordPressSharedUI
 
 extension WordPressComRestApi {
     @objc public static func defaultApi(oAuthToken: String? = nil,

--- a/Modules/Sources/WordPressData/Swift/WordPressOrgRestApi+WordPress.swift
+++ b/Modules/Sources/WordPressData/Swift/WordPressOrgRestApi+WordPress.swift
@@ -1,6 +1,5 @@
 import Foundation
 import WordPressShared
-import WordPressSharedUI
 import WordPressKit
 
 private func apiBase(blog: Blog) -> URL? {

--- a/Modules/Sources/WordPressShared/WPUserAgent.swift
+++ b/Modules/Sources/WordPressShared/WPUserAgent.swift
@@ -1,7 +1,8 @@
 import Foundation
+
+#if canImport(UIKit)
 import UIKit
-import WebKit
-import WordPressShared
+#endif
 
 @objc
 public class WPUserAgent: NSObject {
@@ -75,6 +76,7 @@ public class WPUserAgent: NSObject {
         // [^1]: https://github.com/WebKit/WebKit/blob/5fbb03ee1c6210c79779d6fa1a9e7290daa746d1/Source/WebCore/platform/ios/UserAgentIOS.mm#L88-L113
         // [^2]: https://github.com/WebKit/WebKit/blob/492140d27dbe/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm#L612
 
+        #if canImport(UIKit)
         let device = UIDevice.current
 
         let deviceModel = device.model // Example: "iPhone"
@@ -92,7 +94,15 @@ public class WPUserAgent: NSObject {
             osName = "iPhone OS"
         }
 
-        return "Mozilla/5.0 (\(deviceModel); CPU \(osName) \(osVersion) like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148"
+        return
+            "Mozilla/5.0 (\(deviceModel); CPU \(osName) \(osVersion) like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148"
+        #else
+        // `UIDevice` is unavailable on platforms without UIKit (e.g. macOS in cross-platform builds).
+        // The user agent is only consumed at runtime on iOS; this keeps `WPUserAgent` buildable elsewhere.
+        let version = ProcessInfo.processInfo.operatingSystemVersion
+        let osVersion = "\(version.majorVersion)_\(version.minorVersion)_\(version.patchVersion)"
+        return "Mozilla/5.0 (Macintosh; Intel Mac OS X \(osVersion)) AppleWebKit/605.1.15 (KHTML, like Gecko)"
+        #endif
     }
 }
 

--- a/Modules/Sources/WordPressShared/WPUserAgent.swift
+++ b/Modules/Sources/WordPressShared/WPUserAgent.swift
@@ -67,21 +67,29 @@ public class WPUserAgent: NSObject {
         // ## iPad Pro (iOS 17.0.1)
         // Mozilla/5.0 (iPad; CPU OS 17_0_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148
         //
-        // Based on the WebKit implementation[^1], most of the components are hardcoded, and there are only a couple of dynamic components:
-        // 1. Device model. i.e. iPhone/iPad
-        // 2. OS name and version. i.e. iPhone OS 17_2
+        // Based on the WebKit implementation[^1], most of the components are hardcoded. The only
+        // component that still varies at runtime is the device model (iPhone vs. iPad).
+        //
+        // The OS version used to be dynamic too, but as of iOS/iPadOS 26 WebKit freezes it at the last
+        // pre-26 value ("18_6") and never advances it — an anti-fingerprinting measure, mirroring what
+        // macOS Safari has long done (frozen at "10_15_7"). Reading the live `UIDevice.systemVersion`
+        // would emit a version no real `WKWebView` sends, so we pin it to the frozen constant to match
+        // what devices actually report.[^3]
         //
         // Please note the "Mobile/15E148" part is WKWebView's default and hardcoded "application name"[^2].
         //
         // [^1]: https://github.com/WebKit/WebKit/blob/5fbb03ee1c6210c79779d6fa1a9e7290daa746d1/Source/WebCore/platform/ios/UserAgentIOS.mm#L88-L113
         // [^2]: https://github.com/WebKit/WebKit/blob/492140d27dbe/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm#L612
+        // [^3]: https://nielsleenheer.com/articles/2025/the-user-agent-string-of-safari-on-ios-26-and-macos-26/
 
         #if canImport(UIKit)
         let device = UIDevice.current
 
         let deviceModel = device.model // Example: "iPhone"
         var osName = device.systemName // Example: "iPhone OS"
-        let osVersion = device.systemVersion.replacingOccurrences(of: ".", with: "_") // Example: "17_2"
+
+        // Frozen since iOS/iPadOS 26 (see the note above); real WKWebViews no longer emit the live OS version.
+        let osVersion = "18_6"
 
         // WKWebView on iPad uses a static user agent.
         // https://github.com/WebKit/WebKit/blob/6a053cfb431bd70d5017ba881a39f004e52effc2/Source/WebCore/platform/ios/UserAgentIOS.mm#L97
@@ -99,9 +107,8 @@ public class WPUserAgent: NSObject {
         #else
         // `UIDevice` is unavailable on platforms without UIKit (e.g. macOS in cross-platform builds).
         // The user agent is only consumed at runtime on iOS; this keeps `WPUserAgent` buildable elsewhere.
-        let version = ProcessInfo.processInfo.operatingSystemVersion
-        let osVersion = "\(version.majorVersion)_\(version.minorVersion)_\(version.patchVersion)"
-        return "Mozilla/5.0 (Macintosh; Intel Mac OS X \(osVersion)) AppleWebKit/605.1.15 (KHTML, like Gecko)"
+        // macOS Safari has frozen its OS version at "10_15_7" for years, so match that.
+        return "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko)"
         #endif
     }
 }

--- a/Modules/Tests/WordPressSharedTests/WPUserAgentTests.swift
+++ b/Modules/Tests/WordPressSharedTests/WPUserAgentTests.swift
@@ -20,6 +20,15 @@ class WPWPUserAgentTests {
     }
 
     @Test
+    func userAgentFreezesOSVersion() {
+        // As of iOS/iPadOS 26, WebKit freezes the WKWebView user agent's OS version at "18_6".
+        // `webViewUserAgent` pins to that constant so it matches what real web views emit rather
+        // than reading the live `UIDevice.systemVersion` (which no WKWebView reports anymore).
+        let userAgent = WPUserAgent.defaultUserAgent(userDefaults: .standard)
+        #expect(userAgent.contains(" 18_6 like Mac OS X"))
+    }
+
+    @Test
     func wordPressUserAgentValue() throws {
         let userDefaults = UserDefaults.standard
         let appVersion = try #require(Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String)


### PR DESCRIPTION
## What this does

`WPUserAgent` builds the app's `User-Agent` — a WKWebView-style prefix plus `wp-iphone/<version>` — sent on API requests and used in web views. This PR does two things to it:

- **Moves it from the UIKit-only `WordPressSharedUI` to the cross-platform `WordPressShared`**, so it compiles and is tested on macOS.
- **Pins the WKWebView OS version to WebKit's frozen constant (`18_6`)** instead of reading the live `UIDevice.systemVersion`, so the string matches what real devices emit.

## The move

`WPUserAgent`'s only UIKit dependency is `UIDevice` in `webViewUserAgent`; that block now sits behind `#if canImport(UIKit)` with a macOS fallback for the `#else` path, and the unused `import WebKit` (present only in comments) is gone. `WordPressShared` is already in the root `Package.swift`, so `swift test` now compiles `WPUserAgent` on macOS and CI keeps it cross-platform — the first prerequisite for making `WordPressData` cross-platform, continuing #25344.

**No call sites change.** Every consumer — the app Swift files, the Objective-C services that `@import WordPressShared`, `JetpackSocial`, and the `WordPressData` API-client files — already imports `WordPressShared`, so `WPUserAgent` resolves from its new home unchanged. The only consumer edits drop a now-redundant `import WordPressSharedUI` from five `WordPressData` files that used `WPUserAgent` and nothing else from that module.

## The OS-version freeze

`webViewUserAgent` reconstructs a WKWebView user agent by hand and used to interpolate the live `UIDevice.systemVersion`. As of iOS/iPadOS 26, WebKit **freezes** that field at the last pre-26 value (`iPhone OS 18_6`) and never advances it — an anti-fingerprinting change, matching what macOS Safari has done for years (`10_15_7`). Reading the live version therefore produced a string **no real `WKWebView` emits** on iOS 26+. Pinning to `18_6` restores the match; the device model (iPhone vs. iPad) stays dynamic, since it's the only part that still varies, and the macOS `#else` fallback is pinned to `10_15_7`. Background on the change: [the Safari 26 user agent, explained](https://nielsleenheer.com/articles/2025/the-user-agent-string-of-safari-on-ios-26-and-macos-26/).

**WP.com's servers will see a different `User-Agent`** on iOS 26+ — but only corrected toward what real devices report. The `wp-iphone/<version>` token, which is the part WP.com parses, is unchanged.

## Test plan

- [x] `swift test` on macOS — 77 tests / 11 suites; `WPUserAgent` compiles cross-platform, exercising the `#else` fallback path
- [x] `WPUserAgentTests` pass on an iOS 26.0 simulator: `testWebKitUserAgentFormat` (compares against a live `WKWebView`'s UA) and the new `userAgentFreezesOSVersion` (the emitted string contains ` 18_6 like Mac OS X`)
- [x] `Jetpack` iOS build succeeds — the Objective-C `.m` services resolve `WPUserAgent` via `@import WordPressShared`
- [x] `swift-format` stable and SwiftLint-clean on the moved file
