### PR TITLE
Update `Gifu` from `3.4.1` to `3.5.1`

### DIFF
--- a/Modules/Package.resolved
+++ b/Modules/Package.resolved
@@ -104,8 +104,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/kaishin/Gifu",
       "state" : {
-        "revision" : "82da0086dea14ca9afc9801234ad8dc4cd9e2738",
-        "version" : "3.4.1"
+        "revision" : "46434cd816f035271beb16d80f7bc91381cbd8e4",
+        "version" : "3.5.1"
       }
     },
     {


### PR DESCRIPTION
## Description

Bumps `Gifu` from `3.4.1` to `3.5.1` (latest `3.x`) in the app dependency graph.

`Gifu` is constrained `from: "3.4.1"` in `Modules/Package.swift`, so this is a resolved-file-only change — no manifest edit. Only `Modules/Package.resolved` moves; the pin is taken verbatim from the root cross-platform harness (`Package.resolved`), which already resolves `Gifu` at `3.5.1`.

- A single minor release within the current major (`3.x`) — no API changes, no source changes. Consumed by `AsyncImageKit` via the `Gifu` product for animated-GIF rendering.
- No new transitive dependencies.

**Scope note:** `Gifu 4.0.0` is available but is a major release; the `from: "3.4.1"` constraint intentionally caps below it. Moving to `4.x` needs a manifest constraint change plus `AsyncImageKit` source changes, so it's deliberately left as a separate follow-up — this PR just clears the in-range drift.

## Changelog

`3.5.0`–`3.5.1` (no formal upstream release notes; from the [commit log](https://github.com/kaishin/Gifu/compare/3.4.1...3.5.1)):

- **Added visionOS support.**
- Introduced a `FrameCachingStrategy` enum ([#195](https://github.com/kaishin/Gifu/pull/195)) for tuning frame-cache behavior.
- `existential any` fix ([#199](https://github.com/kaishin/Gifu/pull/199)) plus CI/demo/README housekeeping.
- No API removals; additive within `3.x`.

## Testing instructions

- [x] Pin transplanted from the already-resolved root harness (`3.5.1`); the diff is `Gifu`-only.
- [x] **CI — WordPress + Jetpack iOS builds** — green on CI.
- [x] **CI — Unit Tests** — `AsyncImageKitTests`.

## Related

- Continues the dependency-drift cleanup started in #25811 (`SwiftSoup`).


