### PR TITLE
Update `Pulse` from `5.1.4` to `5.2.3`

### DIFF
--- a/Modules/Package.resolved
+++ b/Modules/Package.resolved
@@ -210,8 +210,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/kean/Pulse",
       "state" : {
-        "revision" : "6125ce7fb51b114ba71b761d18cfd5557923bd4d",
-        "version" : "5.1.4"
+        "revision" : "94b92731d370c129bb771e9c18f69b0a44ccca5c",
+        "version" : "5.2.3"
       }
     },
     {


### PR DESCRIPTION
## Description

Bumps `Pulse` from `5.1.4` to `5.2.3` (latest) in the app dependency graph.

`Pulse` is constrained `from: "5.0.0"` in `Modules/Package.swift`, so this is a resolved-file-only change — no manifest edit. Only `Modules/Package.resolved` moves; the pin is taken verbatim from the root cross-platform harness (`Package.resolved`), which already resolves `Pulse` at `5.2.3`.

- Minor/patch releases within the current major (`5.x`) — no API changes, no source changes. Consumed via the `Pulse`/`PulseUI` products for network-request logging.
- No new transitive dependencies.

## Changelog

`5.2.0`–`5.2.3` ([full history](https://github.com/kean/Pulse/releases)):

- **5.2.0:** major console search/filter overhaul (off-main-thread search engine, incremental/cancelable results, richer suggestions and scopes); Liquid Glass groundwork. **Removed CocoaPods support and pre-built binaries** — we consume Pulse via SPM, so no impact.
- **5.2.1:** fixes a crash on the **iOS 26 Simulator** where app-icon assets fail to rasterize (`NSInternalInconsistencyException`) — relevant given we build against iOS 26.
- **5.2.2 / 5.2.3:** fix a `SIGTRAP` in `NetworkTaskEntity.state`, faster large-response-body text search, an app-icon graphics-context fix, and a `RichTextView` share/copy empty-content fix.
- Developer-facing network-logging tool only.

## Testing instructions

- [x] Pin transplanted from the already-resolved root harness (`5.2.3`); the diff is `Pulse`-only.
- [x] **CI — WordPress + Jetpack iOS builds** — green on CI.
- [x] **CI — Unit Tests**.

## Related

- Continues the dependency-drift cleanup started in #25811 (`SwiftSoup`).


