### PR TITLE
Update `swift-log` from `1.6.2` to `1.14.0`

### DIFF
--- a/Modules/Package.resolved
+++ b/Modules/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "dda5c0004d2c337ca5d411fa9c103eb10933935ce58df86451e2786492abcd51",
+  "originHash" : "394a1dae231289152fc0a7f94cfb495587468c99f146311d7a94ac6a25772e0b",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -289,10 +289,10 @@
     {
       "identity" : "swift-log",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-log",
+      "location" : "https://github.com/apple/swift-log.git",
       "state" : {
-        "revision" : "96a2f8a0fa41e9e09af4585e2724c4e825410b91",
-        "version" : "1.6.2"
+        "revision" : "a878e7f8f46cfc0e1125e565b5c08e7d5272dc9a",
+        "version" : "1.14.0"
       }
     },
     {


### PR DESCRIPTION
## Description

Bumps `swift-log` from `1.6.2` to `1.14.0` (latest) in the app dependency graph.

`swift-log` is constrained `from: "1.5.2"` in `Modules/Package.swift`, so this is a resolved-file-only change — no manifest edit. Only `Modules/Package.resolved` moves; the root cross-platform harness (`Package.resolved`) already resolves `swift-log` at `1.14.0`, so the app graph was simply behind it.

- Stays within the current major (`1.x`) — no source changes. Our only call surface is `WordPress/Classes/System/Logging.swift` (`Logger`, `Logger.Level`), unchanged across `1.6`→`1.14`.
- `swift-log` has no dependencies of its own, so nothing else in the graph moves.

> **Merge order:** #25821 (`CocoaLumberjack` → 3.9.1) is stacked on this branch — CocoaLumberjack 3.9.1 raises its `swift-log` floor to `from: "1.11.0"`, so it can't resolve until this lands. Please merge this one first; #25821 retargets to `trunk` automatically afterward.

## Changelog

Highlights across `1.6.3`–`1.14.0` (16 releases — [full history](https://github.com/apple/swift-log/releases)):

- **New APIs (all additive):** `InMemoryLogHandler` (1.7.0); `Logger.Level` now conforms to `CustomStringConvertible`/`LosslessStringConvertible` (1.8.0); standardized error-metadata convenience (`SLG-0003`, 1.12.0); metadata value attributes (`SLG-0004`, 1.13.0); task-local logger (`SLG-0006`, 1.14.0); compile-time log-level elimination via package traits (`SLG-0002`, 1.8–1.9).
- **Toolchain floor raised:** dropped Swift 5.9/5.10 (1.7.0), then Swift 6.0 (1.12.0). We build on Swift 6.1+, so unaffected.
- **Source-breaking note (1.13.0):** `MetadataValue` compatibility with *custom* string interpolations changed ([#467](https://github.com/apple/swift-log/issues/467)), with follow-up interpolation overloads in 1.13.1/1.13.2. Our usage is plain `Logger` logging via `Logging.swift`, not custom `MetadataValue` interpolation — not affected.
- Strict-concurrency hardening and broader platform support (Android, FreeBSD/OpenBSD, Wasm).

## Testing instructions

- [x] `swift package update` resolves cleanly; the diff is `swift-log`-only.
- [x] **CI — WordPress + Jetpack iOS builds** — green on CI.
- [x] **CI — Unit Tests** exercise logging through `Logging.swift`.

## Related

- Continues the dependency-drift cleanup started in #25811 (`SwiftSoup`).
- #25821 (`CocoaLumberjack` → 3.9.1) is stacked on this PR and depends on it landing first.

