### PR TITLE
Update `lottie-ios` from `4.5.1` to `4.6.1`

### DIFF
--- a/Modules/Package.resolved
+++ b/Modules/Package.resolved
@@ -140,8 +140,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/airbnb/lottie-ios",
       "state" : {
-        "revision" : "047aa81b77adcbf583a966dfef620d17650cc656",
-        "version" : "4.5.1"
+        "revision" : "f4db77d7feacba0c2360b84a40c38a6ce8ff399d",
+        "version" : "4.6.1"
       }
     },
     {


### PR DESCRIPTION
## Description

Bumps `lottie-ios` from `4.5.1` to `4.6.1` (latest) in the app dependency graph.

`lottie-ios` is constrained `from: "4.4.0"` in `Modules/Package.swift`, so this is a resolved-file-only change — no manifest edit. Only `Modules/Package.resolved` moves; the pin is taken verbatim from the root cross-platform harness (`Package.resolved`), which already resolves `lottie-ios` at `4.6.1`.

- Minor/patch releases within the current major (`4.x`) — no API changes, no source changes. Consumed via the `Lottie` product for animated UI.
- No new transitive dependencies.

## Changelog

`4.5.2`–`4.6.1` ([full history](https://github.com/airbnb/lottie-ios/releases)):

- **New:** `.lottie` v2 file-format support (4.5.2); `LottieURLSession` protocol to disable network requests (4.6.0); dynamic text color & stroke support (4.6.0); Obj-C-compatible font/image providers (4.6.1); `.lot` IANA extension recognition (4.6.1).
- **Fixes:** several crash fixes (division-by-zero in `LottieAnimationHelpers` / gradient providers), justified-text parse fix, SwiftUI animation-state-lost-on-window-removal fix, `currentFrame` rounding, main-thread render-system perf, and mask-timing on precomp layers.
- **4.6.0 raises the floor to Xcode 16 / Swift 6.0+** (we're past that).
- 4.6.1 bumps Lottie's *embedded* copy of ZIPFoundation to 0.9.20 for symlink path-traversal hardening — independent of our top-level ZIPFoundation pin.

## Testing instructions

- [x] Pin transplanted from the already-resolved root harness (`4.6.1`); the diff is `lottie-ios`-only.
- [x] **CI — WordPress + Jetpack iOS builds** — green on CI.
- [x] **CI — Unit Tests**.

## Related

- Continues the dependency-drift cleanup started in #25811 (`SwiftSoup`).


