### PR TITLE
Update `swift-collections` from `1.1.4` to `1.6.0`

### DIFF
--- a/Modules/Package.resolved
+++ b/Modules/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "dda5c0004d2c337ca5d411fa9c103eb10933935ce58df86451e2786492abcd51",
+  "originHash" : "394a1dae231289152fc0a7f94cfb495587468c99f146311d7a94ac6a25772e0b",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -282,8 +282,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections",
       "state" : {
-        "revision" : "671108c96644956dddcd89dd59c203dcdb36cec7",
-        "version" : "1.1.4"
+        "revision" : "a0cb0954ecb21e4e31b0070e6ed5674e8556685a",
+        "version" : "1.6.0"
       }
     },
     {


### PR DESCRIPTION
## Description

Bumps `swift-collections` from `1.1.4` to `1.6.0` (latest) in the app dependency graph.

`swift-collections` is constrained `from: "1.0.0"` in `Modules/Package.swift`, so this is a resolved-file-only change — no manifest edit. Only `Modules/Package.resolved` moves; the root cross-platform harness (`Package.resolved`) already resolves it at `1.6.0`, so the app graph was behind.

- Stays within the current major (`1.x`) — no source changes. Consumed by `AsyncImageKit` via the `Collections` product (`OrderedSet`/`OrderedDictionary`), API-stable across `1.1`→`1.6`.
- Apple package with no third-party dependencies of its own.

## Changelog

Highlights across `1.1.5`–`1.6.0` ([full history](https://github.com/apple/swift-collections/releases)):

- **`OrderedSet`/`OrderedDictionary` additions:** `appending(contentsOf:)` (1.2.0), `replaceElement(at:withKey:value:)` (1.5.0), and element-move operations `moveSubrange(_:to:)` / `move(members:to:)` / `move(indices:to:)` (1.6.0).
- Other additive features: `Heap.removeAll(where:)` (1.2.0); `BitSet.makeIterator(from:)` (1.5.0); new ownership-aware container modules (`BasicContainers` with `UniqueArray`/`RigidArray`, `UniqueDeque`/`RigidDeque`) behind their own modules/traits — not imported here.
- Compiles warning-free under Swift 6.0/6.1; LLDB formatters added.
- **Fixed** a source-breaking regression in the `Collections` umbrella import introduced in 1.4.0 — resolved in 1.5.1 ([#654](https://github.com/apple/swift-collections/pull/654)); 1.6.0 is past it.

## Testing instructions

- [x] `swift package update` resolves cleanly; the diff is `swift-collections`-only.
- [x] **CI — WordPress + Jetpack iOS builds** — green on CI.
- [x] **CI — Unit Tests** — `AsyncImageKitTests` exercises the image cache that uses `Collections`.

## Related

- Continues the dependency-drift cleanup started in #25811 (`SwiftSoup`).


