### PR TITLE
Clear first-party warnings from the cross-platform `swift test` job

### DIFF
--- a/Modules/Sources/WordPressCore/Users/UserService.swift
+++ b/Modules/Sources/WordPressCore/Users/UserService.swift
@@ -23,7 +23,7 @@ public actor UserService: UserServiceProtocol {
     }
 
     public func fetchUsers() async throws {
-        let sequence = await client.api.users.sequenceWithEditContext(params: .init(perPage: 100))
+        let sequence = client.api.users.sequenceWithEditContext(params: .init(perPage: 100))
         var started = false
         for try await users in sequence {
             if !started {

--- a/Modules/Tests/WordPressCoreTests/MockWordPressClientAPI.swift
+++ b/Modules/Tests/WordPressCoreTests/MockWordPressClientAPI.swift
@@ -92,7 +92,7 @@ final class MockWordPressClientAPI: WordPressClientAPI, @unchecked Sendable {
 
 // MARK: - Mock Executors
 
-final class MockApiRootRequestExecutor: ApiRootRequestExecutor {
+final class MockApiRootRequestExecutor: ApiRootRequestExecutor, @unchecked Sendable {
     private var routes: Set<String>
 
     init(routes: Set<String>) {
@@ -112,7 +112,7 @@ final class MockApiRootRequestExecutor: ApiRootRequestExecutor {
     }
 }
 
-final class MockUsersRequestExecutor: UsersRequestExecutor {
+final class MockUsersRequestExecutor: UsersRequestExecutor, @unchecked Sendable {
     override init(noHandle: UsersRequestExecutor.NoHandle) {
         super.init(noHandle: noHandle)
     }
@@ -148,7 +148,7 @@ final class MockUsersRequestExecutor: UsersRequestExecutor {
     }
 }
 
-final class MockThemesRequestExecutor: ThemesRequestExecutor {
+final class MockThemesRequestExecutor: ThemesRequestExecutor, @unchecked Sendable {
     private var isBlockTheme: Bool
 
     init(isBlockTheme: Bool) {
@@ -191,7 +191,7 @@ final class MockThemesRequestExecutor: ThemesRequestExecutor {
     }
 }
 
-final class MockSiteSettingsRequestExecutor: SiteSettingsRequestExecutor {
+final class MockSiteSettingsRequestExecutor: SiteSettingsRequestExecutor, @unchecked Sendable {
     override init(noHandle: SiteSettingsRequestExecutor.NoHandle) {
         super.init(noHandle: noHandle)
     }
@@ -235,7 +235,7 @@ final class MockSiteSettingsRequestExecutor: SiteSettingsRequestExecutor {
     }
 }
 
-final class MockWpApiDetails: WpApiDetails {
+final class MockWpApiDetails: WpApiDetails, @unchecked Sendable {
     private var routes: Set<String>
 
     init(routes: Set<String>) {

--- a/Modules/Tests/WordPressCoreTests/WordPressClientFeatureTests.swift
+++ b/Modules/Tests/WordPressCoreTests/WordPressClientFeatureTests.swift
@@ -26,7 +26,7 @@ struct WordPressClientCachingTests {
         mockAPI.mockRoutes = ["/wp-block-editor/v1/settings"]
         mockAPI.mockIsBlockTheme = true
 
-        let client = try WordPressClient(api: mockAPI, siteURL: URL(string: "https://example.com")!)
+        let client = WordPressClient(api: mockAPI, siteURL: URL(string: "https://example.com")!)
 
         // First call - should trigger API fetches
         let result1 = try await client.supports(.blockEditorSettings)
@@ -61,7 +61,7 @@ struct WordPressClientCachingTests {
         let mockAPI = MockWordPressClientAPI()
         mockAPI.mockRoutes = ["/wp-block-editor/v1/sites/12345/settings"]
 
-        let client = try WordPressClient(api: mockAPI, siteURL: URL(string: "https://example.com")!)
+        let client = WordPressClient(api: mockAPI, siteURL: URL(string: "https://example.com")!)
 
         // Call with siteId
         let result = try await client.supports(.blockEditorSettings, forSiteId: 12345)
@@ -81,7 +81,7 @@ struct WordPressClientCachingTests {
         mockAPI.mockRoutes = ["/wp-block-editor/v1/settings", "/wp/v2/plugins"]
         mockAPI.mockIsBlockTheme = true
 
-        let client = try WordPressClient(api: mockAPI, siteURL: URL(string: "https://example.com")!)
+        let client = WordPressClient(api: mockAPI, siteURL: URL(string: "https://example.com")!)
 
         // Make multiple concurrent calls
         async let result1 = client.supports(.blockEditorSettings)


### PR DESCRIPTION
## Description

The cross-platform `swift test` job added in #25344 surfaces a handful of warnings that the iOS app build hides — Xcode suppresses warnings from SPM package dependencies, and `WordPressCore` / `WordPressCoreTests` build in **Swift 6 language mode** (neither package sets `.swiftLanguageMode(.v5)` on them). This clears the first-party ones. All are dead code or a missing conformance — no behavior change.

### 1. Dead `await` — `UserService.fetchUsers()`
`users.sequenceWithEditContext(params:)` builds a `PaginationSequence` **synchronously**; the `async throws` is on iteration (`for try await`), not construction. Dropped the `await`.

### 2. Dead `try` ×3 — `WordPressClientFeatureTests`
`WordPressClient(api:siteURL:)` is **non-throwing**. Dropped the three `try`; each test keeps its other `try await client.supports(…)` calls, so `throws` stays justified.

### 3. Missing `@unchecked Sendable` restatement ×5 — `MockWordPressClientAPI`
The five mock executors subclass wordpress-rs's `@unchecked Sendable` base classes; Swift 6 requires **restating** the conformance on the subclass. Their added stored properties (`routes` / `isBlockTheme`) are set-in-init and read-only, so `@unchecked` is honest.

All three are correct for iOS too — same sources, same `wordpress-rs` binary, no platform conditionals.

The remaining `swiftsoup` "unhandled files" warning is upstream and handled separately in #25811.

## Testing instructions

- [x] `swift test` (cross-platform package) — 128 tests pass and the three first-party warning classes above are gone. (The upstream `swiftsoup` warning still shows on this branch; #25811 removes it.)
- [ ] CI — Swift Package Tests, plus WordPress/Jetpack Unit Tests (`WordPressCoreTests` runs in both).

## Related

- Follows up #25344 (its stated next step: "clean up `swift test` warnings")
- Sibling of #25811 (SwiftSoup bump — the upstream warning)
