### PR TITLE
Make FormattableContentKit's model layer build without UIKit

### DIFF
--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -105,11 +105,27 @@ let package = Package(
             name: "FormattableContentKit",
             dependencies: [
                 "WordPressShared",
-                "WordPressSharedUI",
-                "WordPressUI",
+                // UIKit-only styling deps. The files that use them (WPStyleGuide+Notifications
+                // and the concrete *ContentStyles) are gated with `#if canImport(UIKit)`, so we
+                // drop these edges on macOS to keep the model/protocol layer cross-platform.
+                .target(
+                    name: "WordPressSharedUI",
+                    condition: .when(platforms: [.iOS, .macCatalyst, .tvOS, .watchOS, .visionOS])
+                ),
+                .target(
+                    name: "WordPressUI",
+                    condition: .when(platforms: [.iOS, .macCatalyst, .tvOS, .watchOS, .visionOS])
+                ),
                 // TODO: Remove — It's here just for a NSMutableParagraphStyle init helper
-                "WordPressKit",
-                .product(name: "Gridicons", package: "Gridicons-iOS")
+                .target(
+                    name: "WordPressKit",
+                    condition: .when(platforms: [.iOS, .macCatalyst, .tvOS, .watchOS, .visionOS])
+                ),
+                .product(
+                    name: "Gridicons",
+                    package: "Gridicons-iOS",
+                    condition: .when(platforms: [.iOS, .macCatalyst, .tvOS, .watchOS, .visionOS])
+                )
             ],
             // Set to v5 to avoid @Sendable warnings and errors
             swiftSettings: [.swiftLanguageMode(.v5)]

--- a/Modules/Sources/FormattableContentKit/Actions/FormattableContentActionCommand.swift
+++ b/Modules/Sources/FormattableContentKit/Actions/FormattableContentActionCommand.swift
@@ -1,4 +1,4 @@
-import Foundation
+import WordPressShared
 
 /// Abstracts the logic behind contextual actions that can be applied to FormattableContent.
 ///

--- a/Modules/Sources/FormattableContentKit/Actions/FormattableContentActionCommand.swift
+++ b/Modules/Sources/FormattableContentKit/Actions/FormattableContentActionCommand.swift
@@ -1,4 +1,4 @@
-import UIKit
+import Foundation
 
 /// Abstracts the logic behind contextual actions that can be applied to FormattableContent.
 ///
@@ -7,7 +7,7 @@ public protocol FormattableContentActionCommand: CustomStringConvertible {
     var on: Bool { get set }
 
     var actionTitle: String? { get }
-    var actionColor: UIColor? { get }
+    var actionColor: PlatformColor? { get }
 
     func execute<ContentType: FormattableContent>(context: ActionContext<ContentType>)
 }

--- a/Modules/Sources/FormattableContentKit/Actions/FormattableContentActionCommand.swift
+++ b/Modules/Sources/FormattableContentKit/Actions/FormattableContentActionCommand.swift
@@ -14,12 +14,12 @@ public protocol FormattableContentActionCommand: CustomStringConvertible {
 
 extension FormattableContentActionCommand {
     public static func commandIdentifier() -> Identifier {
-        return Identifier(value: String(describing: self))
+        Identifier(value: String(describing: self))
     }
 }
 
 extension FormattableContentActionCommand {
     public var description: String {
-        return identifier.description
+        identifier.description
     }
 }

--- a/Modules/Sources/FormattableContentKit/FormattableContent/FormattableContentStyles.swift
+++ b/Modules/Sources/FormattableContentKit/FormattableContent/FormattableContentStyles.swift
@@ -1,4 +1,5 @@
 import Foundation
+import WordPressShared
 
 /// Styles definition to be applied to a single FormattableContent entity.
 public protocol FormattableContentStyles {

--- a/Modules/Sources/FormattableContentKit/FormattableContent/FormattableContentStyles.swift
+++ b/Modules/Sources/FormattableContentKit/FormattableContent/FormattableContentStyles.swift
@@ -1,4 +1,4 @@
-import UIKit
+import Foundation
 
 /// Styles definition to be applied to a single FormattableContent entity.
 public protocol FormattableContentStyles {
@@ -9,7 +9,7 @@ public protocol FormattableContentStyles {
     /// Styles definition for a specific set of ranges identified by their kind or nil to not apply any.
     var rangeStylesMap: [FormattableRangeKind: [NSAttributedString.Key: Any]]? { get }
     /// Color for text that represent a link or nil to not apply any.
-    var linksColor: UIColor? { get }
+    var linksColor: PlatformColor? { get }
     /// Key to be used for caching the resulting attributed string. It needs to be unique.
     var key: String { get }
 }

--- a/Modules/Sources/FormattableContentKit/NotificationTextContent.swift
+++ b/Modules/Sources/FormattableContentKit/NotificationTextContent.swift
@@ -1,5 +1,4 @@
 import Foundation
-import UIKit
 
 extension FormattableContentKind {
     public static let image = FormattableContentKind("image")
@@ -13,7 +12,7 @@ public protocol FormattableMediaContent {
     var media: [FormattableMediaItem] { get }
     var imageUrls: [URL] { get }
 
-    func buildRangesToImagesMap(_ mediaMap: [URL: UIImage]) -> [NSValue: UIImage]?
+    func buildRangesToImagesMap(_ mediaMap: [URL: PlatformImage]) -> [NSValue: PlatformImage]?
 }
 
 extension FormattableMediaContent where Self: FormattableContent {
@@ -27,12 +26,12 @@ extension FormattableMediaContent where Self: FormattableContent {
         }
     }
 
-    public func buildRangesToImagesMap(_ mediaMap: [URL: UIImage]) -> [NSValue: UIImage]? {
+    public func buildRangesToImagesMap(_ mediaMap: [URL: PlatformImage]) -> [NSValue: PlatformImage]? {
         guard textOverride == nil else {
             return nil
         }
 
-        var ranges = [NSValue: UIImage]()
+        var ranges = [NSValue: PlatformImage]()
 
         for theMedia in media {
             guard let mediaURL = theMedia.mediaURL else {

--- a/Modules/Sources/FormattableContentKit/NotificationTextContent.swift
+++ b/Modules/Sources/FormattableContentKit/NotificationTextContent.swift
@@ -1,4 +1,5 @@
 import Foundation
+import WordPressShared
 
 extension FormattableContentKind {
     public static let image = FormattableContentKind("image")

--- a/Modules/Sources/FormattableContentKit/NotificationTextContent.swift
+++ b/Modules/Sources/FormattableContentKit/NotificationTextContent.swift
@@ -17,7 +17,7 @@ public protocol FormattableMediaContent {
 
 extension FormattableMediaContent where Self: FormattableContent {
     public var imageUrls: [URL] {
-        return media.compactMap {
+        media.compactMap {
             guard $0.kind == .image && $0.mediaURL != nil else {
                 return nil
             }
@@ -55,7 +55,7 @@ public class NotificationTextContent: FormattableTextContent, FormattableMediaCo
     public let meta: [String: AnyObject]?
 
     public override var text: String? {
-        return textOverride ?? super.text
+        textOverride ?? super.text
     }
 
     public override var kind: FormattableContentKind {
@@ -64,15 +64,21 @@ public class NotificationTextContent: FormattableTextContent, FormattableMediaCo
         }
 
         if let meta,
-           let buttonValue = meta[Constants.MetaKeys.Button] as? Bool,
-           buttonValue == true {
+            let buttonValue = meta[Constants.MetaKeys.Button] as? Bool,
+            buttonValue == true
+        {
             return .button
         }
 
         return super.kind
     }
 
-    init(dictionary: [String: AnyObject], actions commandActions: [FormattableContentAction], ranges: [FormattableContentRange], parent note: Notifiable) {
+    init(
+        dictionary: [String: AnyObject],
+        actions commandActions: [FormattableContentAction],
+        ranges: [FormattableContentRange],
+        parent note: Notifiable
+    ) {
         let rawMedia = dictionary[Constants.BlockKeys.Media] as? [[String: AnyObject]]
         let text = dictionary[Constants.BlockKeys.Text] as? String ?? ""
 

--- a/Modules/Sources/FormattableContentKit/Platform.swift
+++ b/Modules/Sources/FormattableContentKit/Platform.swift
@@ -1,0 +1,19 @@
+#if canImport(UIKit)
+import UIKit
+
+/// The platform's color type: `UIColor` on UIKit platforms, `NSColor` on AppKit.
+///
+/// FormattableContentKit's model and protocol layer is cross-platform; this alias
+/// lets the notification-styling protocols name a color without hard-importing UIKit,
+/// so the module builds on macOS. Colors are only ever materialized at render time,
+/// which happens on iOS.
+public typealias PlatformColor = UIColor
+
+/// The platform's image type: `UIImage` on UIKit platforms, `NSImage` on AppKit.
+public typealias PlatformImage = UIImage
+#elseif canImport(AppKit)
+import AppKit
+
+public typealias PlatformColor = NSColor
+public typealias PlatformImage = NSImage
+#endif

--- a/Modules/Sources/FormattableContentKit/Styles/SnippetsContentStyles.swift
+++ b/Modules/Sources/FormattableContentKit/Styles/SnippetsContentStyles.swift
@@ -1,3 +1,4 @@
+#if canImport(UIKit)
 import WordPressShared
 import WordPressSharedUI
 
@@ -26,3 +27,4 @@ public class SnippetsContentStyles: FormattableContentStyles {
         self.key = key
     }
 }
+#endif

--- a/Modules/Sources/FormattableContentKit/Styles/SubjectContentStyles.swift
+++ b/Modules/Sources/FormattableContentKit/Styles/SubjectContentStyles.swift
@@ -1,3 +1,4 @@
+#if canImport(UIKit)
 import WordPressShared
 import WordPressSharedUI
 
@@ -29,3 +30,4 @@ public class SubjectContentStyles: FormattableContentStyles {
         self.key = key
     }
 }
+#endif

--- a/Modules/Sources/FormattableContentKit/Styles/WPStyleGuide+Notifications.swift
+++ b/Modules/Sources/FormattableContentKit/Styles/WPStyleGuide+Notifications.swift
@@ -1,3 +1,4 @@
+#if canImport(UIKit)
 // FIXME: This does not belong here, see https://github.com/wordpress-mobile/WordPress-iOS/pull/24297
 import Foundation
 import Gridicons
@@ -314,3 +315,4 @@ extension UIFont {
         return UIFont(descriptor: descriptor, size: 0)
     }
 }
+#endif

--- a/Modules/Sources/WordPressShared/Platform.swift
+++ b/Modules/Sources/WordPressShared/Platform.swift
@@ -3,10 +3,8 @@ import UIKit
 
 /// The platform's color type: `UIColor` on UIKit platforms, `NSColor` on AppKit.
 ///
-/// FormattableContentKit's model and protocol layer is cross-platform; this alias
-/// lets the notification-styling protocols name a color without hard-importing UIKit,
-/// so the module builds on macOS. Colors are only ever materialized at render time,
-/// which happens on iOS.
+/// A thin bridge so cross-platform modules can name a color in a signature without
+/// importing UIKit. The concrete color is only ever materialized at the UI layer.
 public typealias PlatformColor = UIColor
 
 /// The platform's image type: `UIImage` on UIKit platforms, `NSImage` on AppKit.


### PR DESCRIPTION
> [!Note]
> I recommend reviewing by commit. The second commit just runs `swift-format` and can be ignored; the first and third are the actual change (the third relocates the two platform typealiases into `WordPressShared`).

## Description

First of a short series making `WordPressData` build on macOS, continuing the cross-platform module work from #25344. `WordPressData.Notification` stores a `FormattableContentFormatter` and `FormattableContentGroup`s, so `FormattableContentKit` has to compile off-iOS before `WordPressData` can — this PR does that, and nothing else.

## Root Cause

`FormattableContentKit` isn't really a UI module — it's the notification data model plus a formatter. Rendering is entirely app-side: `WordPressData.Notification` only **stores** the formatter and its group caches, while every `render()` call, concrete `*ContentStyles`, and raw-block→`FormattableContent` parse lives in `WordPress/Classes`. The server sends untyped JSON blocks that sit in Core Data until the UI lazily builds `FormattableContent` on demand.

Even so, the module hard-imports UIKit. The only UIKit types named in a **signature** (rather than buried inside an `Any`-typed `NSAttributedString` attribute dictionary) are three protocol members:

- `FormattableContentStyles.linksColor: UIColor?`
- `FormattableContentActionCommand.actionColor: UIColor?`
- `FormattableMediaContent.buildRangesToImagesMap(_: [URL: UIImage]) -> [NSValue: UIImage]?`

## Changes

1. **`PlatformColor` / `PlatformImage` typealiases in `WordPressShared`** — `UIColor`/`UIImage` under `canImport(UIKit)`, `NSColor`/`NSImage` under AppKit — used in those three signatures. They live in the cross-platform core that both this module and (next) `WordPressData` import, rather than as a per-module copy. On iOS they resolve to the same types, so every conformer and call site is **unchanged**.
2. **Gate the render-only files** (`WPStyleGuide+Notifications`, `SnippetsContentStyles`, `SubjectContentStyles`) behind `#if canImport(UIKit)`. Nothing cross-platform references them.
3. **Prune the UIKit dependency edges** (`WordPressSharedUI`, `WordPressUI`, `WordPressKit`, `Gridicons`) with `.when(platforms: [.iOS, .macCatalyst, .tvOS, .watchOS, .visionOS])`, matching #25344.

`WordPressData`, the root `Package.swift`, and app code are **unchanged** — those are the follow-ups.

## What this doesn't change

- **iOS behavior** — `PlatformColor` *is* `UIColor` on iOS; the concrete styles compile exactly as before.
- **The colors themselves** — every notification color is a static theme constant (`UIAppColor.*` / `WPStyleGuide.Notifications.*`) or nil; none are parsed from the wire, so no value-level color abstraction was needed.

## Test Plan

- [x] `swift build --package-path Modules --target FormattableContentKit` on the macOS host — fails on `trunk`, passes here (only `WordPressShared` + AppKit link; the four UIKit deps never enter the build plan)
- [x] `xcodebuild -scheme FormattableContentKit -destination 'generic/platform=iOS'` — **BUILD SUCCEEDED**
- [x] SwiftLint clean
- [ ] CI green
