### PR TITLE
Use REST editor for XML-RPC-disabled FAB actions

### DIFF
--- a/Tests/KeystoneTests/Tests/Features/CustomPostTypes/MySiteCreateEditorRoutingTests.swift
+++ b/Tests/KeystoneTests/Tests/Features/CustomPostTypes/MySiteCreateEditorRoutingTests.swift
@@ -1,0 +1,40 @@
+import Testing
+
+@testable import WordPress
+@testable import WordPressData
+
+@MainActor
+struct MySiteCreateEditorRoutingTests {
+
+    @Test("uses Core REST when XML-RPC is disabled on a self-hosted site")
+    func usesCoreRESTForXMLRPCDisabledSelfHostedSite() {
+        let context = ContextManager.forTesting().mainContext
+        let blog = BlogBuilder(context).build()
+        blog.isXMLRPCDisabled = true
+
+        #expect(MySiteViewController.shouldUseCoreRESTEditor(for: blog))
+    }
+
+    @Test("uses the existing editor when XML-RPC is enabled on a self-hosted site")
+    func usesExistingEditorForXMLRPCEnabledSelfHostedSite() {
+        let context = ContextManager.forTesting().mainContext
+        let blog = BlogBuilder(context).build()
+        blog.isXMLRPCDisabled = false
+
+        #expect(!MySiteViewController.shouldUseCoreRESTEditor(for: blog))
+    }
+
+    @Test("uses the existing editor for a WordPress.com site")
+    func usesExistingEditorForWordPressComSite() {
+        let context = ContextManager.forTesting().mainContext
+        let blog = BlogBuilder(context).isHostedAtWPcom().withAnAccount().build()
+        blog.isXMLRPCDisabled = true
+
+        #expect(!MySiteViewController.shouldUseCoreRESTEditor(for: blog))
+    }
+
+    @Test("uses the existing editor when there is no selected site")
+    func usesExistingEditorWithoutSelectedSite() {
+        #expect(!MySiteViewController.shouldUseCoreRESTEditor(for: nil))
+    }
+}

--- a/WordPress/Classes/System/Root View/RootViewPresenter+EditorNavigation.swift
+++ b/WordPress/Classes/System/Root View/RootViewPresenter+EditorNavigation.swift
@@ -1,4 +1,5 @@
 import Foundation
+import SwiftUI
 import WordPressData
 import WordPressShared
 
@@ -40,6 +41,16 @@ extension RootViewPresenter {
         rootViewController.present(editor, animated: false)
     }
 
+    func showCoreRESTPostEditor(blog: Blog) {
+        if rootViewController.presentedViewController != nil {
+            rootViewController.dismiss(animated: false)
+        }
+
+        let properties = [WPAppAnalyticsKeyTapSource: "create_button", WPAppAnalyticsKeyPostType: "post"]
+        WPAppAnalytics.track(.editorCreatedPost, properties: properties, blog: blog)
+        presentCoreRESTEditor(blog: blog, postType: .posts)
+    }
+
     /// - parameter blog: Blog to a add a page to. Uses the current or last blog if not provided
     func showPageEditor(
         blog: Blog? = nil,
@@ -72,6 +83,45 @@ extension RootViewPresenter {
             [weak self] selectedLayout in
             self?.showEditor(blog: blog, title: selectedLayout?.title, content: selectedLayout?.content)
         }
+    }
+
+    func showCoreRESTPageEditor(blog: Blog, source: String = "create_button") {
+        guard rootViewController.presentedViewController == nil else {
+            rootViewController.dismiss(animated: true) { [weak self] in
+                self?.showCoreRESTPageEditor(blog: blog, source: source)
+            }
+            return
+        }
+        WPAnalytics.track(
+            WPAnalyticsEvent.editorCreatedPage,
+            properties: [WPAppAnalyticsKeyTapSource: source],
+            blog: blog
+        )
+        PageCoordinator.showLayoutPickerIfNeeded(from: rootViewController, forBlog: blog) {
+            [weak self] selectedLayout in
+            let initialContent = selectedLayout.map {
+                EditorContent(title: $0.title ?? "", content: $0.content)
+            }
+            self?.presentCoreRESTEditor(blog: blog, postType: .pages, initialContent: initialContent)
+        }
+    }
+
+    private func presentCoreRESTEditor(
+        blog: Blog,
+        postType: PinnedPostType,
+        initialContent: EditorContent? = nil
+    ) {
+        let controller = UIHostingController(rootView: AnyView(EmptyView()))
+        controller.rootView = AnyView(
+            CoreRESTPostEditorRoute(
+                blog: blog,
+                postType: postType,
+                initialContent: initialContent,
+                presentingViewController: controller
+            )
+        )
+        controller.modalPresentationStyle = .fullScreen
+        rootViewController.present(controller, animated: true)
     }
 
     private func showEditor(blog: Blog, title: String?, content: String?) {

--- a/WordPress/Classes/System/Root View/RootViewPresenter+EditorNavigation.swift
+++ b/WordPress/Classes/System/Root View/RootViewPresenter+EditorNavigation.swift
@@ -41,7 +41,12 @@ extension RootViewPresenter {
     }
 
     /// - parameter blog: Blog to a add a page to. Uses the current or last blog if not provided
-    func showPageEditor(blog: Blog? = nil, title: String? = nil, content: String? = nil, source: String = "create_button") {
+    func showPageEditor(
+        blog: Blog? = nil,
+        title: String? = nil,
+        content: String? = nil,
+        source: String = "create_button"
+    ) {
 
         // If we are already showing a view controller, dismiss and show the editor afterward
         guard rootViewController.presentedViewController == nil else {
@@ -58,10 +63,13 @@ extension RootViewPresenter {
             return
         }
 
-        WPAnalytics.track(WPAnalyticsEvent.editorCreatedPage,
-                          properties: [WPAppAnalyticsKeyTapSource: source],
-                          blog: blog)
-        PageCoordinator.showLayoutPickerIfNeeded(from: rootViewController, forBlog: blog) { [weak self] selectedLayout in
+        WPAnalytics.track(
+            WPAnalyticsEvent.editorCreatedPage,
+            properties: [WPAppAnalyticsKeyTapSource: source],
+            blog: blog
+        )
+        PageCoordinator.showLayoutPickerIfNeeded(from: rootViewController, forBlog: blog) {
+            [weak self] selectedLayout in
             self?.showEditor(blog: blog, title: selectedLayout?.title, content: selectedLayout?.content)
         }
     }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+Swift.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+Swift.swift
@@ -134,12 +134,20 @@ extension BlogDetailsViewController {
             source: "custom_post_types",
             presentingViewController: self
         ) { [blog, weak self] client in
-            PinnedPostTypeView(
+            PinnedPostTypeView<CustomPostTabView>(
                 blog: blog,
                 service: CustomPostTypeService(client: client, blog: blog),
                 postType: postType,
                 presentingViewController: self
-            )
+            ) { resolved in
+                CustomPostTabView(
+                    client: client,
+                    service: resolved.wpService,
+                    details: resolved.details,
+                    blog: blog,
+                    presentingViewController: self
+                )
+            }
         }
         let controller = UIHostingController(rootView: rootView)
         controller.navigationItem.largeTitleDisplayMode = .never
@@ -483,11 +491,4 @@ public class ApplicationPasswordAuthenticationInfo: NSObject {
         self.siteDetails = siteDetails
         self.siteUsername = siteUsername
     }
-}
-
-private extension PinnedPostType {
-    // TODO: Ideally use the post type details directly instead of PinnedPostType,
-    // once the CPT infrastructure is more mature.
-    static let posts = PinnedPostType(slug: "post", name: "Posts", icon: nil)
-    static let pages = PinnedPostType(slug: "page", name: "Pages", icon: nil)
 }

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController+FAB.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController+FAB.swift
@@ -1,19 +1,35 @@
 import UIKit
 import SwiftUI
+import WordPressData
 import WordPressShared
 
 extension MySiteViewController {
+
+    static func shouldUseCoreRESTEditor(for blog: Blog?) -> Bool {
+        guard let blog else { return false }
+        return blog.isSelfHosted && blog.isXMLRPCDisabled
+    }
 
     /// Make a create button coordinator with
     /// - Returns: CreateButtonCoordinator with new post, page, and story actions.
     @objc func makeCreateButtonCoordinator() -> CreateButtonCoordinator {
 
-        let newPage = {
-            RootViewCoordinator.sharedPresenter.showPageEditor()
+        let newPage = { [weak self] in
+            let presenter = RootViewCoordinator.sharedPresenter
+            if let blog = self?.blog, Self.shouldUseCoreRESTEditor(for: blog) {
+                presenter.showCoreRESTPageEditor(blog: blog)
+            } else {
+                presenter.showPageEditor()
+            }
         }
 
-        let newPost = {
-            RootViewCoordinator.sharedPresenter.showPostEditor()
+        let newPost = { [weak self] in
+            let presenter = RootViewCoordinator.sharedPresenter
+            if let blog = self?.blog, Self.shouldUseCoreRESTEditor(for: blog) {
+                presenter.showCoreRESTPostEditor(blog: blog)
+            } else {
+                presenter.showPostEditor()
+            }
         }
 
         let source = "my_site"

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController+FAB.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController+FAB.swift
@@ -23,11 +23,17 @@ extension MySiteViewController {
         actions.append(PostAction(handler: newPost, source: source))
         // TODO: check if the current site is eligible
         if Feature.enabled(.voiceToContent) {
-            actions.append(PostFromAudioAction(handler: { [weak self] in
-                self?.dismiss(animated: true) {
-                    self?.startPostFromAudioFlow()
-                }
-            }, source: source))
+            actions.append(
+                PostFromAudioAction(
+                    handler: { [weak self] in
+                        self?
+                            .dismiss(animated: true) {
+                                self?.startPostFromAudioFlow()
+                            }
+                    },
+                    source: source
+                )
+            )
         }
         if blog?.supports(.pages) ?? false {
             actions.append(PageAction(handler: newPage, source: source))

--- a/WordPress/Classes/ViewRelated/CustomPostTypes/CoreRESTPostEditorRoute.swift
+++ b/WordPress/Classes/ViewRelated/CustomPostTypes/CoreRESTPostEditorRoute.swift
@@ -6,18 +6,27 @@ struct CoreRESTPostEditorRoute: View {
     let blog: Blog
     let postType: PinnedPostType
     let initialContent: EditorContent?
-    let presentingViewController: UIViewController
+    weak var presentingViewController: UIViewController?
 
     @Environment(\.dismiss) private var dismiss
 
     var body: some View {
         NavigationStack {
-            ApplicationPasswordRequiredView(
-                blog: blog,
-                localizedFeatureName: Strings.featureName,
-                source: "block_editor",
-                presentingViewController: presentingViewController
-            ) { client in
+            if let presentingViewController {
+                content(presentingViewController: presentingViewController)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func content(presentingViewController: UIViewController) -> some View {
+        ApplicationPasswordRequiredView(
+            blog: blog,
+            localizedFeatureName: Strings.featureName,
+            source: "block_editor",
+            presentingViewController: presentingViewController
+        ) { [weak presentingViewController] client in
+            if let presentingViewController {
                 PinnedPostTypeView<AnyView>(
                     blog: blog,
                     service: CustomPostTypeService(client: client, blog: blog),
@@ -38,11 +47,11 @@ struct CoreRESTPostEditorRoute: View {
                     )
                 }
             }
-            .toolbar {
-                ToolbarItem(placement: .cancellationAction) {
-                    Button(SharedStrings.Button.close) {
-                        dismiss()
-                    }
+        }
+        .toolbar {
+            ToolbarItem(placement: .cancellationAction) {
+                Button(SharedStrings.Button.close) {
+                    dismiss()
                 }
             }
         }

--- a/WordPress/Classes/ViewRelated/CustomPostTypes/CoreRESTPostEditorRoute.swift
+++ b/WordPress/Classes/ViewRelated/CustomPostTypes/CoreRESTPostEditorRoute.swift
@@ -1,0 +1,58 @@
+import SwiftUI
+import UIKit
+import WordPressData
+
+struct CoreRESTPostEditorRoute: View {
+    let blog: Blog
+    let postType: PinnedPostType
+    let initialContent: EditorContent?
+    let presentingViewController: UIViewController
+
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            ApplicationPasswordRequiredView(
+                blog: blog,
+                localizedFeatureName: Strings.featureName,
+                source: "block_editor",
+                presentingViewController: presentingViewController
+            ) { client in
+                PinnedPostTypeView<AnyView>(
+                    blog: blog,
+                    service: CustomPostTypeService(client: client, blog: blog),
+                    postType: postType,
+                    presentingViewController: presentingViewController
+                ) { resolved in
+                    AnyView(
+                        CustomPostEditor(
+                            wpService: resolved.wpService,
+                            client: client,
+                            post: nil,
+                            details: resolved.details,
+                            blog: blog,
+                            initialSettings: nil,
+                            initialContent: initialContent
+                        )
+                        .toolbar(.hidden, for: .navigationBar)
+                    )
+                }
+            }
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button(SharedStrings.Button.close) {
+                        dismiss()
+                    }
+                }
+            }
+        }
+    }
+}
+
+private enum Strings {
+    static let featureName = NSLocalizedString(
+        "applicationPasswordRequired.feature.blockEditor",
+        value: "Block Editor",
+        comment: "Feature name for the block editor in application password required prompt"
+    )
+}

--- a/WordPress/Classes/ViewRelated/CustomPostTypes/PinnedPostTypeView.swift
+++ b/WordPress/Classes/ViewRelated/CustomPostTypes/PinnedPostTypeView.swift
@@ -7,16 +7,22 @@ import WordPressAPI
 import WordPressAPIInternal
 import WordPressUI
 
-struct PinnedPostTypeView: View {
+// TODO: Rename PinnedPostTypeView to reflect its broader role as a post type resolver.
+struct PinnedPostTypeView<Content: View>: View {
+    struct Resolved {
+        let wpService: WpService
+        let details: PostTypeDetailsWithEditContext
+    }
+
     let blog: Blog
     let customPostTypeService: CustomPostTypeService
     let postType: PinnedPostType
     weak var presentingViewController: UIViewController?
+    let content: (Resolved) -> Content
 
     @SiteStorage private var pinnedTypes: [PinnedPostType]
 
-    @State private var service: WpService?
-    @State private var details: PostTypeDetailsWithEditContext?
+    @State private var resolved: Resolved?
     @State private var isLoading = true
     @State private var error: Error?
 
@@ -24,25 +30,21 @@ struct PinnedPostTypeView: View {
         blog: Blog,
         service: CustomPostTypeService,
         postType: PinnedPostType,
-        presentingViewController: UIViewController? = nil
+        presentingViewController: UIViewController? = nil,
+        @ViewBuilder content: @escaping (Resolved) -> Content
     ) {
         self.blog = blog
         self.customPostTypeService = service
         self.postType = postType
         self.presentingViewController = presentingViewController
+        self.content = content
         _pinnedTypes = .pinnedPostTypes(for: TaggedManagedObjectID(blog))
     }
 
     var body: some View {
         Group {
-            if let details, let wpService = customPostTypeService.wpService {
-                CustomPostTabView(
-                    client: customPostTypeService.client,
-                    service: wpService,
-                    details: details,
-                    blog: blog,
-                    presentingViewController: presentingViewController
-                )
+            if let resolved {
+                content(resolved)
             } else if isLoading {
                 ProgressView()
                     .progressViewStyle(.circular)
@@ -66,10 +68,10 @@ struct PinnedPostTypeView: View {
     private func resolve() async {
         defer { isLoading = false }
         do {
-            service = try await customPostTypeService.client.service
+            let wpService = try await customPostTypeService.client.service
 
             if let details = try await customPostTypeService.resolvePostType(slug: postType.slug) {
-                self.details = details
+                resolved = Resolved(wpService: wpService, details: details)
             } else {
                 pinnedTypes.removeAll { $0.slug == postType.slug }
                 self.error = PostTypeNotFoundError(name: postType.name)
@@ -85,6 +87,13 @@ struct PinnedPostType: Codable, Hashable {
     let slug: String
     let name: String
     let icon: String?
+}
+
+extension PinnedPostType {
+    // TODO: Ideally use the post type details directly instead of PinnedPostType,
+    // once the CPT infrastructure is more mature.
+    static let posts = PinnedPostType(slug: "post", name: "Posts", icon: nil)
+    static let pages = PinnedPostType(slug: "page", name: "Pages", icon: nil)
 }
 
 extension SiteStorage where Value == [PinnedPostType] {

--- a/WordPress/Classes/ViewRelated/CustomPostTypes/PinnedPostTypeView.swift
+++ b/WordPress/Classes/ViewRelated/CustomPostTypes/PinnedPostTypeView.swift
@@ -20,7 +20,12 @@ struct PinnedPostTypeView: View {
     @State private var isLoading = true
     @State private var error: Error?
 
-    init(blog: Blog, service: CustomPostTypeService, postType: PinnedPostType, presentingViewController: UIViewController? = nil) {
+    init(
+        blog: Blog,
+        service: CustomPostTypeService,
+        postType: PinnedPostType,
+        presentingViewController: UIViewController? = nil
+    ) {
         self.blog = blog
         self.customPostTypeService = service
         self.postType = postType
@@ -31,7 +36,13 @@ struct PinnedPostTypeView: View {
     var body: some View {
         Group {
             if let details, let wpService = customPostTypeService.wpService {
-                CustomPostTabView(client: customPostTypeService.client, service: wpService, details: details, blog: blog, presentingViewController: presentingViewController)
+                CustomPostTabView(
+                    client: customPostTypeService.client,
+                    service: wpService,
+                    details: details,
+                    blog: blog,
+                    presentingViewController: presentingViewController
+                )
             } else if isLoading {
                 ProgressView()
                     .progressViewStyle(.circular)


### PR DESCRIPTION
## Description

This fixes a production app bug.

When XML-RPC is disabled, the quick actions to create post and pages present the `AbstractPost` post editor, which does not work when XML-RPC is disabled. This PR switches to use the "Custom Post Types" post editor which uses core REST API.

I intentionally kept the scope small, due to we are in the code freeze. The same issue would happen on other creating post entry points: universal link, shortcuts, etc. I will create a separate PR to fix them on the trunk branch.