### PR TITLE
Update `ZIPFoundation` from `0.9.19` to `0.9.20`

### DIFF
--- a/Modules/Package.resolved
+++ b/Modules/Package.resolved
@@ -354,8 +354,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/weichsel/ZIPFoundation",
       "state" : {
-        "revision" : "02b6abe5f6eef7e3cbd5f247c5cc24e246efcfe0",
-        "version" : "0.9.19"
+        "revision" : "22787ffb59de99e5dc1fbfe80b19c97a904ad48d",
+        "version" : "0.9.20"
       }
     }
   ],


### PR DESCRIPTION
## Description

Bumps `ZIPFoundation` from `0.9.19` to `0.9.20` (latest) in the app dependency graph.

`ZIPFoundation` is constrained `from: "0.9.19"` in `Modules/Package.swift`, so this is a resolved-file-only change — no manifest edit. Only `Modules/Package.resolved` moves; the pin is taken verbatim from the root cross-platform harness (`Package.resolved`), which already resolves it at `0.9.20`.

- A single patch release — no API changes, no source changes. Consumed via the `ZIPFoundation` product by the Share and Draft Action extensions.
- No new transitive dependencies.

## Changelog

`0.9.20` ([release notes](https://github.com/weichsel/ZIPFoundation/releases/tag/0.9.20)):

- **Added:** file-modification-date attributes and code-page-437 path decoding on non-Darwin platforms.
- **Fixed:** resource leak in `Archive.makeBackingConfiguration`, memory leak in `Data.readChunk`, a memory-alignment crash in debug builds, the privacy-manifest API-reason ID, and error handling in `MemoryFile` / `ftello`.
- Pure fix/robustness release; no API changes.

## Testing instructions

- [x] Pin transplanted from the already-resolved root harness (`0.9.20`); the diff is `ZIPFoundation`-only.
- [x] **CI — WordPress + Jetpack iOS builds** — green on CI.
- [x] **CI — Unit Tests**.

## Related

- Continues the dependency-drift cleanup started in #25811 (`SwiftSoup`).


