### PR TITLE
Update `CocoaLumberjack` from `3.8.5` to `3.9.1`

### DIFF
--- a/Modules/Package.resolved
+++ b/Modules/Package.resolved
@@ -51,8 +51,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/CocoaLumberjack/CocoaLumberjack",
       "state" : {
-        "revision" : "4b8714a7fb84d42393314ce897127b3939885ec3",
-        "version" : "3.8.5"
+        "revision" : "c5f2ed4d219866117e135cf648180dc7b66739d3",
+        "version" : "3.9.1"
       }
     },
     {


### PR DESCRIPTION
## Description

Bumps `CocoaLumberjack` from `3.8.5` to `3.9.1` (latest) in the app dependency graph.

`CocoaLumberjack` is constrained `from: "3.8.5"` in `Modules/Package.swift`, so this is a resolved-file-only change — no manifest edit. Only `Modules/Package.resolved` moves; the pin is taken verbatim from the root cross-platform harness (`Package.resolved`), which already resolves it at `3.9.1`.

- Minor/patch releases within the current major (`3.x`) — no API changes, no source changes on our side. Consumed via the `CocoaLumberjack`, `CocoaLumberjackSwift`, and `CocoaLumberjackSwiftLogBackend` products (extensions link the ObjC variant to avoid symbol-collision issues).

> **Stacked on #25816.** CocoaLumberjack `3.9.1` raises its own `swift-log` floor to `from: "1.11.0"` and updates its `swift-log` backend for the new log-event API, so it cannot resolve against our current `swift-log 1.6.2`. This branch is therefore based on the `swift-log → 1.14.0` branch (#25816) and must merge after it — GitHub retargets this to `trunk` automatically once #25816 lands. The diff here is CocoaLumberjack-only.

## Changelog

`3.9.0`–`3.9.1` ([full history](https://github.com/CocoaLumberjack/CocoaLumberjack/releases)):

- **3.9.0:** Swift 6.0/6.1 support and concurrency-warning fixes; visionOS support; drops pre-5.10 Swift; `DDFileLogger` file locking is now optional; `DDLogFileManager` accepts a custom `NSFileManager`.
- **3.9.1:** Swift 6.2/6.3 support (drops 5.10); build-warning cleanup for newer Xcodes. **Raises its `swift-log` dependency to `from: "1.11.0"`** and updates its `swift-log` backend for the new log-event API — the coupling that requires #25816.

## Testing instructions

- [x] Pin transplanted from the already-resolved root harness (`3.9.1`); branch rebased on #25816 so the graph resolves (`swift-log 1.14.0` satisfies CocoaLumberjack's `from: "1.11.0"`).
- [x] **CI — WordPress + Jetpack iOS builds** — green on CI (first run hit a flaky `BlogBuilder` test-host crash, unrelated to this bump; clean on retry).
- [x] **CI — Unit Tests**.

## Related

- Continues the dependency-drift cleanup started in #25811 (`SwiftSoup`).
- Stacked on #25816 (`swift-log` → 1.14.0).


