### PR TITLE
Convert the cross-platform `swift test` suites from XCTest to Swift Testing

### DIFF
--- a/Modules/Tests/GutenbergProcessorsTests/GutenbergContentParserTests.swift
+++ b/Modules/Tests/GutenbergProcessorsTests/GutenbergContentParserTests.swift
@@ -1,8 +1,8 @@
-import XCTest
+import Testing
 @testable import GutenbergProcessors
 import SwiftSoup
 
-class GutenbergContentParserTests: XCTestCase {
+struct GutenbergContentParserTests {
     let singleBlock = """
         <!-- wp:block {"id":1} -->
         <div class="wp-block"><p>Hello world!</p></div>
@@ -33,7 +33,7 @@ class GutenbergContentParserTests: XCTestCase {
         <!-- /wp:parent-block -->
         """
 
-    func testParserSingleBlock() {
+    @Test func testParserSingleBlock() {
         let parser = GutenbergContentParser(for: singleBlock)
         let blocks = parser.blocks
 
@@ -41,21 +41,21 @@ class GutenbergContentParserTests: XCTestCase {
             <div class="wp-block"><p>Hello world!</p></div>
             """
 
-        XCTAssertEqual(blocks.count, 1, "Should return one block")
+        #expect(blocks.count == 1, "Should return one block")
 
-        XCTAssertEqual(blocks[0].name, "wp:block", "Name should match block's name")
-        XCTAssertEqual(blocks[0].content, expectedBlockContent, "Content should match block's content")
-        XCTAssertEqual(blocks[0].attributes.count, 1, "Attributes should contain one item")
-        XCTAssertEqual(blocks[0].attributes["id"] as? Int, 1, "Id attribute matches block's attribute")
-        XCTAssertEqual(blocks[0].blocks.count, 0, "Shouldn't contain nested blocks")
+        #expect(blocks[0].name == "wp:block", "Name should match block's name")
+        #expect(blocks[0].content == expectedBlockContent, "Content should match block's content")
+        #expect(blocks[0].attributes.count == 1, "Attributes should contain one item")
+        #expect((blocks[0].attributes["id"] as? Int) == 1, "Id attribute matches block's attribute")
+        #expect(blocks[0].blocks.isEmpty, "Shouldn't contain nested blocks")
     }
 
-    func testParserSingleBlockToHTML() {
+    @Test func testParserSingleBlockToHTML() {
         let parser = GutenbergContentParser(for: singleBlock)
-        XCTAssertEqual(parser.html(), singleBlock, "Parsed content should match the original HTML")
+        #expect(parser.html() == singleBlock, "Parsed content should match the original HTML")
     }
 
-    func testParserNestedBlock() {
+    @Test func testParserNestedBlock() {
         let parser = GutenbergContentParser(for: nestedBlock)
         let blocks = parser.blocks
 
@@ -91,47 +91,45 @@ class GutenbergContentParserTests: XCTestCase {
         let nestedBlock1 = parentBlock.blocks[0]
         let nestedBlock2 = parentBlock.blocks[1]
 
-        XCTAssertEqual(blocks.count, 3, "Should return parent block and nested blocks")
-        XCTAssertEqual(blocks[1].content, nestedBlock1.content, "Nested block is present at root level")
-        XCTAssertEqual(blocks[2].content, nestedBlock2.content, "Nested block is present at root level")
+        #expect(blocks.count == 3, "Should return parent block and nested blocks")
+        #expect(blocks[1].content == nestedBlock1.content, "Nested block is present at root level")
+        #expect(blocks[2].content == nestedBlock2.content, "Nested block is present at root level")
 
-        XCTAssertEqual(parentBlock.name, "wp:parent-block", "Name should match block's name")
-        XCTAssertEqual(parentBlock.content, expectedParentBlockContent, "Content should match block's content")
-        XCTAssertEqual(parentBlock.attributes.count, 1, "Attributes should contain one item")
-        XCTAssertEqual(parentBlock.attributes["name"] as? String, "parent", "Name attribute matches block's attribute")
-        XCTAssertEqual(parentBlock.blocks.count, 2, "Should contain nested blocks")
+        #expect(parentBlock.name == "wp:parent-block", "Name should match block's name")
+        #expect(parentBlock.content == expectedParentBlockContent, "Content should match block's content")
+        #expect(parentBlock.attributes.count == 1, "Attributes should contain one item")
+        #expect((parentBlock.attributes["name"] as? String) == "parent", "Name attribute matches block's attribute")
+        #expect(parentBlock.blocks.count == 2, "Should contain nested blocks")
 
-        XCTAssertEqual(nestedBlock1.name, "wp:nested-block", "Name should match block's name")
-        XCTAssertEqual(nestedBlock1.content, expectedNestedBlock1Content, "Content should match block's content")
-        XCTAssertEqual(nestedBlock1.attributes.count, 2, "Attributes should contain two items")
-        XCTAssertEqual(nestedBlock1.attributes["id"] as? Int, 1, "Id attribute matches block's attribute")
-        XCTAssertEqual(nestedBlock1.attributes["name"] as? String, "block1", "Name attribute matches block's attribute")
-        XCTAssertEqual(nestedBlock1.blocks.count, 0, "Shouldn't contain nested blocks")
-        XCTAssertEqual(
-            nestedBlock1.parentBlock?.content,
-            parentBlock.content,
+        #expect(nestedBlock1.name == "wp:nested-block", "Name should match block's name")
+        #expect(nestedBlock1.content == expectedNestedBlock1Content, "Content should match block's content")
+        #expect(nestedBlock1.attributes.count == 2, "Attributes should contain two items")
+        #expect((nestedBlock1.attributes["id"] as? Int) == 1, "Id attribute matches block's attribute")
+        #expect((nestedBlock1.attributes["name"] as? String) == "block1", "Name attribute matches block's attribute")
+        #expect(nestedBlock1.blocks.isEmpty, "Shouldn't contain nested blocks")
+        #expect(
+            nestedBlock1.parentBlock?.content == parentBlock.content,
             "Should have a parent block and matches parent's content"
         )
 
-        XCTAssertEqual(nestedBlock2.name, "wp:nested-block", "Name should match block's name")
-        XCTAssertEqual(nestedBlock2.content, expectedNestedBlock2Content, "Content should match block's content")
-        XCTAssertEqual(nestedBlock2.attributes.count, 2, "Attributes should contain two items")
-        XCTAssertEqual(nestedBlock2.attributes["id"] as? Int, 2, "Id attribute matches block's attribute")
-        XCTAssertEqual(nestedBlock2.attributes["name"] as? String, "block2", "Name attribute matches block's attribute")
-        XCTAssertEqual(nestedBlock2.blocks.count, 0, "Shouldn't contain nested blocks")
-        XCTAssertEqual(
-            nestedBlock2.parentBlock?.content,
-            parentBlock.content,
+        #expect(nestedBlock2.name == "wp:nested-block", "Name should match block's name")
+        #expect(nestedBlock2.content == expectedNestedBlock2Content, "Content should match block's content")
+        #expect(nestedBlock2.attributes.count == 2, "Attributes should contain two items")
+        #expect((nestedBlock2.attributes["id"] as? Int) == 2, "Id attribute matches block's attribute")
+        #expect((nestedBlock2.attributes["name"] as? String) == "block2", "Name attribute matches block's attribute")
+        #expect(nestedBlock2.blocks.isEmpty, "Shouldn't contain nested blocks")
+        #expect(
+            nestedBlock2.parentBlock?.content == parentBlock.content,
             "Should have a parent block and matches parent's content"
         )
     }
 
-    func testParserNestedBlockToHTML() {
+    @Test func testParserNestedBlockToHTML() {
         let parser = GutenbergContentParser(for: nestedBlock)
-        XCTAssertEqual(parser.html(), nestedBlock, "Parsed content should match the original HTML")
+        #expect(parser.html() == nestedBlock, "Parsed content should match the original HTML")
     }
 
-    func testParserModifyAttributes() {
+    @Test func testParserModifyAttributes() {
         let parser = GutenbergContentParser(for: nestedBlock)
         let blocks = parser.blocks
         let parentBlock = blocks[0]
@@ -162,10 +160,10 @@ class GutenbergContentParserTests: XCTestCase {
             <!-- /wp:parent-block -->
             """
 
-        XCTAssertEqual(parser.html(), expectedResult, "Parsed content should contain the modifications")
+        #expect(parser.html() == expectedResult, "Parsed content should contain the modifications")
     }
 
-    func testParserModifyHTML() {
+    @Test func testParserModifyHTML() {
         let parser = GutenbergContentParser(for: nestedBlock)
         let blocks = parser.blocks
         let parentBlock = blocks[0]
@@ -195,12 +193,12 @@ class GutenbergContentParserTests: XCTestCase {
             <!-- /wp:parent-block -->
             """
 
-        XCTAssertEqual(parser.html(), expectedResult, "Parsed content should contain the modifications")
+        #expect(parser.html() == expectedResult, "Parsed content should contain the modifications")
     }
 
     // MARK: - Serialization contract
 
-    func testVoidElementsAreSelfClosed() {
+    @Test func testVoidElementsAreSelfClosed() {
         let input = """
             <!-- wp:x -->
             <div><hr><input type="text" required></div>
@@ -211,57 +209,57 @@ class GutenbergContentParserTests: XCTestCase {
             <div><hr /><input type="text" required /></div>
             <!-- /wp:x -->
             """
-        XCTAssertEqual(GutenbergContentParser(for: input).html(), expected)
+        #expect(GutenbergContentParser(for: input).html() == expected)
     }
 
-    func testEntitiesArePreserved() {
+    @Test func testEntitiesArePreserved() {
         let content = """
             <!-- wp:x -->
             <a href="?a=1&amp;b=2">Fish &amp; chips</a>
             <!-- /wp:x -->
             """
-        XCTAssertEqual(GutenbergContentParser(for: content).html(), content)
+        #expect(GutenbergContentParser(for: content).html() == content)
     }
 
-    func testRawTextElementsAreNotEscaped() {
+    @Test func testRawTextElementsAreNotEscaped() {
         // Regressing here would corrupt Custom HTML / embedded scripts.
         let content = """
             <!-- wp:html -->
             <script>if (1 < 2 && 3 > 2) { doThing(); }</script>
             <!-- /wp:html -->
             """
-        XCTAssertTrue(GutenbergContentParser(for: content).html().contains("1 < 2 && 3 > 2"))
+        #expect(GutenbergContentParser(for: content).html().contains("1 < 2 && 3 > 2"))
     }
 
-    func testPreformattedWhitespaceIsPreserved() {
+    @Test func testPreformattedWhitespaceIsPreserved() {
         let content = """
             <!-- wp:preformatted -->
             <pre>line one
               indented	tabbed</pre>
             <!-- /wp:preformatted -->
             """
-        XCTAssertEqual(GutenbergContentParser(for: content).html(), content)
+        #expect(GutenbergContentParser(for: content).html() == content)
     }
 
-    func testUnicodeIsPreserved() {
+    @Test func testUnicodeIsPreserved() {
         let content = """
             <!-- wp:x -->
             <p>café ☕ 日本語 — Alşksdf</p>
             <!-- /wp:x -->
             """
-        XCTAssertEqual(GutenbergContentParser(for: content).html(), content)
+        #expect(GutenbergContentParser(for: content).html() == content)
     }
 
-    func testContentWithoutBlockCommentsIsPassedThrough() {
+    @Test func testContentWithoutBlockCommentsIsPassedThrough() {
         let content = "<p>hello world</p>"
-        XCTAssertEqual(GutenbergContentParser(for: content).html(), content)
+        #expect(GutenbergContentParser(for: content).html() == content)
     }
 
-    func testEmptyContentProducesEmptyOutput() {
-        XCTAssertTrue(GutenbergContentParser(for: "").html().isEmpty)
+    @Test func testEmptyContentProducesEmptyOutput() {
+        #expect(GutenbergContentParser(for: "").html().isEmpty)
     }
 
-    func testMultipleSiblingBlocksArePreserved() {
+    @Test func testMultipleSiblingBlocksArePreserved() {
         let content = """
             <!-- wp:a -->
             <p>one</p>
@@ -270,17 +268,17 @@ class GutenbergContentParserTests: XCTestCase {
             <p>two</p>
             <!-- /wp:b -->
             """
-        XCTAssertEqual(GutenbergContentParser(for: content).html(), content)
+        #expect(GutenbergContentParser(for: content).html() == content)
     }
 
-    func testHTMLIsIdempotent() {
+    @Test func testHTMLIsIdempotent() {
         let parser = GutenbergContentParser(for: singleBlock)
-        XCTAssertEqual(parser.html(), parser.html())
+        #expect(parser.html() == parser.html())
     }
 
     // MARK: - Mutation propagation (SwiftSoup 2.12+ serialization-cache regression)
 
-    func testModifyNestedElementAttribute() throws {
+    @Test func testModifyNestedElementAttribute() throws {
         // The mutated <img> is nested inside <figure>; unlike a top-level element,
         // its change is dropped by SwiftSoup 2.12+ unless html() re-renders it.
         let parser = GutenbergContentParser(
@@ -290,15 +288,15 @@ class GutenbergContentParserTests: XCTestCase {
                 <!-- /wp:image -->
                 """
         )
-        let image = try XCTUnwrap(parser.blocks.first?.elements.select("img").first())
+        let image = try #require(parser.blocks.first?.elements.select("img").first())
         try image.attr("src", "https://example.com/new.jpg")
 
         let output = parser.html()
-        XCTAssertTrue(output.contains("src=\"https://example.com/new.jpg\""))
-        XCTAssertFalse(output.contains("local://old.jpg"))
+        #expect(output.contains("src=\"https://example.com/new.jpg\""))
+        #expect(!(output.contains("local://old.jpg")))
     }
 
-    func testModifyDeeplyNestedElement() throws {
+    @Test func testModifyDeeplyNestedElement() throws {
         let parser = GutenbergContentParser(
             for: """
                 <!-- wp:gallery -->
@@ -306,15 +304,15 @@ class GutenbergContentParserTests: XCTestCase {
                 <!-- /wp:gallery -->
                 """
         )
-        let image = try XCTUnwrap(parser.blocks.first?.elements.select("img").first())
+        let image = try #require(parser.blocks.first?.elements.select("img").first())
         try image.attr("src", "https://example.com/deep.jpg")
 
-        XCTAssertTrue(parser.html().contains("https://example.com/deep.jpg"))
+        #expect(parser.html().contains("https://example.com/deep.jpg"))
     }
 
     // MARK: - Attribute parsing
 
-    func testMissingAttributesParseToEmptyDictionary() throws {
+    @Test func testMissingAttributesParseToEmptyDictionary() throws {
         let parser = GutenbergContentParser(
             for: """
                 <!-- wp:spacer -->
@@ -322,10 +320,10 @@ class GutenbergContentParserTests: XCTestCase {
                 <!-- /wp:spacer -->
                 """
         )
-        XCTAssertTrue(try XCTUnwrap(parser.blocks.first).attributes.isEmpty)
+        #expect(try #require(parser.blocks.first).attributes.isEmpty)
     }
 
-    func testMalformedAttributesParseToEmptyDictionary() throws {
+    @Test func testMalformedAttributesParseToEmptyDictionary() throws {
         let parser = GutenbergContentParser(
             for: """
                 <!-- wp:x {not valid json} -->
@@ -333,10 +331,10 @@ class GutenbergContentParserTests: XCTestCase {
                 <!-- /wp:x -->
                 """
         )
-        XCTAssertTrue(try XCTUnwrap(parser.blocks.first).attributes.isEmpty)
+        #expect(try #require(parser.blocks.first).attributes.isEmpty)
     }
 
-    func testWrittenAttributesEscapeSlashesAndSortKeys() throws {
+    @Test func testWrittenAttributesEscapeSlashesAndSortKeys() throws {
         let parser = GutenbergContentParser(
             for: """
                 <!-- wp:file -->
@@ -344,8 +342,8 @@ class GutenbergContentParserTests: XCTestCase {
                 <!-- /wp:file -->
                 """
         )
-        try XCTUnwrap(parser.blocks.first).attributes = ["id": 100, "href": "https://example.com/f.pdf"]
+        try #require(parser.blocks.first).attributes = ["id": 100, "href": "https://example.com/f.pdf"]
         // JSONSerialization `.sortedKeys` orders "href" before "id" and escapes slashes.
-        XCTAssertTrue(parser.html().contains(#"{"href":"https:\/\/example.com\/f.pdf","id":100}"#))
+        #expect(parser.html().contains(#"{"href":"https:\/\/example.com\/f.pdf","id":100}"#))
     }
 }

--- a/Modules/Tests/GutenbergProcessorsTests/GutenbergFileUploadProcessorTests.swift
+++ b/Modules/Tests/GutenbergProcessorsTests/GutenbergFileUploadProcessorTests.swift
@@ -1,7 +1,7 @@
-import XCTest
+import Testing
 @testable import GutenbergProcessors
 
-class GutenbergFileUploadProcessorTests: XCTestCase {
+struct GutenbergFileUploadProcessorTests {
 
     let postContent = """
 <!-- wp:file {"id":-1626352752,"href":"file://file.pdf"} -->
@@ -15,7 +15,7 @@ class GutenbergFileUploadProcessorTests: XCTestCase {
 <!-- /wp:file -->
 """
 
-    func testFileBlockProcessor() {
+    @Test func testFileBlockProcessor() {
         let gutenbergMediaUploadID = Int32(-1626352752)
         let mediaID = 100
         let remoteURLStr = "http://www.wordpress.com/file.pdf"
@@ -25,6 +25,6 @@ class GutenbergFileUploadProcessorTests: XCTestCase {
         let parser = GutenbergContentParser(for: postContent)
         gutenbergFilePostUploadProcessor.process(parser.blocks)
 
-        XCTAssertEqual(parser.html(), postResultContent, "Post content should be updated correctly")
+        #expect(parser.html() == postResultContent, "Post content should be updated correctly")
     }
 }

--- a/Modules/Tests/GutenbergProcessorsTests/GutenbergGalleryUploadProcessorTests.swift
+++ b/Modules/Tests/GutenbergProcessorsTests/GutenbergGalleryUploadProcessorTests.swift
@@ -1,7 +1,7 @@
-import XCTest
+import Testing
 @testable import GutenbergProcessors
 
-class GutenbergGalleryUploadProcessorTests: XCTestCase {
+struct GutenbergGalleryUploadProcessorTests {
 
     let idVariations = [
         """
@@ -101,7 +101,7 @@ class GutenbergGalleryUploadProcessorTests: XCTestCase {
         let mediaLink: String
     }
 
-    func testGutenbergGalleryBlockProcessor() {
+    @Test func testGutenbergGalleryBlockProcessor() {
         let mediaJobs = [
             ImageUploadJob(uploadID: -708, serverID: 708, serverURL: "https://files.wordpress.com/708.jpg", mediaLink: "https://files.wordpress.com/?p=708"),
             ImageUploadJob(uploadID: -415, serverID: 415, serverURL: "https://files.wordpress.com/415.jpg", mediaLink: "https://files.wordpress.com/?p=415"),
@@ -115,7 +115,7 @@ class GutenbergGalleryUploadProcessorTests: XCTestCase {
                 processor.process(parser.blocks)
             }
 
-            XCTAssertEqual(parser.html(), postResultContent, "Post content should be updated correctly")
+            #expect(parser.html() == postResultContent, "Post content should be updated correctly")
         }
     }
 }

--- a/Modules/Tests/GutenbergProcessorsTests/GutenbergImgUploadProcessorTests.swift
+++ b/Modules/Tests/GutenbergProcessorsTests/GutenbergImgUploadProcessorTests.swift
@@ -1,7 +1,7 @@
-import XCTest
+import Testing
 @testable import GutenbergProcessors
 
-class GutenbergImgUploadProcessorTests: XCTestCase {
+struct GutenbergImgUploadProcessorTests {
 
     let postContent = """
 <!-- wp:image {"id":-181231834} -->
@@ -15,7 +15,7 @@ class GutenbergImgUploadProcessorTests: XCTestCase {
 <!-- /wp:image -->
 """
 
-    func testImgBlockProcessor() {
+    @Test func testImgBlockProcessor() {
         let gutenbergMediaUploadID = Int32(-181231834)
         let mediaID = 100
         let remoteURLStr = "http://www.wordpress.com/logo.jpg"
@@ -25,7 +25,7 @@ class GutenbergImgUploadProcessorTests: XCTestCase {
         let parser = GutenbergContentParser(for: postContent)
         gutenbergImgPostUploadProcessor.process(parser.blocks)
 
-        XCTAssertEqual(parser.html(), postResultContent, "Post content should be updated correctly")
+        #expect(parser.html() == postResultContent, "Post content should be updated correctly")
     }
 
     let postMediaBlockContent = """
@@ -44,7 +44,7 @@ class GutenbergImgUploadProcessorTests: XCTestCase {
     <!-- /wp:media-text -->
     """
 
-    func testMediaTextBlockProcessor() {
+    @Test func testMediaTextBlockProcessor() {
         let gutenbergMediaUploadID = Int32(-181231834)
         let mediaID = 100
         let remoteURLStr = "http://www.wordpress.com/logo.jpg"
@@ -54,6 +54,6 @@ class GutenbergImgUploadProcessorTests: XCTestCase {
         let parser = GutenbergContentParser(for: postMediaBlockContent)
         gutenbergImgPostUploadProcessor.process(parser.blocks)
 
-        XCTAssertEqual(parser.html(), postMediaBlockResultContent, "Post content should be updated correctly")
+        #expect(parser.html() == postMediaBlockResultContent, "Post content should be updated correctly")
     }
 }

--- a/Modules/Tests/GutenbergProcessorsTests/GutenbergRefactoredGalleryUploadProcessorTests.swift
+++ b/Modules/Tests/GutenbergProcessorsTests/GutenbergRefactoredGalleryUploadProcessorTests.swift
@@ -1,7 +1,7 @@
-import XCTest
+import Testing
 @testable import GutenbergProcessors
 
-class GutenbergRefactoredGalleryUploadProcessorTests: XCTestCase {
+struct GutenbergRefactoredGalleryUploadProcessorTests {
     struct ImageUploadJob {
         let localId: Int32
         let remoteId: Int
@@ -73,7 +73,7 @@ class GutenbergRefactoredGalleryUploadProcessorTests: XCTestCase {
     """
     }
 
-    func testRefactoredGalleryImageBlockProcessor() {
+    @Test func testRefactoredGalleryImageBlockProcessor() {
         let job = ImageUploadJob(localId: -123456789, remoteId: 123456789, localUrl: "file:///usr/temp/123.jpg", remoteURL: "https://files.wordpress.com/123.jpg", mediaLink: "https://files.wordpress.com/?p=123")
 
         let gutenbergImgPostUploadProcessor = GutenbergImgUploadProcessor(mediaUploadID: job.localId, serverMediaID: job.remoteId, remoteURLString: job.remoteURL)
@@ -87,10 +87,10 @@ class GutenbergRefactoredGalleryUploadProcessorTests: XCTestCase {
         let parser = GutenbergContentParser(for: refactoredGalleryContent)
         gutenbergImgPostUploadProcessor.process(parser.blocks)
 
-        XCTAssertEqual(parser.html(), refactoredGalleryResultContent, "Post content should be updated correctly")
+        #expect(parser.html() == refactoredGalleryResultContent, "Post content should be updated correctly")
     }
 
-    func testRefactoredGalleryBlockProcessor() {
+    @Test func testRefactoredGalleryBlockProcessor() {
         let mediaJobs = [
             ImageUploadJob(localId: -1, remoteId: 1, localUrl: "file:///usr/temp/1.jpg", remoteURL: "https://files.wordpress.com/1.jpg", mediaLink: "https://files.wordpress.com/?p=1"),
             ImageUploadJob(localId: -2, remoteId: 2, localUrl: "file:///usr/temp/2.jpg", remoteURL: "https://files.wordpress.com/2.jpg", mediaLink: "https://files.wordpress.com/?p=2"),
@@ -116,10 +116,10 @@ class GutenbergRefactoredGalleryUploadProcessorTests: XCTestCase {
             imageProcessor.process(blocks)
         }
 
-        XCTAssertEqual(parser.html(), galleryResultBlockContent, "Post content should be updated correctly")
+        #expect(parser.html() == galleryResultBlockContent, "Post content should be updated correctly")
     }
 
-    func testMixedOldRefactoredGalleryBlockProcessor() {
+    @Test func testMixedOldRefactoredGalleryBlockProcessor() {
         let mediaJobs = [
             ImageUploadJob(localId: -708, remoteId: 708, localUrl: "file:///usr/temp/image708.jpg", remoteURL: "https://files.wordpress.com/708.jpg", mediaLink: "https://files.wordpress.com/?p=708"),
             ImageUploadJob(localId: -1, remoteId: 1, localUrl: "file:///usr/temp/1.jpg", remoteURL: "https://files.wordpress.com/1.jpg", mediaLink: "https://files.wordpress.com/?p=1")
@@ -141,6 +141,6 @@ class GutenbergRefactoredGalleryUploadProcessorTests: XCTestCase {
             imageProcessor.process(blocks)
         }
 
-        XCTAssertEqual(parser.html(), postResultContent, "Post content should be updated correctly")
+        #expect(parser.html() == postResultContent, "Post content should be updated correctly")
     }
 }

--- a/Modules/Tests/JetpackStatsWidgetsCoreTests/ThisWeekWidgetStatsTests.swift
+++ b/Modules/Tests/JetpackStatsWidgetsCoreTests/ThisWeekWidgetStatsTests.swift
@@ -1,8 +1,9 @@
-import XCTest
+import Foundation
+import Testing
 import JetpackStatsWidgetsCore
 
-final class ThisWeekWidgetStatsTests: XCTestCase {
-    func testDaysFromSummaryData_moreSummaryData() {
+struct ThisWeekWidgetStatsTests {
+    @Test func testDaysFromSummaryData_moreSummaryData() {
         var summaryData: [ThisWeekWidgetStats.Input] = []
 
         // Given there's summary data for more than max days to display
@@ -13,10 +14,10 @@ final class ThisWeekWidgetStatsTests: XCTestCase {
         // Then the method should not crash
         // and return maxDaysToDisplay number of days
         let days = ThisWeekWidgetStats.daysFrom(summaryData: summaryData)
-        XCTAssertEqual(days.count, ThisWeekWidgetStats.maxDaysToDisplay)
+        #expect(days.count == ThisWeekWidgetStats.maxDaysToDisplay)
     }
 
-    func testDaysFromSummaryData_lessSummaryData() {
+    @Test func testDaysFromSummaryData_lessSummaryData() {
         var summaryData: [ThisWeekWidgetStats.Input] = []
 
         // Given there's summary data for less than max days to display
@@ -27,6 +28,6 @@ final class ThisWeekWidgetStatsTests: XCTestCase {
         // Then the method should not crash
         // and have expected number of This Week data
         let days = ThisWeekWidgetStats.daysFrom(summaryData: summaryData)
-        XCTAssertEqual(days.count, ThisWeekWidgetStats.maxDaysToDisplay - 2)
+        #expect(days.count == ThisWeekWidgetStats.maxDaysToDisplay - 2)
     }
 }

--- a/Modules/Tests/JetpackStatsWidgetsCoreTests/URLWidgetUrlSourceTests.swift
+++ b/Modules/Tests/JetpackStatsWidgetsCoreTests/URLWidgetUrlSourceTests.swift
@@ -1,19 +1,20 @@
 // Notice the import is not @testable.
 // Let's test the behavior of the public interface and interact with the library the same a consumer would.
+import Foundation
 import JetpackStatsWidgetsCore
-import XCTest
+import Testing
 
-final class WidgetUrlSourceTests: XCTestCase {
+struct WidgetUrlSourceTests {
 
-    func testHomeScreenWidgetSource() throws {
-        let url = try XCTUnwrap(URL(string: "https://test"))
+    @Test func testHomeScreenWidgetSource() throws {
+        let url = try #require(URL(string: "https://test"))
         let widgetUrl = url.appendingSource(.homeScreenWidget)
-        XCTAssertEqual(widgetUrl.absoluteString, "https://test?source=widget")
+        #expect(widgetUrl.absoluteString == "https://test?source=widget")
     }
 
-    func testLockScreenWidgetSource() throws {
-        let url = try XCTUnwrap(URL(string: "https://test"))
+    @Test func testLockScreenWidgetSource() throws {
+        let url = try #require(URL(string: "https://test"))
         let widgetUrl = url.appendingSource(.lockScreenWidget)
-        XCTAssertEqual(widgetUrl.absoluteString, "https://test?source=lockscreen_widget")
+        #expect(widgetUrl.absoluteString == "https://test?source=lockscreen_widget")
     }
 }

--- a/Modules/Tests/JetpackStatsWidgetsCoreTests/WidgetDataCacheReaderTests.swift
+++ b/Modules/Tests/JetpackStatsWidgetsCoreTests/WidgetDataCacheReaderTests.swift
@@ -1,12 +1,13 @@
+import Foundation
 import JetpackStatsWidgetsCore
-import XCTest
+import Testing
 
-final class WidgetDataCacheReaderTests: XCTestCase {
+struct WidgetDataCacheReaderTests {
 
     typealias Result = Swift.Result<HomeWidgetDataDouble, WidgetDataReadError>
 
     /// When the cache has data for the requested site, it returns it regardless of whether the user is logged in
-    func testWidgetDataForKnownSiteIdentifier() {
+    @Test func testWidgetDataForKnownSiteIdentifier() {
         let data = HomeWidgetDataDouble(siteID: 1)
         let sut = WidgetDataCacheReaderDouble(dataToReturn: data)
 
@@ -30,7 +31,7 @@ final class WidgetDataCacheReaderTests: XCTestCase {
 
     /// When the requested site id is not in the cache but the default site is,
     /// it returns it regardless of the user logged in status
-    func testWidgetDataForNilSiteIdentifierWithDataForDefaultSite() {
+    @Test func testWidgetDataForNilSiteIdentifierWithDataForDefaultSite() {
         let id = 1
         let data = HomeWidgetDataDouble(siteID: id)
         let sut = WidgetDataCacheReaderDouble(dataToReturn: data)
@@ -47,7 +48,7 @@ final class WidgetDataCacheReaderTests: XCTestCase {
 
     /// When the requested site id is nil but the cache has data for the default site,
     /// it returns it data for the default site, regardless of the user logged in status
-    func testWidgetDataForMissingSiteIdentifierWithDataForDefaultSite() {
+    @Test func testWidgetDataForMissingSiteIdentifierWithDataForDefaultSite() {
         let id = 1
         let data = HomeWidgetDataDouble(siteID: id)
         let sut = WidgetDataCacheReaderDouble(dataToReturn: data)
@@ -63,7 +64,7 @@ final class WidgetDataCacheReaderTests: XCTestCase {
     }
 
     /// When the cache has no data and the user is logged out, it always returns a failure with the "logged out" error
-    func testWidgetDataWithNoDataAndUserLoggedOut() {
+    @Test func testWidgetDataWithNoDataAndUserLoggedOut() {
         let sut = WidgetDataCacheReaderDouble(dataToReturn: nil)
 
         assert(
@@ -85,7 +86,7 @@ final class WidgetDataCacheReaderTests: XCTestCase {
     }
 
     /// When the cache has no data and the user is logged in, it always returns a failure with the "no site" error
-    func testWidgetDataWithNoDataAndUserLoggedIn() {
+    @Test func testWidgetDataWithNoDataAndUserLoggedIn() {
         let sut = WidgetDataCacheReaderDouble(dataToReturn: nil)
 
         assert(
@@ -108,7 +109,7 @@ final class WidgetDataCacheReaderTests: XCTestCase {
 
     /// When the cache has data that doesn't match the input parameters, and the user is logged in,
     /// it returns the site with the lower id
-    func testWidgetDataFallbackWhenLoggedIn() {
+    @Test func testWidgetDataFallbackWhenLoggedIn() {
         let data = HomeWidgetDataDouble(siteID: 0)
         let sut = WidgetDataCacheReaderDouble(
             dataToReturn: [
@@ -139,7 +140,7 @@ final class WidgetDataCacheReaderTests: XCTestCase {
 
     /// When the cache has data that doesn't match the input parameters, and the user is logged out,
     /// it returns the "logged out" error
-    func testWidgetDataFallbackWhenLoggedOut() {
+    @Test func testWidgetDataFallbackWhenLoggedOut() {
         let sut = WidgetDataCacheReaderDouble(
             dataToReturn: [
                 HomeWidgetDataDouble(siteID: 2),
@@ -167,16 +168,16 @@ final class WidgetDataCacheReaderTests: XCTestCase {
 
     // MARK: -
 
-    func assert(result actual: Result, equals expected: Result, line: UInt = #line) {
+    func assert(result actual: Result, equals expected: Result, sourceLocation: SourceLocation = #_sourceLocation) {
         switch (actual, expected) {
         case (.success(let actualData), .success(let expectedData)):
-            XCTAssertEqual(actualData, expectedData, line: line)
+            #expect(actualData == expectedData, sourceLocation: sourceLocation)
         case (.failure(let actualError), .failure(let expectedError)):
-            XCTAssertEqual(actualError, expectedError, line: line)
+            #expect(actualError == expectedError, sourceLocation: sourceLocation)
         case (.success(let data), .failure):
-            XCTFail("Expected to fail but succeeded with \(data)", line: line)
+            Issue.record("Expected to fail but succeeded with \(data)", sourceLocation: sourceLocation)
         case (.failure(let error), .success):
-            XCTFail("Expected to succeed but failed with \(error)", line: line)
+            Issue.record("Expected to succeed but failed with \(error)", sourceLocation: sourceLocation)
         }
     }
 }

--- a/Modules/Tests/WordPressFluxTests/WordPressFluxTests.swift
+++ b/Modules/Tests/WordPressFluxTests/WordPressFluxTests.swift
@@ -1,6 +1,9 @@
 import Testing
 import WordPressFlux
 
+// WordPressFlux's `Dispatcher` asserts it is only called from the main thread.
+// XCTest ran test methods on the main thread; Swift Testing runs them off the
+// main thread, so the suite is pinned to `@MainActor`.
 @MainActor
 struct WordPressFluxTests {
     @Test func testStoreReceivesActions() {

--- a/Modules/Tests/WordPressFluxTests/WordPressFluxTests.swift
+++ b/Modules/Tests/WordPressFluxTests/WordPressFluxTests.swift
@@ -1,8 +1,9 @@
-import XCTest
+import Testing
 import WordPressFlux
 
-class WordPressFluxTests: XCTestCase {
-    func testStoreReceivesActions() {
+@MainActor
+struct WordPressFluxTests {
+    @Test func testStoreReceivesActions() {
         struct TestAction: Action {}
         class TestStore: Store {
             var receivedActions = [Action]()
@@ -14,12 +15,12 @@ class WordPressFluxTests: XCTestCase {
 
         let dispatcher = ActionDispatcher()
         let store = TestStore(dispatcher: dispatcher)
-        XCTAssertEqual(store.receivedActions.count, 0, "Store shouldn't have received any actions yet")
+        #expect(store.receivedActions.isEmpty, "Store shouldn't have received any actions yet")
         ActionDispatcher.dispatch(TestAction(), dispatcher: dispatcher)
-        XCTAssertEqual(store.receivedActions.count, 1, "Store shouldn't have received one action")
+        #expect(store.receivedActions.count == 1, "Store shouldn't have received one action")
     }
 
-    func testStoreEmitsChanges() {
+    @Test func testStoreEmitsChanges() {
         class TestStore: Store {
             func test() {
                 emitChange()
@@ -31,17 +32,17 @@ class WordPressFluxTests: XCTestCase {
         var receipt: Receipt? = store.onChange {
             changeCount += 1
         }
-        XCTAssertNotNil(receipt, "We should have a receipt now")
+        #expect(receipt != nil, "We should have a receipt now")
         store.test()
-        XCTAssertEqual(changeCount, 1, "Store should have emitted one change event")
+        #expect(changeCount == 1, "Store should have emitted one change event")
         store.test()
-        XCTAssertEqual(changeCount, 2, "Store should have emitted two change events")
+        #expect(changeCount == 2, "Store should have emitted two change events")
         receipt = nil
         store.test()
-        XCTAssertEqual(changeCount, 2, "We should not receive any more events after releasing the receipt")
+        #expect(changeCount == 2, "We should not receive any more events after releasing the receipt")
     }
 
-    func testStatefulStoreEmitsChanges() {
+    @Test func testStatefulStoreEmitsChanges() {
         class TestStore: StatefulStore<Int> {
             init() {
                 super.init(initialState: 1)
@@ -60,18 +61,18 @@ class WordPressFluxTests: XCTestCase {
         }))
         var stateChangeCount = 0
         receipts.append(store.onStateChange({ old, new in
-            XCTAssertEqual(new, old * 2, "New state should be double than old")
+            #expect(new == old * 2, "New state should be double than old")
             stateChangeCount += 1
         }))
 
-        XCTAssertEqual(store.state, 1, "Initial state should be 1")
+        #expect(store.state == 1, "Initial state should be 1")
         store.test()
-        XCTAssertEqual(store.state, 2, "Second state should be 2")
-        XCTAssertEqual(changeCount, 1, "Store should have emitted one change event")
-        XCTAssertEqual(stateChangeCount, 1, "Store should have emitted one state change event")
+        #expect(store.state == 2, "Second state should be 2")
+        #expect(changeCount == 1, "Store should have emitted one change event")
+        #expect(stateChangeCount == 1, "Store should have emitted one state change event")
     }
 
-    func testStatefulStoreWithoutTransaction() {
+    @Test func testStatefulStoreWithoutTransaction() {
         class TestStore: StatefulStore<Int> {
             init() {
                 super.init(initialState: 1)
@@ -91,18 +92,18 @@ class WordPressFluxTests: XCTestCase {
         }))
         var stateChangeCount = 0
         receipts.append(store.onStateChange({ old, new in
-            XCTAssertEqual(new, old * 2, "New state should be double than old")
+            #expect(new == old * 2, "New state should be double than old")
             stateChangeCount += 1
         }))
 
-        XCTAssertEqual(store.state, 1, "Initial state should be 1")
+        #expect(store.state == 1, "Initial state should be 1")
         store.test()
-        XCTAssertEqual(store.state, 4, "Second state should be 4")
-        XCTAssertEqual(changeCount, 2, "Store should have emitted one change event")
-        XCTAssertEqual(stateChangeCount, 2, "Store should have emitted one state change event")
+        #expect(store.state == 4, "Second state should be 4")
+        #expect(changeCount == 2, "Store should have emitted one change event")
+        #expect(stateChangeCount == 2, "Store should have emitted one state change event")
     }
 
-    func testStatefulStoreWithTransaction() {
+    @Test func testStatefulStoreWithTransaction() {
         class TestStore: StatefulStore<Int> {
             init() {
                 super.init(initialState: 1)
@@ -124,18 +125,18 @@ class WordPressFluxTests: XCTestCase {
         }))
         var stateChangeCount = 0
         receipts.append(store.onStateChange({ old, new in
-            XCTAssertEqual(new, old * 4, "New state should be 4x the old one")
+            #expect(new == old * 4, "New state should be 4x the old one")
             stateChangeCount += 1
         }))
 
-        XCTAssertEqual(store.state, 1, "Initial state should be 1")
+        #expect(store.state == 1, "Initial state should be 1")
         store.test()
-        XCTAssertEqual(store.state, 4, "Second state should be 4")
-        XCTAssertEqual(changeCount, 1, "Store should have emitted one change event")
-        XCTAssertEqual(stateChangeCount, 1, "Store should have emitted one state change event")
+        #expect(store.state == 4, "Second state should be 4")
+        #expect(changeCount == 1, "Store should have emitted one change event")
+        #expect(stateChangeCount == 1, "Store should have emitted one state change event")
     }
 
-    func testQueryStore() {
+    @Test func testQueryStore() {
         struct TestQuery {
             let id: Int
         }
@@ -155,7 +156,7 @@ class WordPressFluxTests: XCTestCase {
         let store = TestStore()
         var receipts = [Receipt]()
         receipts.append(store.query(TestQuery(id: 1)))
-        XCTAssertEqual(store.activeQueries.count, 1, "Store should have one active query")
-        XCTAssertEqual(store.queriesChangedCount, 1, "Store should have processed one queriesChanged event")
+        #expect(store.activeQueries.count == 1, "Store should have one active query")
+        #expect(store.queriesChangedCount == 1, "Store should have processed one queriesChanged event")
     }
 }

--- a/Modules/Tests/WordPressFluxTests/XCTestManifests.swift
+++ b/Modules/Tests/WordPressFluxTests/XCTestManifests.swift
@@ -1,9 +1,0 @@
-import XCTest
-
-#if !canImport(ObjectiveC)
-public func allTests() -> [XCTestCaseEntry] {
-    return [
-        testCase(WordPressFluxTests.allTests),
-    ]
-}
-#endif

--- a/Modules/Tests/WordPressSharedTests/ArrayTests.swift
+++ b/Modules/Tests/WordPressSharedTests/ArrayTests.swift
@@ -1,83 +1,83 @@
-import XCTest
+import Testing
 @testable import WordPressShared
 
-class ArrayTests: XCTestCase {
-    func testRepeatLast() {
+struct ArrayTests {
+    @Test func testRepeatLast() {
         let array = [1, 2, 3]
         let repeated = Array(array.repeatingLast().prefix(5))
         let expected = [1, 2, 3, 3, 3]
-        XCTAssertEqual(expected, repeated)
+        #expect(expected == repeated)
     }
 
-    func testRepeatLastWithEmptyArray() {
+    @Test func testRepeatLastWithEmptyArray() {
         let array = [Int]()
         let repeated = Array(array.repeatingLast().prefix(5))
         let expected = [Int]()
-        XCTAssertEqual(expected, repeated)
+        #expect(expected == repeated)
     }
 
-    func testDifferentIndicesReturnsEmptyWithSameArray() {
+    @Test func testDifferentIndicesReturnsEmptyWithSameArray() {
         let test = [1, 2, 3]
         let result = test.differentIndices(test)
-        XCTAssert(result.isEmpty)
+        #expect(result.isEmpty)
     }
 
-    func testDifferentIndicesReturnsDifferencesWhenOtherSmaller() {
+    @Test func testDifferentIndicesReturnsDifferencesWhenOtherSmaller() {
         let test = [1, 2, 3]
         let other = [1]
         let result = test.differentIndices(other)
-        XCTAssertEqual(result, [1, 2])
+        #expect(result == [1, 2])
     }
 
-    func testDifferentIndicesReturnsDifferencesWhenOtherLarger() {
+    @Test func testDifferentIndicesReturnsDifferencesWhenOtherLarger() {
         let test = [1, 2, 3]
         let other = [1, 0, 3, 4]
         let result = test.differentIndices(other)
-        XCTAssertEqual(result, [1])
+        #expect(result == [1])
     }
 
-    func testSortedGroupEmptyArray() {
+    @Test func testSortedGroupEmptyArray() {
         let test = [TestElement]()
         let result = test.sortedGroup(keyPath: \TestElement.key)
-        XCTAssertEqual(result.count, 0)
+        #expect(result.isEmpty)
     }
 
-    func testSortedGroupCase1() {
+    @Test func testSortedGroupCase1() {
         let test: [TestElement] = [TestElement(key: "a", value: 1), TestElement(key: "a", value: 2)]
         let result = test.sortedGroup(keyPath: \TestElement.key)
-        XCTAssertEqual(result[0].0, test[0].key)
-        XCTAssertEqual(result[0].1[0], test[0])
-        XCTAssertEqual(result[0].1[1], test[1])
+        #expect(result[0].0 == test[0].key)
+        #expect(result[0].1[0] == test[0])
+        #expect(result[0].1[1] == test[1])
     }
 
-    func testSortedGroupCase2() {
+    @Test func testSortedGroupCase2() {
         let test: [TestElement] = [TestElement(key: "a", value: 1), TestElement(key: "b", value: 1)]
         let result = test.sortedGroup(keyPath: \TestElement.key)
-        XCTAssertEqual(result[0].0, test[0].key)
-        XCTAssertEqual(result[1].0, test[1].key)
-        XCTAssertEqual(result[0].1[0], test[0])
-        XCTAssertEqual(result[1].1[0], test[1])
+        #expect(result[0].0 == test[0].key)
+        #expect(result[1].0 == test[1].key)
+        #expect(result[0].1[0] == test[0])
+        #expect(result[1].1[0] == test[1])
     }
 
-    func testSortedGroupCase3() {
+    @Test func testSortedGroupCase3() {
         let test: [TestElement] = [TestElement(key: "a", value: 1), TestElement(key: "b", value: 1),
                                    TestElement(key: "b", value: 2), TestElement(key: "c", value: 1)]
         let result = test.sortedGroup(keyPath: \TestElement.key)
-        XCTAssertEqual(result[0].0, test[0].key)
-        XCTAssertEqual(result[1].0, test[1].key)
-        XCTAssertEqual(result[2].0, test[3].key)
-        XCTAssertEqual(result[0].1[0], test[0])
-        XCTAssertEqual(result[1].1[0], test[1])
-        XCTAssertEqual(result[1].1[1], test[2])
-        XCTAssertEqual(result[2].1[0], test[3])
+        #expect(result[0].0 == test[0].key)
+        #expect(result[1].0 == test[1].key)
+        #expect(result[2].0 == test[3].key)
+        #expect(result[0].1[0] == test[0])
+        #expect(result[1].1[0] == test[1])
+        #expect(result[1].1[1] == test[2])
+        #expect(result[2].1[0] == test[3])
     }
 
-    func testUniqueRemovesDuplicates() {
+    @Test func testUniqueRemovesDuplicates() {
         let test = ["🦄", "🦄", "🌈"]
 
         let result = test.unique
 
-        XCTAssertTrue(result.count == 2 && result.contains("🦄") && result.contains("🌈"))
+        #expect(result.count == 2 && result.contains("🦄") && result.contains("🌈"))
     }
 }
 

--- a/Modules/Tests/WordPressSharedTests/AsyncOperationTests.swift
+++ b/Modules/Tests/WordPressSharedTests/AsyncOperationTests.swift
@@ -1,25 +1,26 @@
-import XCTest
+import Foundation
+import Testing
 import WordPressShared
 
-class AsyncOperationTests: XCTestCase {
+struct AsyncOperationTests {
     let operation = AsyncOperation()
 
-    func testIsAsynchronous() {
-        XCTAssertTrue(operation.isAsynchronous)
+    @Test func testIsAsynchronous() {
+        #expect(operation.isAsynchronous)
     }
 
-    func testDefaultState() {
-        XCTAssertTrue(operation.state == AsyncOperation.State.isReady)
+    @Test func testDefaultState() {
+        #expect(operation.state == AsyncOperation.State.isReady)
     }
 
-    func testIsExecutingState() {
+    @Test func testIsExecutingState() {
         operation.start()
-        XCTAssertTrue(operation.isExecuting)
+        #expect(operation.isExecuting)
     }
 
-    func testIsFinishedState() {
+    @Test func testIsFinishedState() {
         operation.cancel()
         operation.start()
-        XCTAssertTrue(operation.isFinished)
+        #expect(operation.isFinished)
     }
 }

--- a/Modules/Tests/WordPressSharedTests/DashboardDynamicCardAnalyticsEventTests.swift
+++ b/Modules/Tests/WordPressSharedTests/DashboardDynamicCardAnalyticsEventTests.swift
@@ -1,9 +1,9 @@
 @testable import WordPressShared
-import XCTest
+import Testing
 
-final class DashboardDynamicCardAnalyticsEventTests: XCTestCase {
+struct DashboardDynamicCardAnalyticsEventTests {
 
-    func testNamesAndProperties() {
+    @Test func testNamesAndProperties() {
         // Given
         let (id, url) = ("123", "https://wordpress.com")
 
@@ -13,11 +13,11 @@ final class DashboardDynamicCardAnalyticsEventTests: XCTestCase {
         let cardCTATappedEvent = DashboardDynamicCardAnalyticsEvent.cardCtaTapped(id: id, url: url)
 
         // Then
-        XCTAssertEqual(cardShownEvent.name, "dynamic_dashboard_card_shown")
-        XCTAssertEqual(cardTappedEvent.name, "dynamic_dashboard_card_tapped")
-        XCTAssertEqual(cardCTATappedEvent.name, "dynamic_dashboard_card_cta_tapped")
-        XCTAssertEqual(cardShownEvent.properties, ["id": id])
-        XCTAssertEqual(cardTappedEvent.properties, ["id": id, "url": url])
-        XCTAssertEqual(cardCTATappedEvent.properties, ["id": id, "url": url])
+        #expect(cardShownEvent.name == "dynamic_dashboard_card_shown")
+        #expect(cardTappedEvent.name == "dynamic_dashboard_card_tapped")
+        #expect(cardCTATappedEvent.name == "dynamic_dashboard_card_cta_tapped")
+        #expect(cardShownEvent.properties == ["id": id])
+        #expect(cardTappedEvent.properties == ["id": id, "url": url])
+        #expect(cardCTATappedEvent.properties == ["id": id, "url": url])
     }
 }

--- a/Modules/Tests/WordPressSharedTests/DebouncerTests.swift
+++ b/Modules/Tests/WordPressSharedTests/DebouncerTests.swift
@@ -1,11 +1,11 @@
-import XCTest
+import Foundation
+import Testing
 @testable import WordPressShared
 
-class DebouncerTests: XCTestCase {
+struct DebouncerTests {
 
     /// Tests that the debouncer runs within an accurate time range normally.
-    ///
-    func testDebouncerRunsNormally() {
+    @Test func testDebouncerRunsNormally() throws {
         let timerDelay = 0.5
         let allowedError = 0.5
         let minDelay = timerDelay * (1 - allowedError)
@@ -13,57 +13,64 @@ class DebouncerTests: XCTestCase {
         let testTimeout = maxDelay + 0.01
 
         let startDate = Date()
-        let debouncerHasRunAccurately = XCTestExpectation(description: "The debouncer should run within an accurate time range normally.")
-
+        var actualDelay: TimeInterval?
         let debouncer = Debouncer(delay: timerDelay) {
-            let actualDelay = Date().timeIntervalSince(startDate)
-
-            if actualDelay >= minDelay
-                && actualDelay <= maxDelay {
-
-                debouncerHasRunAccurately.fulfill()
-            } else {
-                XCTFail("Actual delay was: \(actualDelay))")
-            }
+            actualDelay = Date().timeIntervalSince(startDate)
         }
         debouncer.call()
 
-        wait(for: [debouncerHasRunAccurately], timeout: testTimeout)
+        // Keep the debouncer alive while we pump the run loop; releasing it early
+        // would fire the callback immediately via `deinit`.
+        withExtendedLifetime(debouncer) {
+            let deadline = Date().addingTimeInterval(testTimeout)
+            while actualDelay == nil && Date() < deadline {
+                RunLoop.current.run(mode: .default, before: deadline)
+            }
+        }
+
+        let delay = try #require(actualDelay, "The debouncer should run within an accurate time range normally.")
+        #expect(delay >= minDelay && delay <= maxDelay, "Actual delay was: \(delay)")
     }
 
-    /// Tests that the debouncer runs immediately if its released.
-    ///
-    func testDebouncerRunsImmediatelyIfReleased() {
-        let debouncerHasRun = XCTestExpectation(description: "The debouncer should run immediately if it's released")
+    /// Tests that the debouncer runs immediately if it's released.
+    @Test func testDebouncerRunsImmediatelyIfReleased() {
+        var didRun = false
 
+        // The debouncer is not retained, so it deallocates at the end of this
+        // statement and fires the pending callback synchronously from `deinit`.
         Debouncer(delay: 0.5) {
-            debouncerHasRun.fulfill()
-        }.call()
+            didRun = true
+        }
+        .call()
 
-        wait(for: [debouncerHasRun], timeout: 0)
+        #expect(didRun, "The debouncer should run immediately if it's released")
     }
 
     /// Tests that we can cancel the debouncer's operation.
-    ///
-    func testDebouncerCanBeCancelled() {
+    @Test func testDebouncerCanBeCancelled() {
         let debouncerDelay = 0.2
         let testTimeout = debouncerDelay * 2
-        let debouncerHasRun = XCTestExpectation(description: "The debouncer's operation should be cancellable.")
-        debouncerHasRun.isInverted = true
 
+        var didRun = false
         let debouncer = Debouncer(delay: debouncerDelay) {
-            debouncerHasRun.fulfill()
+            didRun = true
         }
 
         debouncer.call()
         debouncer.cancel()
 
-        wait(for: [debouncerHasRun], timeout: testTimeout)
+        withExtendedLifetime(debouncer) {
+            let deadline = Date().addingTimeInterval(testTimeout)
+            while Date() < deadline {
+                RunLoop.current.run(mode: .default, before: deadline)
+            }
+        }
+
+        #expect(!didRun, "The debouncer's operation should be cancellable.")
     }
 
     /// Tests that the debouncer works fine when used with an ad hoc callback.
-    ///
-    func testDebouncerWithAdHocCallback() {
+    @Test func testDebouncerWithAdHocCallback() throws {
         let timerDelay = 0.5
         let allowedError = 0.5
         let minDelay = timerDelay * (1 - allowedError)
@@ -71,21 +78,20 @@ class DebouncerTests: XCTestCase {
         let testTimeout = maxDelay + 0.01
 
         let startDate = Date()
-        let debouncerHasRunAccurately = XCTestExpectation(description: "The debouncer should run within an accurate time range normally.")
-
+        var actualDelay: TimeInterval?
         let debouncer = Debouncer(delay: timerDelay)
-        debouncer.call() {
-            let actualDelay = Date().timeIntervalSince(startDate)
+        debouncer.call {
+            actualDelay = Date().timeIntervalSince(startDate)
+        }
 
-            if actualDelay >= minDelay
-                && actualDelay <= maxDelay {
-
-                debouncerHasRunAccurately.fulfill()
-            } else {
-                XCTFail("Actual delay was: \(actualDelay))")
+        withExtendedLifetime(debouncer) {
+            let deadline = Date().addingTimeInterval(testTimeout)
+            while actualDelay == nil && Date() < deadline {
+                RunLoop.current.run(mode: .default, before: deadline)
             }
         }
 
-        wait(for: [debouncerHasRunAccurately], timeout: testTimeout)
+        let delay = try #require(actualDelay, "The debouncer should run within an accurate time range normally.")
+        #expect(delay >= minDelay && delay <= maxDelay, "Actual delay was: \(delay)")
     }
 }

--- a/Modules/Tests/WordPressSharedTests/DebouncerTests.swift
+++ b/Modules/Tests/WordPressSharedTests/DebouncerTests.swift
@@ -19,8 +19,10 @@ struct DebouncerTests {
         }
         debouncer.call()
 
-        // Keep the debouncer alive while we pump the run loop; releasing it early
-        // would fire the callback immediately via `deinit`.
+        // `Debouncer` schedules its callback on a `Timer`, which fires only while its run loop is
+        // running. XCTest's `wait(for:)` ran that run loop for us; Swift Testing's async waiting
+        // doesn't, so we run it ourselves until the timer fires. `withExtendedLifetime` keeps the
+        // debouncer alive across the wait — releasing it early fires the callback from `deinit`.
         withExtendedLifetime(debouncer) {
             let deadline = Date().addingTimeInterval(testTimeout)
             while actualDelay == nil && Date() < deadline {
@@ -59,6 +61,8 @@ struct DebouncerTests {
         debouncer.call()
         debouncer.cancel()
 
+        // Run the run loop for the full delay so a still-scheduled Timer would fire;
+        // a cancelled debouncer must not (see testDebouncerRunsNormally).
         withExtendedLifetime(debouncer) {
             let deadline = Date().addingTimeInterval(testTimeout)
             while Date() < deadline {
@@ -84,6 +88,7 @@ struct DebouncerTests {
             actualDelay = Date().timeIntervalSince(startDate)
         }
 
+        // Run the run loop until the Timer fires, as in testDebouncerRunsNormally.
         withExtendedLifetime(debouncer) {
             let deadline = Date().addingTimeInterval(testTimeout)
             while actualDelay == nil && Date() < deadline {

--- a/Modules/Tests/WordPressSharedTests/DelayTests.swift
+++ b/Modules/Tests/WordPressSharedTests/DelayTests.swift
@@ -1,23 +1,23 @@
-import XCTest
+import Testing
 @testable import WordPressShared
 
-class DelayTests: XCTestCase {
-    func testIncrementalDelay() {
+struct DelayTests {
+    @Test func testIncrementalDelay() {
         var delay = IncrementalDelay([1, 5, 20, 60])
-        XCTAssertEqual(1, delay.current)
+        #expect(1 == delay.current)
         delay.increment()
-        XCTAssertEqual(5, delay.current)
+        #expect(5 == delay.current)
         delay.increment()
-        XCTAssertEqual(20, delay.current)
+        #expect(20 == delay.current)
         delay.increment()
-        XCTAssertEqual(60, delay.current)
+        #expect(60 == delay.current)
         delay.increment()
-        XCTAssertEqual(60, delay.current)
+        #expect(60 == delay.current)
         delay.reset()
-        XCTAssertEqual(1, delay.current)
+        #expect(1 == delay.current)
         delay.increment()
-        XCTAssertEqual(5, delay.current)
+        #expect(5 == delay.current)
         delay.reset()
-        XCTAssertEqual(1, delay.current)
+        #expect(1 == delay.current)
     }
 }

--- a/Modules/Tests/WordPressSharedTests/DictionaryHelpersTests.swift
+++ b/Modules/Tests/WordPressSharedTests/DictionaryHelpersTests.swift
@@ -1,27 +1,27 @@
 import Foundation
-import XCTest
+import Testing
 @testable import WordPressShared
 
 // MARK: - DictionaryHelpersTests
 //
-class DictionaryHelpersTests: XCTestCase {
-    func testValueAsStringReturnsTheExpectedStringWhenTheValueIsEffectivelyAsString() {
+struct DictionaryHelpersTests {
+    @Test func testValueAsStringReturnsTheExpectedStringWhenTheValueIsEffectivelyAsString() {
         let dictionary = [
             "key": "value!"
         ]
 
         let retrieved = dictionary.valueAsString(forKey: "key")
-        XCTAssertNotNil(retrieved)
-        XCTAssertEqual(retrieved, "value!")
+        #expect(retrieved != nil)
+        #expect(retrieved == "value!")
     }
 
-    func testValueAsStringReturnsTheExpectedStringWhenTheValueIsNumeric() {
+    @Test func testValueAsStringReturnsTheExpectedStringWhenTheValueIsNumeric() {
         let dictionary = [
             "key": 1234
         ]
 
         let retrieved = dictionary.valueAsString(forKey: "key")
-        XCTAssertNotNil(retrieved)
-        XCTAssertEqual(retrieved, "1234")
+        #expect(retrieved != nil)
+        #expect(retrieved == "1234")
     }
 }

--- a/Modules/Tests/WordPressSharedTests/EmailFormatValidatorTests.swift
+++ b/Modules/Tests/WordPressSharedTests/EmailFormatValidatorTests.swift
@@ -1,30 +1,30 @@
-import XCTest
+import Testing
 import WordPressShared
 
-class EmailFormatValidatorTests: XCTestCase {
+struct EmailFormatValidatorTests {
 
-    func testValidEmailAddresses() {
-        XCTAssertTrue(EmailFormatValidator.validate(string: "e@example.com"))
-        XCTAssertTrue(EmailFormatValidator.validate(string: "example@example.com"))
-        XCTAssertTrue(EmailFormatValidator.validate(string: "example@example-example.com"))
-        XCTAssertTrue(EmailFormatValidator.validate(string: "example@example.example.example.com"))
-        XCTAssertTrue(EmailFormatValidator.validate(string: "example.example+example@example.com"))
+    @Test func testValidEmailAddresses() {
+        #expect(EmailFormatValidator.validate(string: "e@example.com"))
+        #expect(EmailFormatValidator.validate(string: "example@example.com"))
+        #expect(EmailFormatValidator.validate(string: "example@example-example.com"))
+        #expect(EmailFormatValidator.validate(string: "example@example.example.example.com"))
+        #expect(EmailFormatValidator.validate(string: "example.example+example@example.com"))
     }
 
-    func testInvalidEmailAddresses() {
-        XCTAssertFalse(EmailFormatValidator.validate(string: ""))
-        XCTAssertFalse(EmailFormatValidator.validate(string: "example"))
-        XCTAssertFalse(EmailFormatValidator.validate(string: "example@@example.com"))
-        XCTAssertFalse(EmailFormatValidator.validate(string: "example@example@.com"))
-        XCTAssertFalse(EmailFormatValidator.validate(string: "@example.com"))
-        XCTAssertFalse(EmailFormatValidator.validate(string: "example@example"))
-        XCTAssertFalse(EmailFormatValidator.validate(string: "example@.com"))
-        XCTAssertFalse(EmailFormatValidator.validate(string: "example@example..com"))
-        XCTAssertFalse(EmailFormatValidator.validate(string: "example@.example.com"))
-        XCTAssertFalse(EmailFormatValidator.validate(string: "example@example.com."))
-        XCTAssertFalse(EmailFormatValidator.validate(string: "example@examp?.com"))
-        XCTAssertFalse(EmailFormatValidator.validate(string: "example@exam_ple.com"))
-        XCTAssertFalse(EmailFormatValidator.validate(string: "examp***le@exam_ple.com"))
-        XCTAssertFalse(EmailFormatValidator.validate(string: "example@exam ple.com"))
+    @Test func testInvalidEmailAddresses() {
+        #expect(!(EmailFormatValidator.validate(string: "")))
+        #expect(!(EmailFormatValidator.validate(string: "example")))
+        #expect(!(EmailFormatValidator.validate(string: "example@@example.com")))
+        #expect(!(EmailFormatValidator.validate(string: "example@example@.com")))
+        #expect(!(EmailFormatValidator.validate(string: "@example.com")))
+        #expect(!(EmailFormatValidator.validate(string: "example@example")))
+        #expect(!(EmailFormatValidator.validate(string: "example@.com")))
+        #expect(!(EmailFormatValidator.validate(string: "example@example..com")))
+        #expect(!(EmailFormatValidator.validate(string: "example@.example.com")))
+        #expect(!(EmailFormatValidator.validate(string: "example@example.com.")))
+        #expect(!(EmailFormatValidator.validate(string: "example@examp?.com")))
+        #expect(!(EmailFormatValidator.validate(string: "example@exam_ple.com")))
+        #expect(!(EmailFormatValidator.validate(string: "examp***le@exam_ple.com")))
+        #expect(!(EmailFormatValidator.validate(string: "example@exam ple.com")))
     }
 }

--- a/Modules/Tests/WordPressSharedTests/EmailTypoCheckerTests.swift
+++ b/Modules/Tests/WordPressSharedTests/EmailTypoCheckerTests.swift
@@ -1,27 +1,27 @@
-import XCTest
+import Testing
 import WordPressShared
 
-class EmailTypoCheckerTests: XCTestCase {
+struct EmailTypoCheckerTests {
 
-    func testSuggestions() {
-        XCTAssertEqual(EmailTypoChecker.guessCorrection(email: "hello@mop.com"), "hello@mop.com")
-        XCTAssertEqual(EmailTypoChecker.guessCorrection(email: "hello@gmail.com"), "hello@gmail.com")
-        XCTAssertEqual(EmailTypoChecker.guessCorrection(email: "hello"), "hello")
-        XCTAssertEqual(EmailTypoChecker.guessCorrection(email: "hello@"), "hello@")
-        XCTAssertEqual(EmailTypoChecker.guessCorrection(email: "@"), "@")
-        XCTAssertEqual(EmailTypoChecker.guessCorrection(email: ""), "")
-        XCTAssertEqual(EmailTypoChecker.guessCorrection(email: "@hello"), "@hello")
-        XCTAssertEqual(EmailTypoChecker.guessCorrection(email: "@hello.com"), "@hello.com")
-        XCTAssertEqual(EmailTypoChecker.guessCorrection(email: "kikoo@gmail.com"), "kikoo@gmail.com")
-        XCTAssertEqual(EmailTypoChecker.guessCorrection(email: "kikoo@azdoij.cm"), "kikoo@azdoij.cm")
+    @Test func testSuggestions() {
+        #expect(EmailTypoChecker.guessCorrection(email: "hello@mop.com") == "hello@mop.com")
+        #expect(EmailTypoChecker.guessCorrection(email: "hello@gmail.com") == "hello@gmail.com")
+        #expect(EmailTypoChecker.guessCorrection(email: "hello") == "hello")
+        #expect(EmailTypoChecker.guessCorrection(email: "hello@") == "hello@")
+        #expect(EmailTypoChecker.guessCorrection(email: "@") == "@")
+        #expect(EmailTypoChecker.guessCorrection(email: "").isEmpty)
+        #expect(EmailTypoChecker.guessCorrection(email: "@hello") == "@hello")
+        #expect(EmailTypoChecker.guessCorrection(email: "@hello.com") == "@hello.com")
+        #expect(EmailTypoChecker.guessCorrection(email: "kikoo@gmail.com") == "kikoo@gmail.com")
+        #expect(EmailTypoChecker.guessCorrection(email: "kikoo@azdoij.cm") == "kikoo@azdoij.cm")
 
-        XCTAssertEqual(EmailTypoChecker.guessCorrection(email: "hello@gmial.com"), "hello@gmail.com")
-        XCTAssertEqual(EmailTypoChecker.guessCorrection(email: "hello@gmai.com"), "hello@gmail.com")
-        XCTAssertEqual(EmailTypoChecker.guessCorrection(email: "hello@yohoo.com"), "hello@yahoo.com")
-        XCTAssertEqual(EmailTypoChecker.guessCorrection(email: "hello@yhoo.com"), "hello@yahoo.com")
-        XCTAssertEqual(EmailTypoChecker.guessCorrection(email: "hello@ayhoo.com"), "hello@yahoo.com")
-        XCTAssertEqual(EmailTypoChecker.guessCorrection(email: "hello@yhoo.com"), "hello@yahoo.com")
-        XCTAssertEqual(EmailTypoChecker.guessCorrection(email: "hello@outloo.com"), "hello@outlook.com")
-        XCTAssertEqual(EmailTypoChecker.guessCorrection(email: "hello@comcats.com"), "hello@comcast.com")
+        #expect(EmailTypoChecker.guessCorrection(email: "hello@gmial.com") == "hello@gmail.com")
+        #expect(EmailTypoChecker.guessCorrection(email: "hello@gmai.com") == "hello@gmail.com")
+        #expect(EmailTypoChecker.guessCorrection(email: "hello@yohoo.com") == "hello@yahoo.com")
+        #expect(EmailTypoChecker.guessCorrection(email: "hello@yhoo.com") == "hello@yahoo.com")
+        #expect(EmailTypoChecker.guessCorrection(email: "hello@ayhoo.com") == "hello@yahoo.com")
+        #expect(EmailTypoChecker.guessCorrection(email: "hello@yhoo.com") == "hello@yahoo.com")
+        #expect(EmailTypoChecker.guessCorrection(email: "hello@outloo.com") == "hello@outlook.com")
+        #expect(EmailTypoChecker.guessCorrection(email: "hello@comcats.com") == "hello@comcast.com")
     }
 }

--- a/Modules/Tests/WordPressSharedTests/KeychainUtilsTests.swift
+++ b/Modules/Tests/WordPressSharedTests/KeychainUtilsTests.swift
@@ -1,17 +1,15 @@
 import SFHFKeychainUtils
-import XCTest
+import Testing
 @testable import WordPressShared
 
-class KeychainUtilsTests: XCTestCase {
+struct KeychainUtilsTests {
 
-    override func setUp() {
-        super.setUp()
-
+    init() {
         SFHFKeychainUtilsMock.configure(with: [:])
     }
 
     @available(*, deprecated, message: "Exercises the deprecated KeychainUtils.copyKeychain")
-    func testCopyingPasswordsBetweenKeychains() {
+    @Test func testCopyingPasswordsBetweenKeychains() {
         let service = "service"
         let username = "username"
         let password = "password"
@@ -22,7 +20,7 @@ class KeychainUtilsTests: XCTestCase {
         try? subject.copyKeychain(from: nil, to: sharedGroup, updateExisting: true)
 
         let sharedPassword = try? SFHFKeychainUtilsMock.getPasswordForUsername(username, andServiceName: service, accessGroup: sharedGroup)
-        XCTAssertEqual(sharedPassword, password)
+        #expect(sharedPassword == password)
     }
 }
 

--- a/Modules/Tests/WordPressSharedTests/LanguagesTests.swift
+++ b/Modules/Tests/WordPressSharedTests/LanguagesTests.swift
@@ -1,9 +1,8 @@
-import XCTest
 import Testing
 @testable import WordPressShared
 
 @Suite("Languages Tests")
-class LanguagesTests {
+struct LanguagesTests {
     let en = 1
     let es = 19
     let zhCN = 449
@@ -12,8 +11,8 @@ class LanguagesTests {
     @Test func testLanguagesEffectivelyLoadJsonFile() {
         let languages = WordPressComLanguageDatabase.shared
 
-        XCTAssert(!languages.all.isEmpty)
-        XCTAssert(!languages.popular.isEmpty)
+        #expect(!languages.all.isEmpty)
+        #expect(!languages.popular.isEmpty)
     }
 
     @Test func testAllLanguagesHaveValidFields() {
@@ -21,8 +20,8 @@ class LanguagesTests {
         let sum = languages.all + languages.popular
 
         for language in sum {
-            XCTAssert(!language.slug.isEmpty)
-            XCTAssert(!language.name.isEmpty)
+            #expect(!language.slug.isEmpty)
+            #expect(!language.name.isEmpty)
         }
     }
 
@@ -31,7 +30,7 @@ class LanguagesTests {
 
         for language in languages.popular {
             let filtered = languages.all.filter { $0.id == language.id }
-            XCTAssert(filtered.count == 1)
+            #expect(filtered.count == 1)
         }
     }
 
@@ -41,57 +40,57 @@ class LanguagesTests {
         let english = languages.nameForLanguageWithId(en)
         let spanish = languages.nameForLanguageWithId(es)
 
-        XCTAssert(english == "English")
-        XCTAssert(spanish == "Español")
+        #expect(english == "English")
+        #expect(spanish == "Español")
     }
 
     @Test func testDeviceLanguageReturnsValueForSpanish() {
         let languages = WordPressComLanguageDatabase(deviceLanguageCode: "es")
-        XCTAssertEqual(languages.deviceLanguage.id, es)
+        #expect(languages.deviceLanguage.id == es)
     }
 
     @Test func testDeviceLanguageReturnsValueForSpanishSpainLowercase() {
         let languages = WordPressComLanguageDatabase(deviceLanguageCode: "es-es")
-        XCTAssertEqual(languages.deviceLanguage.id, es)
+        #expect(languages.deviceLanguage.id == es)
     }
 
     @Test func testDeviceLanguageReturnsValueForSpanishSpain() {
         let languages = WordPressComLanguageDatabase(deviceLanguageCode: "es-ES")
-        XCTAssertEqual(languages.deviceLanguage.id, es)
+        #expect(languages.deviceLanguage.id == es)
     }
 
     @Test func testDeviceLanguageReturnsEnglishForUnknownLanguage() {
         let languages = WordPressComLanguageDatabase(deviceLanguageCode: "not-a-language")
-        XCTAssertEqual(languages.deviceLanguage.id, en)
+        #expect(languages.deviceLanguage.id == en)
     }
 
     @Test func testDeviceLanguageReturnsValueForSpanishSpainExtra() {
         let languages = WordPressComLanguageDatabase(deviceLanguageCode: "es-ES-extra")
-        XCTAssertEqual(languages.deviceLanguage.id, es)
+        #expect(languages.deviceLanguage.id == es)
     }
 
     @Test func testDeviceLanguageReturnsValueForSpanishNO() {
         let languages = WordPressComLanguageDatabase(deviceLanguageCode: "es-NO")
-        XCTAssertEqual(languages.deviceLanguage.id, es)
+        #expect(languages.deviceLanguage.id == es)
     }
 
     @Test func testDeviceLanguageReturnsZhCNForZhHans() {
         let languages = WordPressComLanguageDatabase(deviceLanguageCode: "zh-Hans")
-        XCTAssertEqual(languages.deviceLanguage.id, zhCN)
+        #expect(languages.deviceLanguage.id == zhCN)
     }
 
     @Test func testDeviceLanguageReturnsZhTWForZhHant() {
         let languages = WordPressComLanguageDatabase(deviceLanguageCode: "zh-Hant")
-        XCTAssertEqual(languages.deviceLanguage.id, zhTW)
+        #expect(languages.deviceLanguage.id == zhTW)
     }
 
     @Test func testDeviceLanguageReturnsZhCNForZhHansES() {
         let languages = WordPressComLanguageDatabase(deviceLanguageCode: "zh-Hans-ES")
-        XCTAssertEqual(languages.deviceLanguage.id, zhCN)
+        #expect(languages.deviceLanguage.id == zhCN)
     }
 
     @Test func testDeviceLanguageReturnsZhTWForZhHantES() {
         let languages = WordPressComLanguageDatabase(deviceLanguageCode: "zh-Hant-ES")
-        XCTAssertEqual(languages.deviceLanguage.id, zhTW)
+        #expect(languages.deviceLanguage.id == zhTW)
     }
 }

--- a/Modules/Tests/WordPressSharedTests/LazyTests.swift
+++ b/Modules/Tests/WordPressSharedTests/LazyTests.swift
@@ -1,7 +1,7 @@
-import XCTest
+import Testing
 @testable import WordPressShared
 
-class LazyTests: XCTestCase {
+final class LazyTests {
     @Lazy
     var container = Container()
 
@@ -15,30 +15,28 @@ class LazyTests: XCTestCase {
         }
     }
 
-    override func tearDown() {
-        super.tearDown()
-
+    deinit {
         Container.initCallCount = 0
     }
 
-    func testLazyProperty() {
-        XCTAssertEqual(Container.initCallCount, 0, "Has to be created lazily")
+    @Test func testLazyProperty() {
+        #expect(Container.initCallCount == 0, "Has to be created lazily")
 
         // Accessing value without triggering init
-        XCTAssertNil($container.value)
-        XCTAssertEqual(Container.initCallCount, 0, "Accessing the projected value should not trigger init")
+        #expect($container.value == nil)
+        #expect(Container.initCallCount == 0, "Accessing the projected value should not trigger init")
 
         // Accessing value while initializing it lazily
-        XCTAssertEqual(container.name, "hello")
-        XCTAssertNotNil($container.value)
-        XCTAssertEqual(Container.initCallCount, 1)
+        #expect(container.name == "hello")
+        #expect($container.value != nil)
+        #expect(Container.initCallCount == 1)
 
         // Using the cached value
         container.name = "here goes nothing"
-        XCTAssertEqual(Container.initCallCount, 1, "Lazily created value is retained")
+        #expect(Container.initCallCount == 1, "Lazily created value is retained")
 
         // Resetting the value
         $container.reset()
-        XCTAssertNil($container.value)
+        #expect($container.value == nil)
     }
 }

--- a/Modules/Tests/WordPressSharedTests/LoggingURLRedactorTests.swift
+++ b/Modules/Tests/WordPressSharedTests/LoggingURLRedactorTests.swift
@@ -1,28 +1,29 @@
-import XCTest
+import Foundation
+import Testing
 @testable import WordPressShared
 
-class LoggingURLRedactorTests: XCTestCase {
+struct LoggingURLRedactorTests {
 
-    func testThatMagicLoginTokenURLsAreRedacted() {
+    @Test func testThatMagicLoginTokenURLsAreRedacted() {
         let wpInternalMagicTokenURL = URL(string: "wpinternal://magic-login?foo=bar&token=foo")!
         let wpInternalRedactedURL = URL(string: "wpinternal://magic-login?foo=bar&token=redacted")!
-        XCTAssertEqual(wpInternalRedactedURL, LoggingURLRedactor.redactedURL(wpInternalMagicTokenURL))
+        #expect(wpInternalRedactedURL == LoggingURLRedactor.redactedURL(wpInternalMagicTokenURL))
 
         let magicTokenURL = URL(string: "wordpress://magic-login?foo=bar&token=foo")!
         let redactedURL = URL(string: "wordpress://magic-login?foo=bar&token=redacted")!
-        XCTAssertEqual(redactedURL, LoggingURLRedactor.redactedURL(magicTokenURL))
+        #expect(redactedURL == LoggingURLRedactor.redactedURL(magicTokenURL))
 
         let debugMagicTokenURL = URL(string: "wpdebug://magic-login?foo=bar&token=foo")!
         let debugRedactedURL = URL(string: "wpdebug://magic-login?foo=bar&token=redacted")!
-        XCTAssertEqual(debugRedactedURL, LoggingURLRedactor.redactedURL(debugMagicTokenURL))
+        #expect(debugRedactedURL == LoggingURLRedactor.redactedURL(debugMagicTokenURL))
 
         let alphaMagicTokenURL = URL(string: "wpalpha://magic-login?foo=bar&token=foo")!
         let alphaRedactedURL = URL(string: "wpalpha://magic-login?foo=bar&token=redacted")!
-        XCTAssertEqual(alphaRedactedURL, LoggingURLRedactor.redactedURL(alphaMagicTokenURL))
+        #expect(alphaRedactedURL == LoggingURLRedactor.redactedURL(alphaMagicTokenURL))
     }
 
-    func testThatSafeURLsAreNotRedacted() {
+    @Test func testThatSafeURLsAreNotRedacted() {
         let safeURL = URL(string: "https://foo.com/bar?token=baz")!
-        XCTAssertEqual(safeURL, LoggingURLRedactor.redactedURL(safeURL))
+        #expect(safeURL == LoggingURLRedactor.redactedURL(safeURL))
     }
 }

--- a/Modules/Tests/WordPressSharedTests/MathTest.swift
+++ b/Modules/Tests/WordPressSharedTests/MathTest.swift
@@ -1,60 +1,61 @@
-import XCTest
+import CoreGraphics
+import Testing
 @testable import WordPressShared
 
-class MathTest: XCTestCase {
+struct MathTest {
 
-    func testRound() {
-        XCTAssertEqual((-5).round(5), -5)
-        XCTAssertEqual((-4).round(5), -5)
-        XCTAssertEqual((-3).round(5), -5)
-        XCTAssertEqual((-2).round(5), 0)
-        XCTAssertEqual((-1).round(5), 0)
-        XCTAssertEqual(0.round(5), 0)
-        XCTAssertEqual(1.round(5), 0)
-        XCTAssertEqual(2.round(5), 0)
-        XCTAssertEqual(3.round(5), 5)
-        XCTAssertEqual(4.round(5), 5)
-        XCTAssertEqual(5.round(5), 5)
-        XCTAssertEqual(6.round(5), 5)
-        XCTAssertEqual(7.round(5), 5)
-        XCTAssertEqual(120.round(50), 100)
-        XCTAssertEqual(245.round(50), 250)
+    @Test func testRound() {
+        #expect((-5).round(5) == -5)
+        #expect((-4).round(5) == -5)
+        #expect((-3).round(5) == -5)
+        #expect((-2).round(5) == 0)
+        #expect((-1).round(5) == 0)
+        #expect(0.round(5) == 0)
+        #expect(1.round(5) == 0)
+        #expect(2.round(5) == 0)
+        #expect(3.round(5) == 5)
+        #expect(4.round(5) == 5)
+        #expect(5.round(5) == 5)
+        #expect(6.round(5) == 5)
+        #expect(7.round(5) == 5)
+        #expect(120.round(50) == 100)
+        #expect(245.round(50) == 250)
     }
 
-    func testClamp() {
-        XCTAssertEqual(5.clamp(min: 10, max: 20), 10)
-        XCTAssertEqual(10.clamp(min: 10, max: 20), 10)
-        XCTAssertEqual(15.clamp(min: 10, max: 20), 15)
-        XCTAssertEqual(20.clamp(min: 10, max: 20), 20)
-        XCTAssertEqual(30.clamp(min: 10, max: 20), 20)
+    @Test func testClamp() {
+        #expect(5.clamp(min: 10, max: 20) == 10)
+        #expect(10.clamp(min: 10, max: 20) == 10)
+        #expect(15.clamp(min: 10, max: 20) == 15)
+        #expect(20.clamp(min: 10, max: 20) == 20)
+        #expect(30.clamp(min: 10, max: 20) == 20)
     }
 
-    func testClampCGSizeWithSize() {
+    @Test func testClampCGSizeWithSize() {
         let maxSize = CGSize(width: 4000, height: 3000)
         let minSize = CGSize(width: 400, height: 300)
 
         do {
             let clamped = CGSize(width: 3000, height: 4000).clamp(min: minSize, max: maxSize)
             let expected = CGSize(width: 3000, height: 3000)
-            XCTAssertEqual(clamped, expected)
+            #expect(clamped == expected)
         }
 
         do {
             let clamped = CGSize(width: 6000, height: 4000).clamp(min: minSize, max: maxSize)
             let expected = CGSize(width: 4000, height: 3000)
-            XCTAssertEqual(clamped, expected)
+            #expect(clamped == expected)
         }
 
         do {
             let clamped = CGSize(width: 100, height: 400).clamp(min: minSize, max: maxSize)
             let expected = CGSize(width: 400, height: 400)
-            XCTAssertEqual(clamped, expected)
+            #expect(clamped == expected)
         }
 
         do {
             let clamped = CGSize(width: 100, height: 100).clamp(min: minSize, max: maxSize)
             let expected = CGSize(width: 400, height: 300)
-            XCTAssertEqual(clamped, expected)
+            #expect(clamped == expected)
         }
     }
 }

--- a/Modules/Tests/WordPressSharedTests/MediaUploadHashTests.swift
+++ b/Modules/Tests/WordPressSharedTests/MediaUploadHashTests.swift
@@ -1,20 +1,12 @@
 import Foundation
-import XCTest
+import Testing
 
-class MediaUploadHashTests: XCTestCase {
+struct MediaUploadHashTests {
 
-    override func setUp() {
-        super.setUp()
-    }
-
-    override func tearDown() {
-        super.tearDown()
-    }
-
-    func testMediaUploadHash() {
+    @Test func testMediaUploadHash() {
         let preSavedHash = -3384528372733689582
         let sampleMediaID = "x-coredata://2CE343D5-9019-44AB-9C59-E393C238A497/Media/p5565"
 
-        XCTAssertEqual(preSavedHash, sampleMediaID.hash, "The presaved hash must be equal to the generated one. If this fails the Gutenberg extension on Media called gutenbergUploadID needs to be changed")
+        #expect(preSavedHash == sampleMediaID.hash, "The presaved hash must be equal to the generated one. If this fails the Gutenberg extension on Media called gutenbergUploadID needs to be changed")
     }
 }

--- a/Modules/Tests/WordPressSharedTests/NSAttributedStringTests.swift
+++ b/Modules/Tests/WordPressSharedTests/NSAttributedStringTests.swift
@@ -1,25 +1,25 @@
 import Foundation
-import XCTest
+import Testing
 import WordPressShared
 
 // MARK: - NSAttributedString Unit Tests
 //
-open class NSAttributedStringTests: XCTestCase {
+struct NSAttributedStringTests {
     /// Verifies that `trimNewLines` effectively nukes leading newline characters.
     ///
-    func testTrimNewlinesEffectivelyNukesLeadingNewlines() {
+    @Test func testTrimNewlinesEffectivelyNukesLeadingNewlines() {
         let expected = "Lord Yosemite SHOULD be a Game of Thrones Character"
         let input = NSAttributedString(string: "\n\n\n\(expected)")
 
-        XCTAssertEqual(input.trimNewlines().string, expected)
+        #expect(input.trimNewlines().string == expected)
     }
 
     /// Verifies that `trimNewLines` effectively nukes trailing newline characters.
     ///
-    func testTrimNewlinesEffectivelyNukesTrailingNewlines() {
+    @Test func testTrimNewlinesEffectivelyNukesTrailingNewlines() {
         let expected = "Lord Yosemite SHOULD be a Game of Thrones Character"
         let input = NSAttributedString(string: "\(expected)\n\n\n")
 
-        XCTAssertEqual(input.trimNewlines().string, expected)
+        #expect(input.trimNewlines().string == expected)
     }
 }

--- a/Modules/Tests/WordPressSharedTests/NSDateHelperTest.swift
+++ b/Modules/Tests/WordPressSharedTests/NSDateHelperTest.swift
@@ -1,8 +1,8 @@
 import Foundation
-import XCTest
+import Testing
 @testable import WordPressShared
 
-class NSDateHelperTest: XCTestCase {
+struct NSDateHelperTest {
     struct Data {
         let year: Int
         let month: Int
@@ -21,38 +21,38 @@ class NSDateHelperTest: XCTestCase {
         return formatter
     }
 
-    override func setUp() {
+    init() {
         NSTimeZone.default = TimeZone(secondsFromGMT: 0)!
         date = dateFormatter.date(from: data.dateString)
     }
 
-    func testDateAndTimeComponents() {
-        XCTAssertNotNil(date)
+    @Test func testDateAndTimeComponents() {
+        #expect(date != nil)
 
         let components = date!.dateAndTimeComponents()
-        XCTAssertEqual(components.year, data.year)
-        XCTAssertEqual(components.month, data.month)
-        XCTAssertEqual(components.day, data.day)
+        #expect(components.year == data.year)
+        #expect(components.month == data.month)
+        #expect(components.day == data.day)
     }
 
     /// Verifies that `mediumString` produces relative format strings when less than 7 days have elapsed.
     /// If this test is failing, check that the Test Plan is still using en-US as its language
-    func testToMediumStringRelativeString() {
+    @Test func testToMediumStringRelativeString() {
         let date = Date()
 
-        XCTAssertEqual(date.toMediumString(), "now")
+        #expect(date.toMediumString() == "now")
 
-        XCTAssertEqual(date.addingTimeInterval(-60 * 5).toMediumString(), "5 minutes ago")
-        XCTAssertEqual(date.addingTimeInterval(1).addingTimeInterval(60 * 5).toMediumString(), "in 5 minutes")
+        #expect(date.addingTimeInterval(-60 * 5).toMediumString() == "5 minutes ago")
+        #expect(date.addingTimeInterval(1).addingTimeInterval(60 * 5).toMediumString() == "in 5 minutes")
 
-        XCTAssertEqual(date.addingTimeInterval(-60 * 60 * 2).toMediumString(), "2 hours ago")
-        XCTAssertEqual(date.addingTimeInterval(1).addingTimeInterval(60 * 60 * 2).toMediumString(), "in 2 hours")
+        #expect(date.addingTimeInterval(-60 * 60 * 2).toMediumString() == "2 hours ago")
+        #expect(date.addingTimeInterval(1).addingTimeInterval(60 * 60 * 2).toMediumString() == "in 2 hours")
 
-        XCTAssertEqual(date.addingTimeInterval(-60 * 60 * 24).toMediumString(), "yesterday")
-        XCTAssertEqual(date.addingTimeInterval(1).addingTimeInterval(60 * 60 * 24).toMediumString(), "tomorrow")
+        #expect(date.addingTimeInterval(-60 * 60 * 24).toMediumString() == "yesterday")
+        #expect(date.addingTimeInterval(1).addingTimeInterval(60 * 60 * 24).toMediumString() == "tomorrow")
 
-        XCTAssertEqual(date.addingTimeInterval(-60 * 60 * 24 * 6).toMediumString(), "6 days ago")
-        XCTAssertEqual(date.addingTimeInterval(1).addingTimeInterval(60 * 60 * 24 * 6).toMediumString(), "in 6 days")
+        #expect(date.addingTimeInterval(-60 * 60 * 24 * 6).toMediumString() == "6 days ago")
+        #expect(date.addingTimeInterval(1).addingTimeInterval(60 * 60 * 24 * 6).toMediumString() == "in 6 days")
     }
 
     /// Verifies that  `mediumStringWithTime` takes into account the time zone adjustment
@@ -60,10 +60,10 @@ class NSDateHelperTest: XCTestCase {
     /// This legacy test is a bit silly because it is simply testing that the code calls `DateFormatter` with the expected configuration.
     /// This was done to make the test robust against underlying changes in `DateFormatter`'s behavior.
     /// Example failure this avoids: https://buildkite.com/automattic/wordpress-shared-ios/builds/235#018ed45e-c2be-40e5-9759-6bd7c0735ce9/6-2623
-    func testMediumStringTimeZoneAdjust() {
+    @Test func testMediumStringTimeZoneAdjust() {
         let date = Date()
         let timeZone = TimeZone(secondsFromGMT: Calendar.current.timeZone.secondsFromGMT() - (60 * 60))
-        XCTAssertEqual(date.toMediumString(inTimeZone: timeZone), "now")
+        #expect(date.toMediumString(inTimeZone: timeZone) == "now")
 
         let timeFormatter = DateFormatter()
         timeFormatter.doesRelativeDateFormatting = true
@@ -71,11 +71,11 @@ class NSDateHelperTest: XCTestCase {
         timeFormatter.timeStyle = .short
         let withoutTimeZoneAdjust = timeFormatter.string(from: date)
 
-        XCTAssertEqual(date.mediumStringWithTime(), withoutTimeZoneAdjust)
+        #expect(date.mediumStringWithTime() == withoutTimeZoneAdjust)
 
         timeFormatter.timeZone = timeZone
         let withTimeZoneAdjust = timeFormatter.string(from: date)
 
-        XCTAssertEqual(date.mediumStringWithTime(timeZone: timeZone), withTimeZoneAdjust)
+        #expect(date.mediumStringWithTime(timeZone: timeZone) == withTimeZoneAdjust)
     }
 }

--- a/Modules/Tests/WordPressSharedTests/NotificationCenterObserveOnceTests.swift
+++ b/Modules/Tests/WordPressSharedTests/NotificationCenterObserveOnceTests.swift
@@ -1,30 +1,31 @@
-import XCTest
+import Foundation
+import Testing
 @testable import WordPressShared
 
 private let counterKey = "counter"
 
-class NotificationCenterObserveOnceTests: XCTestCase {
+@Suite(.serialized)
+final class NotificationCenterObserveOnceTests {
     let testNotification = Notification.Name("NotificationCenterObserveOnceTestNotification")
     let notificationCenter = NotificationCenter.default
     var observer: NSObjectProtocol?
 
-    override func tearDown() {
-        super.tearDown()
+    deinit {
         observer = nil
     }
 
-    func testNotificationIsOnlyReceivedOnce() {
+    @Test func testNotificationIsOnlyReceivedOnce() {
         var timesReceived = 0
         observer = notificationCenter.observeOnce(forName: testNotification, object: nil, queue: nil, using: { _ in
             timesReceived += 1
         })
         notificationCenter.post(name: testNotification, object: nil)
-        XCTAssertEqual(timesReceived, 1, "Observer should get the notification once")
+        #expect(timesReceived == 1, "Observer should get the notification once")
         notificationCenter.post(name: testNotification, object: nil)
-        XCTAssertEqual(timesReceived, 1, "Observer should get the notification only once")
+        #expect(timesReceived == 1, "Observer should get the notification only once")
     }
 
-    func testNotificationIsOnlyReceivedWhenMatchesFilter() {
+    @Test func testNotificationIsOnlyReceivedWhenMatchesFilter() {
         var timesReceived = 0
         observer = notificationCenter.observeOnce(forName: testNotification, object: nil, queue: nil, using: { _ in
             timesReceived += 1
@@ -35,15 +36,15 @@ class NotificationCenterObserveOnceTests: XCTestCase {
             return counter > 2
         })
         notificationCenter.post(notification(counter: 0))
-        XCTAssertEqual(timesReceived, 0, "Observer should not receive the notification for counter < 2")
+        #expect(timesReceived == 0, "Observer should not receive the notification for counter < 2")
         notificationCenter.post(notification(counter: 1))
-        XCTAssertEqual(timesReceived, 0, "Observer should not receive the notification for counter < 2")
+        #expect(timesReceived == 0, "Observer should not receive the notification for counter < 2")
         notificationCenter.post(notification(counter: 2))
-        XCTAssertEqual(timesReceived, 0, "Observer should not receive the notification for counter < 2")
+        #expect(timesReceived == 0, "Observer should not receive the notification for counter < 2")
         notificationCenter.post(notification(counter: 3))
-        XCTAssertEqual(timesReceived, 1, "Observer should get the notification once")
+        #expect(timesReceived == 1, "Observer should get the notification once")
         notificationCenter.post(notification(counter: 4))
-        XCTAssertEqual(timesReceived, 1, "Observer should get the notification only once")
+        #expect(timesReceived == 1, "Observer should get the notification only once")
     }
 
     private func notification(counter: Int) -> Foundation.Notification {

--- a/Modules/Tests/WordPressSharedTests/QRLoginURLParserTests.swift
+++ b/Modules/Tests/WordPressSharedTests/QRLoginURLParserTests.swift
@@ -1,37 +1,38 @@
-import XCTest
+import Foundation
+import Testing
 @testable import WordPressShared
 
-class QRLoginURLParserTests: XCTestCase {
+struct QRLoginURLParserTests {
     /// Test to make sure isValidHost returns true when passed a valid URL host
-    func testIsValidHostSuccess() {
+    @Test func testIsValidHostSuccess() {
         let url = URL(string: "https://apps.wordpress.com")!
-        XCTAssertTrue(QRLoginURLParser.isValidHost(url: url))
+        #expect(QRLoginURLParser.isValidHost(url: url))
     }
 
     /// Test to make sure isValidHost returns false when passed a URL with an unsupported host
-    func testIsValidHostFailure() {
+    @Test func testIsValidHostFailure() {
         let url = URL(string: "https://wordpress.com")!
-        XCTAssertFalse(QRLoginURLParser.isValidHost(url: url))
+        #expect(!(QRLoginURLParser.isValidHost(url: url)))
     }
 
     /// Make sure the parser does not return nil when it successfully parses a URL
-    func testParserSuccess() {
+    @Test func testParserSuccess() {
         let urlString = "https://apps.wordpress.com?#qr-code-login?token=hello&data=world"
         let parser = QRLoginURLParser(urlString: urlString)
 
-        XCTAssertNotNil(parser.parse())
+        #expect(parser.parse() != nil)
     }
 
     /// Make sure the parser returns nil when it can't parse a URL
-    func testParserFailure() {
+    @Test func testParserFailure() {
         let urlString = "https://apps.wordpress.com?token=shouldnt&data=work"
         let parser = QRLoginURLParser(urlString: urlString)
 
-        XCTAssertNil(parser.parse())
+        #expect(parser.parse() == nil)
     }
 
     /// Make sure the QRLoginToken values are set correctly
-    func testLoginTokenIsValid() {
+    @Test func testLoginTokenIsValid() {
         let token = "hello"
         let data = "world"
 
@@ -39,8 +40,8 @@ class QRLoginURLParserTests: XCTestCase {
         let parser = QRLoginURLParser(urlString: urlString)
         let loginToken = parser.parse()
 
-        XCTAssertNotNil(loginToken)
-        XCTAssertEqual(loginToken!.token, token)
-        XCTAssertEqual(loginToken!.data, data)
+        #expect(loginToken != nil)
+        #expect(loginToken!.token == token)
+        #expect(loginToken!.data == data)
     }
 }

--- a/Modules/Tests/WordPressSharedTests/QueueTests.swift
+++ b/Modules/Tests/WordPressSharedTests/QueueTests.swift
@@ -1,36 +1,30 @@
-import XCTest
+import Testing
 @testable import WordPressShared
 
-class QueueTests: XCTestCase {
+final class QueueTests {
     private var queue = Queue<Int>()
 
-    override func setUp() {
-        super.setUp()
-
-        queue = Queue<Int>()
-    }
-
-    func testNewQueueIsEmpty() {
+    @Test func testNewQueueIsEmpty() {
         let item = queue.pop()
-        XCTAssertNil(item)
+        #expect(item == nil)
     }
 
-    func testSingleItemAddedToQueue() {
+    @Test func testSingleItemAddedToQueue() {
         queue.push(1)
         let item = queue.pop()
-        XCTAssertEqual(item, 1)
+        #expect(item == 1)
     }
 
-    func testSingleItemRemovedFromQueue() {
+    @Test func testSingleItemRemovedFromQueue() {
         queue.push(1)
 
         let item = queue.pop()
         let nothing = queue.pop()
-        XCTAssertNotNil(item)
-        XCTAssertNil(nothing)
+        #expect(item != nil)
+        #expect(nothing == nil)
     }
 
-    func testMultipleItemsReturnedInFIFOOrder() {
+    @Test func testMultipleItemsReturnedInFIFOOrder() {
         queue.push(1)
         queue.push(2)
         queue.push(3)
@@ -44,14 +38,14 @@ class QueueTests: XCTestCase {
         let item4 = queue.pop()
         let item5 = queue.pop()
 
-        XCTAssertEqual(item1, 1)
-        XCTAssertEqual(item2, 2)
-        XCTAssertEqual(item3, 3)
-        XCTAssertEqual(item4, 4)
-        XCTAssertNil(item5)
+        #expect(item1 == 1)
+        #expect(item2 == 2)
+        #expect(item3 == 3)
+        #expect(item4 == 4)
+        #expect(item5 == nil)
     }
 
-    func testRemoveAllEmptiesTheQueue() {
+    @Test func testRemoveAllEmptiesTheQueue() {
         // Given
         queue.push(1)
         queue.push(2)
@@ -61,10 +55,10 @@ class QueueTests: XCTestCase {
         queue.removeAll()
 
         // Then
-        XCTAssertNil(queue.pop())
+        #expect(queue.pop() == nil)
     }
 
-    func testRemoveAllRemovesElementsMatchingThePredicate() {
+    @Test func testRemoveAllRemovesElementsMatchingThePredicate() {
         // Given
         queue.push(1)
         queue.push(2)
@@ -74,7 +68,7 @@ class QueueTests: XCTestCase {
         queue.removeAll { $0 >= 2 }
 
         // Then
-        XCTAssertEqual(queue.pop(), 1)
-        XCTAssertNil(queue.pop())
+        #expect(queue.pop() == 1)
+        #expect(queue.pop() == nil)
     }
 }

--- a/Modules/Tests/WordPressSharedTests/ReaderCSSTests.swift
+++ b/Modules/Tests/WordPressSharedTests/ReaderCSSTests.swift
@@ -1,24 +1,25 @@
-import XCTest
+import Foundation
+import Testing
 
 @testable import WordPressShared
 
-class ReaderCSSTests: XCTestCase {
+struct ReaderCSSTests {
     // MARK: - When online
 
     /// When requesting the CSS for the first time, use the current date in seconds
     ///
-    func testOnlineFirstTime() {
+    @Test func testOnlineFirstTime() {
         let now = Int(Date().timeIntervalSince1970)
         let database = EphemeralKeyValueDatabase()
 
         let readerCSS = ReaderCSS(now: now, store: database, isInternetReachable: { true })
 
-        XCTAssertEqual(readerCSS.address, "https://wordpress.com/calypso/reader-mobile.css?\(now)")
+        #expect(readerCSS.address == "https://wordpress.com/calypso/reader-mobile.css?\(now)")
     }
 
     /// When the CSS was requested at least 5 days ago, update the address
     ///
-    func testOnlineExpired() {
+    @Test func testOnlineExpired() {
         let now = Int(Date().timeIntervalSince1970)
         let fiveDaysAgo = now - 5 * 60 * 60 * 24
         let database = EphemeralKeyValueDatabase()
@@ -26,12 +27,12 @@ class ReaderCSSTests: XCTestCase {
 
         let readerCSS = ReaderCSS(now: now, store: database, isInternetReachable: { true })
 
-        XCTAssertEqual(readerCSS.address, "https://wordpress.com/calypso/reader-mobile.css?\(now)")
+        #expect(readerCSS.address == "https://wordpress.com/calypso/reader-mobile.css?\(now)")
     }
 
     /// When the CSS was requested less than 5 days ago, use the time of when it was requested
     ///
-    func testOnlineNotExpired() {
+    @Test func testOnlineNotExpired() {
         let now = Int(Date().timeIntervalSince1970)
         let fourDaysAgo = now - 4 * 60 * 60 * 24
         let database = EphemeralKeyValueDatabase()
@@ -39,25 +40,25 @@ class ReaderCSSTests: XCTestCase {
 
         let readerCSS = ReaderCSS(now: now, store: database, isInternetReachable: { true })
 
-        XCTAssertEqual(readerCSS.address, "https://wordpress.com/calypso/reader-mobile.css?\(fourDaysAgo)")
+        #expect(readerCSS.address == "https://wordpress.com/calypso/reader-mobile.css?\(fourDaysAgo)")
     }
 
     // MARK: - When offline
 
     /// When requesting the CSS for the first time, use the current date in seconds
     ///
-    func testOfflineFirstTime() {
+    @Test func testOfflineFirstTime() {
         let now = Int(Date().timeIntervalSince1970)
         let database = EphemeralKeyValueDatabase()
 
         let readerCSS = ReaderCSS(now: now, store: database, isInternetReachable: { false })
 
-        XCTAssertEqual(readerCSS.address, "https://wordpress.com/calypso/reader-mobile.css?\(now)")
+        #expect(readerCSS.address == "https://wordpress.com/calypso/reader-mobile.css?\(now)")
     }
 
     /// When the CSS was requested at least 5 days ago but device isssss offline, keep the address
     ///
-    func testOfflineExpired() {
+    @Test func testOfflineExpired() {
         let now = Int(Date().timeIntervalSince1970)
         let fiveDaysAgo = now - 5 * 60 * 60 * 24
         let database = EphemeralKeyValueDatabase()
@@ -65,12 +66,12 @@ class ReaderCSSTests: XCTestCase {
 
         let readerCSS = ReaderCSS(now: now, store: database, isInternetReachable: { false })
 
-        XCTAssertEqual(readerCSS.address, "https://wordpress.com/calypso/reader-mobile.css?\(fiveDaysAgo)")
+        #expect(readerCSS.address == "https://wordpress.com/calypso/reader-mobile.css?\(fiveDaysAgo)")
     }
 
     /// When the CSS was requested less than 5 days ago and we're offline, keep the old timestamp
     ///
-    func testOfflineNotExpired() {
+    @Test func testOfflineNotExpired() {
         let now = Int(Date().timeIntervalSince1970)
         let fourDaysAgo = now - 4 * 60 * 60 * 24
         let database = EphemeralKeyValueDatabase()
@@ -78,6 +79,6 @@ class ReaderCSSTests: XCTestCase {
 
         let readerCSS = ReaderCSS(now: now, store: database, isInternetReachable: { false })
 
-        XCTAssertEqual(readerCSS.address, "https://wordpress.com/calypso/reader-mobile.css?\(fourDaysAgo)")
+        #expect(readerCSS.address == "https://wordpress.com/calypso/reader-mobile.css?\(fourDaysAgo)")
     }
 }

--- a/Modules/Tests/WordPressSharedTests/Scanner+QuotedTextTests.swift
+++ b/Modules/Tests/WordPressSharedTests/Scanner+QuotedTextTests.swift
@@ -1,12 +1,12 @@
 import Foundation
-import XCTest
+import Testing
 import WordPressShared
 
 // MARK: - Scanner+QuotedTextTests
 //
-class ScannerTests: XCTestCase {
+struct ScannerTests {
 
-    func testScannerCorrectlyReturnsSingleQuotes() {
+    @Test func testScannerCorrectlyReturnsSingleQuotes() {
         // Given
         let inputString = #"Lorem "ipsum" dolor sit amet elit"#
 
@@ -15,10 +15,10 @@ class ScannerTests: XCTestCase {
         let quotes = scanner.scanQuotedText()
 
         // Then
-        XCTAssertEqual(quotes, ["ipsum"])
+        #expect(quotes == ["ipsum"])
     }
 
-    func testScannerCorrectlyReturnsMultipleQuotes() {
+    @Test func testScannerCorrectlyReturnsMultipleQuotes() {
         // Given
         let inputString = #"Lorem "ipsum" dolor sit "amet" elit"#
 
@@ -27,10 +27,10 @@ class ScannerTests: XCTestCase {
         let quotes = scanner.scanQuotedText()
 
         // Then
-        XCTAssertEqual(quotes, ["ipsum", "amet"])
+        #expect(quotes == ["ipsum", "amet"])
     }
 
-    func testScannerReturnsOnlyClosedQuotes() {
+    @Test func testScannerReturnsOnlyClosedQuotes() {
         // Given
         let inputString = #""Lorem" ipsum dolor sit "amet elit"#
 
@@ -39,10 +39,10 @@ class ScannerTests: XCTestCase {
         let quotes = scanner.scanQuotedText()
 
         // Then
-        XCTAssertEqual(quotes, ["Lorem"])
+        #expect(quotes == ["Lorem"])
     }
 
-    func testScannerReturnsOnlyNonEmptyQuotes() {
+    @Test func testScannerReturnsOnlyNonEmptyQuotes() {
         // Given
         let inputString = #"Lorem "ipsum" "" dolor "sit" """"amet "elit""#
 
@@ -51,10 +51,10 @@ class ScannerTests: XCTestCase {
         let quotes = scanner.scanQuotedText()
 
         // Then
-        XCTAssertEqual(quotes, ["ipsum", "sit", "elit"])
+        #expect(quotes == ["ipsum", "sit", "elit"])
     }
 
-    func testScannerReturnsEmptyArrayForNoResults() {
+    @Test func testScannerReturnsEmptyArrayForNoResults() {
         // Given
         let inputString = #"Lorem ipsum dolor sit amet elit"#
 
@@ -63,6 +63,6 @@ class ScannerTests: XCTestCase {
         let quotes = scanner.scanQuotedText()
 
         // Then
-        XCTAssertEqual(quotes, [])
+        #expect(quotes == [])
     }
 }

--- a/Modules/Tests/WordPressSharedTests/SiteCreationHeaderDataTests.swift
+++ b/Modules/Tests/WordPressSharedTests/SiteCreationHeaderDataTests.swift
@@ -1,7 +1,7 @@
-import XCTest
+import Testing
 @testable import WordPressShared
 
-final class SiteCreationHeaderDataTests: XCTestCase {
+struct SiteCreationHeaderDataTests {
     private struct Constants {
         static let title = "🌈"
         static let subtitle = "🦄"
@@ -9,21 +9,15 @@ final class SiteCreationHeaderDataTests: XCTestCase {
 
     private var data: SiteCreationHeaderData?
 
-    override func setUp() {
-        super.setUp()
+    init() {
         data = SiteCreationHeaderData(title: Constants.title, subtitle: Constants.subtitle)
     }
 
-    override func tearDown() {
-        data = nil
-        super.tearDown()
+    @Test func testTitleRemainsConstant() {
+        #expect(data?.title == Constants.title)
     }
 
-    func testTitleRemainsConstant() {
-        XCTAssertEqual(data?.title, Constants.title)
-    }
-
-    func testSubtitleRemainsConstant() {
-        XCTAssertEqual(data?.subtitle, Constants.subtitle)
+    @Test func testSubtitleRemainsConstant() {
+        #expect(data?.subtitle == Constants.subtitle)
     }
 }

--- a/Modules/Tests/WordPressSharedTests/StringHelperTests.swift
+++ b/Modules/Tests/WordPressSharedTests/StringHelperTests.swift
@@ -1,18 +1,9 @@
-import XCTest
+import Foundation
+import Testing
 
 @testable import WordPressShared
 
-class StringHelperTests: XCTestCase {
-
-    override func setUp() {
-        super.setUp()
-        // Put setup code here. This method is called before the invocation of each test method in the class.
-    }
-
-    override func tearDown() {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
-        super.tearDown()
-    }
+struct StringHelperTests {
 
     // Note:
     // Specially extra aligned for my RWC friends. With love.
@@ -23,16 +14,16 @@ class StringHelperTests: XCTestCase {
     let text = " Lorem Ipsum Matarem Les Idiotum Sarasum Zorrentum Modus Operandum "
     let anchor = "<a href=\"%@\">%@</a>"
 
-    func testLinkifyingPlainLinks() {
+    @Test func testLinkifyingPlainLinks() {
         var count = 0
         for link in links {
             let linkified = String(format: anchor, link, linkText[count])
-            XCTAssertEqual(link.stringWithAnchoredLinks(), linkified, "Oh noes!")
+            #expect(link.stringWithAnchoredLinks() == linkified, "Oh noes!")
             count += 1
         }
     }
 
-    func testLinkifyingLinksWithinText() {
+    @Test func testLinkifyingLinksWithinText() {
         var plain = String()
         var linkified = String()
 
@@ -43,41 +34,41 @@ class StringHelperTests: XCTestCase {
             count += 1
         }
 
-        XCTAssertEqual(plain.stringWithAnchoredLinks(), linkified, "Oh noes!")
+        #expect(plain.stringWithAnchoredLinks() == linkified, "Oh noes!")
     }
 
-    func testLinkifyingPlainText() {
-        XCTAssertEqual(text.stringWithAnchoredLinks(), text, "Oh noes!")
+    @Test func testLinkifyingPlainText() {
+        #expect(text.stringWithAnchoredLinks() == text, "Oh noes!")
     }
 
-    func testTrim() {
+    @Test func testTrim() {
         let trimmedString = "string string"
         let sourceString = "   \(trimmedString)   "
-        XCTAssert(trimmedString == sourceString.trim())
+        #expect(trimmedString == sourceString.trim())
     }
 
-    func testRemovePrefix() {
+    @Test func testRemovePrefix() {
         let string = "X-Post: This is a test"
-        XCTAssertEqual("This is a test", string.removingPrefix("X-Post: "))
-        XCTAssertEqual(string, string.removingPrefix("Something Else"))
+        #expect("This is a test" == string.removingPrefix("X-Post: "))
+        #expect(string == string.removingPrefix("Something Else"))
     }
 
-    func testRemoveSuffix() {
+    @Test func testRemoveSuffix() {
         let string = "http://example.com/"
-        XCTAssertEqual("http://example.com", string.removingSuffix("/"))
-        XCTAssertEqual("http://example", string.removingSuffix(".com/"))
-        XCTAssertEqual(string, string.removingSuffix(".org/"))
+        #expect("http://example.com" == string.removingSuffix("/"))
+        #expect("http://example" == string.removingSuffix(".com/"))
+        #expect(string == string.removingSuffix(".org/"))
     }
 
-    func testRemovePrefixPattern() {
+    @Test func testRemovePrefixPattern() {
         let string = "X-Post: This is a test"
-        XCTAssertEqual("This is a test", try! string.removingPrefix(pattern: "X-.*?: +"))
-        XCTAssertEqual(string, try! string.removingPrefix(pattern: "Th.* "))
+        #expect("This is a test" == (try! string.removingPrefix(pattern: "X-.*?: +")))
+        #expect(string == (try! string.removingPrefix(pattern: "Th.* ")))
     }
 
-    func testRemoveSuffixPattern() {
+    @Test func testRemoveSuffixPattern() {
         let string = "X-Post: This is a test"
-        XCTAssertEqual("X-Post: This is", try! string.removingSuffix(pattern: "( a)? +test"))
-        XCTAssertEqual(string, try! string.removingSuffix(pattern: "Th.* "))
+        #expect("X-Post: This is" == (try! string.removingSuffix(pattern: "( a)? +test")))
+        #expect(string == (try! string.removingSuffix(pattern: "Th.* ")))
     }
 }

--- a/Modules/Tests/WordPressSharedTests/StringRankedSearchTests.swift
+++ b/Modules/Tests/WordPressSharedTests/StringRankedSearchTests.swift
@@ -1,77 +1,69 @@
-import XCTest
+import Testing
 import WordPressShared
 
-final class StringRankedSearchTests: XCTestCase {
-    func testScoreInRange() {
+struct StringRankedSearchTests {
+    @Test func testScoreInRange() {
         // High confidence
-        XCTAssertInRange(0.8...1.0, score("Appleseed", "Appleseed"))
-        XCTAssertInRange(0.8...1.0, score("John Appleseed", "Appleseed"))
-        XCTAssertInRange(0.8...1.0, score("John Appleseed", "John"))
-        XCTAssertInRange(0.8...1.0, score("John Appleseed", "App"))
-        XCTAssertInRange(0.8...1.0, score("John O'Appleseed", "App"))
-        XCTAssertInRange(0.8...1.0, score("john-appleseed", "j-a"))
-        XCTAssertInRange(0.8...1.0, score("#john-appleseed", "john"))
-        XCTAssertInRange(0.8...1.0, score("John Appleseed", "Apseed"))
+        expectInRange(0.8...1.0, score("Appleseed", "Appleseed"))
+        expectInRange(0.8...1.0, score("John Appleseed", "Appleseed"))
+        expectInRange(0.8...1.0, score("John Appleseed", "John"))
+        expectInRange(0.8...1.0, score("John Appleseed", "App"))
+        expectInRange(0.8...1.0, score("John O'Appleseed", "App"))
+        expectInRange(0.8...1.0, score("john-appleseed", "j-a"))
+        expectInRange(0.8...1.0, score("#john-appleseed", "john"))
+        expectInRange(0.8...1.0, score("John Appleseed", "Apseed"))
 
         // Medium confidence
-        XCTAssertInRange(0.5...0.8, score("John Appleseed", "A"))
-        XCTAssertInRange(0.5...0.8, score("John Appleseed", "Ap"))
-        XCTAssertInRange(0.5...0.8, score("John Appleseed", "ohn"))
-        XCTAssertInRange(0.5...0.8, score("#john-appleseed", "j-a"))
-        XCTAssertInRange(0.5...0.8, score("John Appleseed", "applex"))
+        expectInRange(0.5...0.8, score("John Appleseed", "A"))
+        expectInRange(0.5...0.8, score("John Appleseed", "Ap"))
+        expectInRange(0.5...0.8, score("John Appleseed", "ohn"))
+        expectInRange(0.5...0.8, score("#john-appleseed", "j-a"))
+        expectInRange(0.5...0.8, score("John Appleseed", "applex"))
 
         // Low confidence
-        XCTAssertInRange(0.2...0.5, score("John Appleseed", "Ae"))
-        XCTAssertInRange(0.2...0.5, score("John Appleseed", "Jn"))
+        expectInRange(0.2...0.5, score("John Appleseed", "Ae"))
+        expectInRange(0.2...0.5, score("John Appleseed", "Jn"))
 
         // Very low confidence
-        XCTAssertInRange(0.0...0.2, score("John Appleseed", "o"))
-        XCTAssertInRange(0.0...0.2, score("John Appleseed", "X"))
-        XCTAssertInRange(0.0...0.2, score("John Appleseed", "x"))
-        XCTAssertInRange(0.0...0.2, score("John Appleseed", "applexx"))
+        expectInRange(0.0...0.2, score("John Appleseed", "o"))
+        expectInRange(0.0...0.2, score("John Appleseed", "X"))
+        expectInRange(0.0...0.2, score("John Appleseed", "x"))
+        expectInRange(0.0...0.2, score("John Appleseed", "applexx"))
     }
 
-    func testBonuses() {
+    @Test func testBonuses() {
         // Bonus for the number of the matching words in the input.
-        XCTAssertLessThan(score("John Appleseed", "App"), score("Appleseed", "App"))
+        #expect(score("John Appleseed", "App") < score("Appleseed", "App"))
 
         // Bonus for distance between matches
-        XCTAssertLessThan(score("John Xxxx Appleseed", "John Appleseed"), score("John Appleseed Xxxx", "John Appleseed"))
+        #expect(score("John Xxxx Appleseed", "John Appleseed") < score("John Appleseed Xxxx", "John Appleseed"))
 
         // Bonus for distance between matches
-        XCTAssertLessThan(score("John Xxxx Appleseed", "John Appleseed"), score("John Appleseed Xxxx", "John Appleseed"))
+        #expect(score("John Xxxx Appleseed", "John Appleseed") < score("John Appleseed Xxxx", "John Appleseed"))
 
         // Bonus for distance between matches
-        XCTAssertLessThan(score("John Xxxx Appleseed", "John Appleseed"), score("Xxxx John Appleseed", "John Appleseed"))
+        #expect(score("John Xxxx Appleseed", "John Appleseed") < score("Xxxx John Appleseed", "John Appleseed"))
 
         // Bonus for more characters in a row
-        XCTAssertLessThan(score("Apxplesee", "App"), score("Appleseed", "App"))
+        #expect(score("Apxplesee", "App") < score("Appleseed", "App"))
 
         // Bonus for more characters in a row is higher than the penalty for a number of matches
-        XCTAssertLessThan(score("Apxplesee", "App"), score("John Appleseed", "App"))
+        #expect(score("Apxplesee", "App") < score("John Appleseed", "App"))
 
         // Bonus for more characters in a row is higher than the penalty for mismatches case.
-        XCTAssertLessThan(score("Apxplesee", "App"), score("appleseed", "App"))
+        #expect(score("Apxplesee", "App") < score("appleseed", "App"))
 
         // The diacritics are considered a match
-        XCTAssertLessThan(score("Kxhu", "Kahu"), score("Kāhu", "Kahu"))
+        #expect(score("Kxhu", "Kahu") < score("Kāhu", "Kahu"))
 
         // Bonus for exact match diacritics are present
-        XCTAssertLessThan(score("Kāhu", "Kahu"), score("Kahu", "Kahu"))
+        #expect(score("Kāhu", "Kahu") < score("Kahu", "Kahu"))
 
         // Bonus for exact match diacritics are present
-        XCTAssertLessThan(score("Kāhu", "Kahu"), score("Kāhu", "Kāhu"))
+        #expect(score("Kāhu", "Kahu") < score("Kāhu", "Kāhu"))
 
         // Bonus for number length match
-        XCTAssertLessThan(score("john-appleseed-xxxx", "project"), score("john-appleseed", "project"))
-    }
-
-    func xtestPerformance() throws {
-        measure {
-            for _ in 0..<10000 {
-                _ = score("John Appleseed", "John")
-            }
-        }
+        #expect(score("john-appleseed-xxxx", "project") < score("john-appleseed", "project"))
     }
 }
 
@@ -79,6 +71,10 @@ private func score(_ lhs: String, _ rhs: String) -> Double {
     StringRankedSearch(searchTerm: rhs).score(for: lhs)
 }
 
-private func XCTAssertInRange<T: Comparable>(_ range: some RangeExpression<T>, _ value: T, file: StaticString = #filePath, line: UInt = #line) {
-    XCTAssert(range.contains(value), "(\"\(value)\") is not in (\"\(range)\")", file: file, line: line)
+private func expectInRange<T: Comparable>(
+    _ range: some RangeExpression<T>,
+    _ value: T,
+    sourceLocation: SourceLocation = #_sourceLocation
+) {
+    #expect(range.contains(value), "(\"\(value)\") is not in (\"\(range)\")", sourceLocation: sourceLocation)
 }

--- a/Modules/Tests/WordPressSharedTests/StringRemovingMatchesTests.swift
+++ b/Modules/Tests/WordPressSharedTests/StringRemovingMatchesTests.swift
@@ -1,35 +1,35 @@
-import XCTest
+import Testing
 @testable import WordPressShared
 
-class StringRemovingMatchesTests: XCTestCase {
+struct StringRemovingMatchesTests {
 
-    func testStringRemovingMatches() {
+    @Test func testStringRemovingMatches() {
         let initial = "<p>Some Content</p>"
         let pattern = "<p>"
         let expected = "Some Content</p>"
 
         let final = initial.removingMatches(pattern: pattern)
 
-        XCTAssertEqual(final, expected)
+        #expect(final == expected)
     }
 
-    func testStringRemovingMatchesWithEmojis() {
+    @Test func testStringRemovingMatchesWithEmojis() {
         let initial = "🌎world🌎"
         let pattern = "🌎"
         let expected = "world"
 
         let final = initial.removingMatches(pattern: pattern)
 
-        XCTAssertEqual(final, expected)
+        #expect(final == expected)
     }
 
-    func testStringRemovingMatchesWithEmojis2() {
+    @Test func testStringRemovingMatchesWithEmojis2() {
         let initial = "🌎world🌎"
         let pattern = "world"
         let expected = "🌎🌎"
 
         let final = initial.removingMatches(pattern: pattern)
 
-        XCTAssertEqual(final, expected)
+        #expect(final == expected)
     }
 }

--- a/Modules/Tests/WordPressSharedTests/StringURLValidationTests.swift
+++ b/Modules/Tests/WordPressSharedTests/StringURLValidationTests.swift
@@ -1,11 +1,11 @@
-import XCTest
+import Testing
 @testable import WordPressShared
 
-class StringURLValidationTests: XCTestCase {
+struct StringURLValidationTests {
 
     // MARK: - Invalid URLs
 
-    func testInvalidURLs() {
+    @Test func testInvalidURLs() {
         let urls = [
             "invalidurl",
             "123123",
@@ -13,7 +13,7 @@ class StringURLValidationTests: XCTestCase {
 
         for url in urls {
             guard !url.isValidURL() else {
-                XCTFail("\(url) is valid (expected invalid).")
+                Issue.record("\(url) is valid (expected invalid).")
                 continue
             }
         }
@@ -21,7 +21,7 @@ class StringURLValidationTests: XCTestCase {
 
     // MARK: - Valid URLs
 
-    func testValidURLs() {
+    @Test func testValidURLs() {
         let urls = [
             "https://cheese-pc",
             "https://localhost",
@@ -30,7 +30,7 @@ class StringURLValidationTests: XCTestCase {
 
         for url in urls {
             guard url.isValidURL() else {
-                XCTFail("\(url) is invalid (expected valid).")
+                Issue.record("\(url) is invalid (expected valid).")
                 continue
             }
         }

--- a/Modules/Tests/WordPressSharedTests/URL+LinkNormalizationTests.swift
+++ b/Modules/Tests/WordPressSharedTests/URL+LinkNormalizationTests.swift
@@ -1,37 +1,28 @@
+import Foundation
 import WordPressShared
-import XCTest
+import Testing
 
-class URL_WordPressLinkNormalizationTests: XCTestCase {
+struct URL_WordPressLinkNormalizationTests {
 
-    override func setUp() {
-        super.setUp()
-        // Put setup code here. This method is called before the invocation of each test method in the class.
-    }
-
-    override func tearDown() {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
-        super.tearDown()
-    }
-
-    func testNormalizedURLForWordPressLink() {
+    @Test func testNormalizedURLForWordPressLink() {
         var url = URL(string: "www.wordpress.com")!
         var normalizedURL = url.normalizedURLForWordPressLink()
-        XCTAssertEqual("http://www.wordpress.com", normalizedURL.absoluteString)
+        #expect("http://www.wordpress.com" == normalizedURL.absoluteString)
 
         url = URL(string: "wordpress.com")!
         normalizedURL = url.normalizedURLForWordPressLink()
-        XCTAssertEqual("http://wordpress.com", normalizedURL.absoluteString)
+        #expect("http://wordpress.com" == normalizedURL.absoluteString)
 
         url = URL(string: "wordpress.com/index.html")!
         normalizedURL = url.normalizedURLForWordPressLink()
-        XCTAssertEqual("http://wordpress.com/index.html", normalizedURL.absoluteString)
+        #expect("http://wordpress.com/index.html" == normalizedURL.absoluteString)
 
         url = URL(string: "index.html")!
         normalizedURL = url.normalizedURLForWordPressLink()
-        XCTAssertEqual("http://index.html", normalizedURL.absoluteString)
+        #expect("http://index.html" == normalizedURL.absoluteString)
 
         url = URL(string: "/index.html")!
         normalizedURL = url.normalizedURLForWordPressLink()
-        XCTAssertEqual("/index.html", normalizedURL.absoluteString)
+        #expect("/index.html" == normalizedURL.absoluteString)
     }
 }

--- a/Modules/Tests/WordPressSharedTests/URLHelpersTests.swift
+++ b/Modules/Tests/WordPressSharedTests/URLHelpersTests.swift
@@ -1,23 +1,24 @@
-import XCTest
+import Foundation
+import Testing
 import WordPressShared
 
-class URLHelpersTests: XCTestCase {
+struct URLHelpersTests {
 
-    func testAddCacheBusterToExistingQueryParameters() async throws {
+    @Test func testAddCacheBusterToExistingQueryParameters() async throws {
         try await doTest("https://gravatar.com/avatar/1234?s=80")
     }
 
-    func testAddCacheBusterToCanonicalURL() async throws {
+    @Test func testAddCacheBusterToCanonicalURL() async throws {
         try await doTest("https://gravatar.com")
     }
 
     func doTest(_ urlString: String) async throws {
-        let url = try XCTUnwrap(URL(string: urlString))
+        let url = try #require(URL(string: urlString))
         let newURL = url.appendingGravatarCacheBusterParam()
-        XCTAssertNotEqual(url.absoluteString, newURL.absoluteString)
+        #expect(url.absoluteString != newURL.absoluteString)
 
         let components = URLComponents(url: newURL, resolvingAgainstBaseURL: false)
         let cacheBusterQueryItem = components?.queryItems?.first(where: { $0.name == "_" })
-        XCTAssertNotNil(cacheBusterQueryItem?.value)
+        #expect(cacheBusterQueryItem?.value != nil)
     }
 }

--- a/Modules/Tests/WordPressSharedTests/URLIncrementalFilenameTests.swift
+++ b/Modules/Tests/WordPressSharedTests/URLIncrementalFilenameTests.swift
@@ -1,58 +1,41 @@
+import Foundation
+import Testing
 import WordPressShared
-import XCTest
 
-class URLIncrementalFilenameTests: XCTestCase {
+struct URLIncrementalFilenameTests {
 
-    fileprivate lazy var tempTestDirectory: URL = {
-        return FileManager.default.temporaryDirectory.appendingPathComponent("URLIncrementalFilenameTests-\(UUID().uuidString)")
-    }()
+    private let tempTestDirectory = FileManager.default.temporaryDirectory.appendingPathComponent(
+        "URLIncrementalFilenameTests-\(UUID().uuidString)"
+    )
 
-    override func setUp() {
-        super.setUp()
-        do {
-            try FileManager.default.createDirectory(at: tempTestDirectory, withIntermediateDirectories: true, attributes: nil)
-        } catch {
-            XCTFail("Error on setup writing test directory: \(error.localizedDescription)")
-        }
-    }
-
-    override func tearDown() {
-        super.tearDown()
-        removeTemporaryTestDirectoryIfNeeded()
-    }
-
-    fileprivate func removeTemporaryTestDirectoryIfNeeded() {
-        let directory = tempTestDirectory
-        let fileManager = FileManager.default
-        guard fileManager.fileExists(atPath: directory.path) else {
-            return
-        }
-        do {
-            try fileManager.removeItem(at: directory)
-        } catch {
-            XCTFail("Error on removing test directory: \(error.localizedDescription)")
-        }
-    }
-
-    func testThatIncrementalFilenameURLWorks() {
+    @Test func testThatIncrementalFilenameURLWorks() throws {
+        try FileManager.default.createDirectory(
+            at: tempTestDirectory,
+            withIntermediateDirectories: true,
+            attributes: nil
+        )
+        defer { try? FileManager.default.removeItem(at: tempTestDirectory) }
 
         let sampleData = "{\"sample\": \"yes\"}"
         let filename = "sample.json"
 
         let url = tempTestDirectory.appendingPathComponent(filename, isDirectory: false).incrementalFilename()
         // Check that the first file name is unchanged, in the case that there no existing files of the same name
-        XCTAssertTrue(url.lastPathComponent == filename, "Error: initial URL filename did not match original filename")
-        do {
-            // Write the first sample file
-            try sampleData.write(to: url, atomically: true, encoding: .utf8)
-            let firstIncrement = url.incrementalFilename()
-            // Check that the increment matches what is expected when there is an existing file
-            XCTAssertTrue(firstIncrement.lastPathComponent == "sample-1.json", "Error: incremented URL filename was not incremented as expected")
-            try sampleData.write(to: firstIncrement, atomically: true, encoding: .utf8)
-            let secondIncrement = url.incrementalFilename()
-            XCTAssertTrue(secondIncrement.lastPathComponent == "sample-2.json", "Error: incremented URL filename was not incremented as expected")
-        } catch {
-            XCTFail("Error testing sample data: \(error.localizedDescription)")
-        }
+        #expect(url.lastPathComponent == filename, "Error: initial URL filename did not match original filename")
+
+        // Write the first sample file
+        try sampleData.write(to: url, atomically: true, encoding: .utf8)
+        let firstIncrement = url.incrementalFilename()
+        // Check that the increment matches what is expected when there is an existing file
+        #expect(
+            firstIncrement.lastPathComponent == "sample-1.json",
+            "Error: incremented URL filename was not incremented as expected"
+        )
+        try sampleData.write(to: firstIncrement, atomically: true, encoding: .utf8)
+        let secondIncrement = url.incrementalFilename()
+        #expect(
+            secondIncrement.lastPathComponent == "sample-2.json",
+            "Error: incremented URL filename was not incremented as expected"
+        )
     }
 }


### PR DESCRIPTION
Converts the last XCTest suites in the repo-root `swift test` run — the macOS cross-platform gate added in #25344 — to Swift Testing. That gate now runs **233 Swift Testing cases across 53 suites and zero XCTest cases**.

## What changed

38 test files across the four targets that still had XCTest, plus one deletion:

- **`GutenbergProcessorsTests`** (5), **`JetpackStatsWidgetsCoreTests`** (3), **`WordPressFluxTests`** (1), **`WordPressSharedTests`** (29). `WordPressCoreTests` was already Swift Testing.
- Delete `WordPressFluxTests/XCTestManifests.swift` — the Linux `allTests()` manifest is dead under Swift Testing, and was already `#if !canImport(ObjectiveC)` (empty on Apple platforms).

Most of it is mechanical: `XCTestCase` subclass → `struct` suite, `func testX` → `@Test func`, `XCTAssert*` → `#expect` / `try #require` / `Issue.record`, `setUp` → `init`. Four suites needed more than a rote swap.

### `WordPressFluxTests` runs on `@MainActor` now

Flux's `Dispatcher` traps off the main thread (`assertMainThread()`, `Dispatcher.swift:41`). XCTest ran these on the main thread so they passed; Swift Testing runs on the cooperative pool, so the plain conversion **aborted the entire `swift test` process** with `Assertion failed: Dispatcher should only be called from the main thread` — a trap, not a single recorded failure. Pinning the suite to `@MainActor` restores main-thread execution.

### `DebouncerTests` pumps the run loop instead of awaiting

`Debouncer` schedules a `Timer` on the current run loop. XCTest's `wait(for:timeout:)` spun that run loop; Swift Testing's `await`/`confirmation` don't, so a naive async port never fires the timer. These stay synchronous and spin `RunLoop.current.run(mode:before:)` until the callback lands or the deadline passes, wrapped in `withExtendedLifetime` — `Debouncer.deinit` fires the pending callback on dealloc, so releasing it early corrupts the timing. `testDebouncerRunsImmediatelyIfReleased` relies on that same deinit behavior and stays a pure synchronous check.

### Smaller notes

- `WidgetDataCacheReaderTests`' `assert(…line:)` helper becomes `sourceLocation: SourceLocation = #_sourceLocation`, forwarded to `#expect(…, sourceLocation:)` / `Issue.record(…, sourceLocation:)` so failures still point at the call site.
- `LazyTests` stays a `final class` — its `@Lazy` property wrapper mutates and its `tearDown` (→ `deinit`) resets static state, both wanting reference semantics.
- `XCTAssertEqual(x.count, 0)` and `XCTAssertEqual(y, "")` became `#expect(x.isEmpty)` / `#expect(y.isEmpty)`: the `== 0` / `== ""` forms trip SwiftLint's `empty_count` / `empty_string`, which the `XCTAssertEqual` argument form did not.
- Dropped a disabled `xtestPerformance` case — XCTest `measure` has no Swift Testing equivalent.

### The relocated suites (#25815, #25825)

After this branch was first written, #25815 (the KeystoneTests move) and #25825 (three Foundation extensions) relocated 15 more XCTest suites into `WordPressSharedTests`. The branch is rebased on top of them and converts those too, so the gate stays entirely Swift Testing instead of re-gaining XCTest the moment it merges. Two needed care: `NotificationCenterObserveOnceTests` is pinned to `@Suite(.serialized)` — its two tests share `NotificationCenter.default` and one observes without a filter, so under Swift Testing's default parallelism it would catch the other's posts; and `QueueTests` stays a `final class` because `Queue` is a value type it mutates across each test.

## The suite runs faster, too

Runner-reported execution time drops from ~1.6s to ~0.5s for the same 233 tests (one warm run: 1.56s → 0.52s). Swift Testing parallelizes by default, whereas `swift test` runs XCTest serially within the bundle. The win is entirely `DebouncerTests`: its four timer-based cases sleep ~1.4s in total and ran serially under XCTest (`Executed 4 tests … in 1.414 seconds`), which by itself was most of the before-run. Swift Testing overlaps them with each other and the other 229 tests, so the run collapses to about its single slowest test. Not the goal of the change, just a free improvement to the gate.

## Not in this PR

- `RichContentFormatterTests.swift` and `WPUserAgentTests.swift` are `exclude:`d from the macOS `WordPressSharedTests` target (they don't build on macOS), so they're outside the `swift test` set and stay XCTest.
- Pre-existing `swift-format` warnings in the Gutenberg fixtures (column-0 multiline HTML strings) are left as-is; reformatting them is unrelated churn. This PR introduces no new `swift-format` warnings.

## Test plan

- [x] `swift test` from the repo root: 233 Swift Testing cases in 53 suites pass; the XCTest runner reports `Executed 0 tests`.
- [x] `rake lint[<changed files>]`: 0 violations.
- [x] `swift-format lint` on the changed files: no new warnings — the three fully-rewritten suites (`DebouncerTests`, `StringRankedSearchTests`, `URLIncrementalFilenameTests`) went from 5/4/6 warnings to 0.
- [x] CI (Buildkite build #33419) compiles and runs these files on the simulator via `Modules/Package.swift` (`WordPressUnitTests.xctestplan`): the WordPress + Jetpack **Build for Testing** and **Unit Tests** jobs are green — the conversions run on iOS, not just macOS.

