### PR TITLE
Remove WordPressData's WordPressUI and WordPressSharedUI dependencies

### DIFF
--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -338,7 +338,6 @@ let package = Package(
                 "FormattableContentKit",
                 "SFHFKeychainUtils",
                 "WordPressShared",
-                "WordPressSharedUI",
                 "WordPressKit",
                 .product(name: "CocoaLumberjack", package: "CocoaLumberjack"),
                 .product(name: "CocoaLumberjackSwift", package: "CocoaLumberjack"),

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -340,7 +340,6 @@ let package = Package(
                 "WordPressShared",
                 "WordPressSharedUI",
                 "WordPressKit",
-                "WordPressUI",
                 .product(name: "CocoaLumberjack", package: "CocoaLumberjack"),
                 .product(name: "CocoaLumberjackSwift", package: "CocoaLumberjack"),
                 .product(name: "Gravatar", package: "Gravatar-SDK-iOS"),

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -318,7 +318,6 @@ let package = Package(
                 "FormattableContentKit",
                 "SFHFKeychainUtils",
                 "WordPressShared",
-                "WordPressSharedUI",
                 "WordPressKit",
                 .product(name: "CocoaLumberjack", package: "CocoaLumberjack"),
                 .product(name: "CocoaLumberjackSwift", package: "CocoaLumberjack"),

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -320,7 +320,6 @@ let package = Package(
                 "WordPressShared",
                 "WordPressSharedUI",
                 "WordPressKit",
-                "WordPressUI",
                 .product(name: "CocoaLumberjack", package: "CocoaLumberjack"),
                 .product(name: "CocoaLumberjackSwift", package: "CocoaLumberjack"),
                 .product(name: "Gravatar", package: "Gravatar-SDK-iOS"),

--- a/Modules/Sources/WordPressData/Mapping/ReaderPost+Mapping.swift
+++ b/Modules/Sources/WordPressData/Mapping/ReaderPost+Mapping.swift
@@ -1,7 +1,6 @@
 import CoreData
 import WordPressKit
 import WordPressShared
-import WordPressSharedUI
 
 extension ReaderPost {
     /// Finds an existing `ReaderPost` matching the given `globalID` and `topic`,

--- a/Modules/Sources/WordPressData/Swift/ManagedPerson.swift
+++ b/Modules/Sources/WordPressData/Swift/ManagedPerson.swift
@@ -1,7 +1,6 @@
 import Foundation
 import CoreData
 import WordPressKit
-import WordPressUI
 import Gravatar
 
 public typealias Person = RemotePerson

--- a/Modules/Sources/WordPressShared/Utility/RichContentFormatter.swift
+++ b/Modules/Sources/WordPressShared/Utility/RichContentFormatter.swift
@@ -1,7 +1,4 @@
 import Foundation
-import UIKit
-import WordPressShared
-import WordPressSharedObjCUI
 
 /// Contains methods for formatting post or comment content for display.
 ///
@@ -28,7 +25,7 @@ import WordPressSharedObjCUI
         static let styleAttr = try! NSRegularExpression(pattern: "\\s*style=\"[^\"]*\"", options: .caseInsensitive)
 
         // Gallery Images
-        static let galleryImgTags = try! NSRegularExpression(pattern: "<img[^>]*data-orig-file[^>]*/>", options: .caseInsensitive)
+        public static let galleryImgTags = try! NSRegularExpression(pattern: "<img[^>]*data-orig-file[^>]*/>", options: .caseInsensitive)
 
         // Trailing BR Tags
         static let trailingBRTags = try! NSRegularExpression(pattern: "(\\s*<br\\s*(/?)\\s*>\\s*)+$", options: .caseInsensitive)
@@ -36,31 +33,6 @@ import WordPressSharedObjCUI
         // Gutenberg Galleries
         static let gutenbergGalleryList = try! NSRegularExpression(pattern: "(<ul[^>]+>)<li[^>]+gallery-item[^>]+><figure><img .+?</figure></li>", options: .caseInsensitive)
         static let gutenbergGalleryListItem = try! NSRegularExpression(pattern: "<li[^>]+gallery-item[^>]+>(<figure><img .+?</figure>)</li>", options: .caseInsensitive)
-    }
-
-    /// Formats the specified content string for display. Forbidden HTML tags are
-    /// removed, paragraphs are normalized, etc.
-    ///
-    /// - Parameters:
-    ///     - string: The content string to format.
-    ///     - isPrivate: Whether the content is from a private blog.
-    ///
-    /// - Returns: The formatted string.
-    ///
-    @objc public class func formatContentString(_ string: String, isPrivateSite isPrivate: Bool) -> String {
-        guard !string.isEmpty else {
-            return string
-        }
-
-        var content = string
-        content = removeForbiddenTags(content)
-        content = normalizeParagraphs(content)
-        content = removeInlineStyles(content)
-        content = (content as NSString).replacingHTMLEmoticonsWithEmoji() as String
-        content = formatGutenbergGallery(content)
-        content = resizeGalleryImageURL(content, isPrivateSite: isPrivate)
-        content = formatVideoTags(content)
-        return content
     }
 
     /// Removes forbidden HTML tags from the specified string.
@@ -195,59 +167,6 @@ import WordPressSharedObjCUI
                                                            withTemplate: "")
 
         return content
-    }
-
-    /// Mutates gallery image URLs to be correctly sized.
-    ///
-    /// - Parameters:
-    ///     - string: The content string to format.
-    ///     - isPrivate: Whether the content is from a private blog.
-    ///
-    /// - Returns: The formatted string.
-    ///
-    @objc public class func resizeGalleryImageURL(_ string: String, isPrivateSite isPrivate: Bool) -> String {
-        guard !string.isEmpty else {
-            return string
-        }
-
-        let imageSize = UIScreen.main.bounds.size
-        let scale = UIScreen.main.scale
-        let scaledSize = imageSize.applying(CGAffineTransform(scaleX: scale, y: scale))
-
-        let mContent = NSMutableString(string: string)
-
-        let matches = RegEx.galleryImgTags.matches(in: mContent as String, options: [], range: NSRange(location: 0, length: mContent.length))
-
-        for match in matches.reversed() {
-            let imgElementStr = mContent.substring(with: match.range)
-            let srcImgURLStr = parseValueForAttribute("src", inElement: imgElementStr)
-            let originalImgURLStr = parseValueForAttribute("data-orig-file", inElement: imgElementStr)
-
-            guard let originalURL = URL(string: originalImgURLStr) else {
-                continue
-            }
-
-            var modifiedURL: URL
-            if isPrivate {
-                modifiedURL = WPImageURLHelper.imageURLWithSize(scaledSize, forImageURL: originalURL)
-            } else {
-                modifiedURL = PhotonImageURLHelper.photonURL(with: imageSize, forImageURL: originalURL)
-            }
-
-            guard modifiedURL.absoluteString.isEmpty() == false else {
-                continue
-            }
-
-            let mImageStr = NSMutableString(string: imgElementStr)
-            mImageStr.replaceOccurrences(of: srcImgURLStr,
-                                         with: modifiedURL.absoluteString,
-                                         options: .literal,
-                                         range: NSRange(location: 0, length: imgElementStr.count))
-
-            mContent.replaceCharacters(in: match.range, with: mImageStr as String)
-        }
-
-        return mContent as String
     }
 
     /// Parses the specified string for the value of the specified attribute.

--- a/Modules/Sources/WordPressSharedUI/RichContentFormatter+DisplayPipeline.swift
+++ b/Modules/Sources/WordPressSharedUI/RichContentFormatter+DisplayPipeline.swift
@@ -1,0 +1,97 @@
+import Foundation
+import UIKit
+import WordPressShared
+import WordPressSharedObjCUI
+
+/// UIKit-dependent additions to `RichContentFormatter`.
+///
+/// The platform-independent text transformations live in `WordPressShared`. The
+/// display pipeline below depends on the screen (for gallery image sizing) and on
+/// `WordPressSharedObjCUI`'s Photon helper, so it stays in the UI layer.
+///
+extension RichContentFormatter {
+
+    /// Formats the specified content string for display. Forbidden HTML tags are
+    /// removed, paragraphs are normalized, etc.
+    ///
+    /// - Parameters:
+    ///     - string: The content string to format.
+    ///     - isPrivate: Whether the content is from a private blog.
+    ///
+    /// - Returns: The formatted string.
+    ///
+    @objc public class func formatContentString(_ string: String, isPrivateSite isPrivate: Bool) -> String {
+        guard !string.isEmpty else {
+            return string
+        }
+
+        var content = string
+        content = removeForbiddenTags(content)
+        content = normalizeParagraphs(content)
+        content = removeInlineStyles(content)
+        content = (content as NSString).replacingHTMLEmoticonsWithEmoji() as String
+        content = formatGutenbergGallery(content)
+        content = resizeGalleryImageURL(content, isPrivateSite: isPrivate)
+        content = formatVideoTags(content)
+        return content
+    }
+
+    /// Mutates gallery image URLs to be correctly sized.
+    ///
+    /// - Parameters:
+    ///     - string: The content string to format.
+    ///     - isPrivate: Whether the content is from a private blog.
+    ///
+    /// - Returns: The formatted string.
+    ///
+    @objc public class func resizeGalleryImageURL(_ string: String, isPrivateSite isPrivate: Bool) -> String {
+        guard !string.isEmpty else {
+            return string
+        }
+
+        let imageSize = UIScreen.main.bounds.size
+        let scale = UIScreen.main.scale
+        let scaledSize = imageSize.applying(CGAffineTransform(scaleX: scale, y: scale))
+
+        let mContent = NSMutableString(string: string)
+
+        let matches = RegEx.galleryImgTags.matches(
+            in: mContent as String,
+            options: [],
+            range: NSRange(location: 0, length: mContent.length)
+        )
+
+        for match in matches.reversed() {
+            let imgElementStr = mContent.substring(with: match.range)
+            let srcImgURLStr = parseValueForAttribute("src", inElement: imgElementStr)
+            let originalImgURLStr = parseValueForAttribute("data-orig-file", inElement: imgElementStr)
+
+            guard let originalURL = URL(string: originalImgURLStr) else {
+                continue
+            }
+
+            var modifiedURL: URL
+            if isPrivate {
+                modifiedURL = WPImageURLHelper.imageURLWithSize(scaledSize, forImageURL: originalURL)
+            } else {
+                modifiedURL = PhotonImageURLHelper.photonURL(with: imageSize, forImageURL: originalURL)
+            }
+
+            guard modifiedURL.absoluteString.isEmpty() == false else {
+                continue
+            }
+
+            let mImageStr = NSMutableString(string: imgElementStr)
+            mImageStr.replaceOccurrences(
+                of: srcImgURLStr,
+                with: modifiedURL.absoluteString,
+                options: .literal,
+                range: NSRange(location: 0, length: imgElementStr.count)
+            )
+
+            mContent.replaceCharacters(in: match.range, with: mImageStr as String)
+        }
+
+        return mContent as String
+    }
+}

--- a/Modules/Tests/WordPressSharedTests/RichContentFormatterTests.swift
+++ b/Modules/Tests/WordPressSharedTests/RichContentFormatterTests.swift
@@ -1,6 +1,5 @@
 import XCTest
 @testable import WordPressShared
-@testable import WordPressSharedUI
 
 class RichContentFormatterTests: XCTestCase {
 
@@ -30,10 +29,6 @@ class RichContentFormatterTests: XCTestCase {
         let styleStr = "<div><p>test</p></div><pre>\n\ntest\n\n</pre>\n<p><div>test</div></p>\n"
         let sanitizedStr = RichContentFormatter.filterNewLines(styleStr)
         XCTAssertTrue(str == sanitizedStr, "Not all paragraphs were normalized.")
-    }
-
-    func testResizeGalleryImageURLsForContentEmptyString() {
-        XCTAssertTrue("" == RichContentFormatter.resizeGalleryImageURL("", isPrivateSite: false))
     }
 
     func testRemoveTrailingBRTags() {

--- a/Modules/Tests/WordPressSharedTests/RichContentFormatterUITests.swift
+++ b/Modules/Tests/WordPressSharedTests/RichContentFormatterUITests.swift
@@ -1,0 +1,10 @@
+import XCTest
+@testable import WordPressShared
+@testable import WordPressSharedUI
+
+class RichContentFormatterUITests: XCTestCase {
+
+    func testResizeGalleryImageURLsForContentEmptyString() {
+        XCTAssertTrue("" == RichContentFormatter.resizeGalleryImageURL("", isPrivateSite: false))
+    }
+}

--- a/Package.swift
+++ b/Package.swift
@@ -43,7 +43,7 @@ let package = Package(
             path: "Modules/Tests/WordPressSharedTests",
             exclude: [
                 "WordPressShared.xctestplan",
-                "RichContentFormatterTests.swift",
+                "RichContentFormatterUITests.swift",
                 "WPUserAgentTests.swift"
             ],
             swiftSettings: [.swiftLanguageMode(.v5)]


### PR DESCRIPTION
## Description

`WordPressData` is a Core Data model layer, but it depended on two UI modules — `WordPressUI` and `WordPressSharedUI`. Neither dependency was necessary. This removes both.

> [!NOTE]
> Two commits, reviewable independently: `Remove dead WordPressUI import from WordPressData`, then `Split RichContentFormatter out of WordPressSharedUI`.

- **Delete** the unused `import WordPressUI` from `ManagedPerson` and drop `WordPressUI` from `WordPressData`'s package dependencies.
- **Split `RichContentFormatter`** so its platform-independent text methods move down to `WordPressShared`, and drop `WordPressSharedUI` from `WordPressData`'s package dependencies.

### Splitting `RichContentFormatter`

`RichContentFormatter` sanitizes post and comment HTML — stripping forbidden tags and inline styles, normalizing paragraphs, tidying Gutenberg galleries. It's plain `String → String` text work, but it lived in `WordPressSharedUI`, so everything that used it — including `WordPressData` — pulled in the UI layer.

Only two of its methods actually need that layer: `resizeGalleryImageURL` reads the screen (`UIScreen.main`) to size gallery images and calls `PhotonImageURLHelper` from `WordPressSharedObjCUI`, and `formatContentString` chains through it. Those two move to a new `RichContentFormatter+DisplayPipeline.swift` in `WordPressSharedUI`, as an `@objc` extension on the class. The other eight methods and the `RegEx` table move to `WordPressShared`.

**ObjC callers see no change.** `RichContentFormatter` is still one `@objc` class. `CommentService.m` already `@import`s both `WordPressShared` and `WordPressSharedUI`, so `removeTrailingBreakTags` (now in `WordPressShared`) and `formatContentString` (the `WordPressSharedUI` category) both resolve. `WordPressData`'s `ReaderPost+Mapping` gets the pure methods from `WordPressShared`, which it already imported.

The tests move with the code: `RichContentFormatterTests` is now `WordPressShared`-only and runs on macOS under `swift test`; the single gallery-resize test stays iOS-only in the new `RichContentFormatterUITests`.

### The `WordPressUI` import was dead

`ManagedPerson` was the only file in `WordPressData` importing `WordPressUI`, and the one symbol that looked like it needed it — `AvatarURL(url:)?.canonicalURL` — belongs to the Gravatar SDK, which the file already imports directly. `WordPressUI` supplied nothing.

### What I considered

The alternative was to move the whole class to `WordPressShared` and gate `resizeGalleryImageURL` behind `#if canImport(UIKit)`, giving `WordPressShared` a conditional dependency on `WordPressSharedObjCUI` for the Photon helper. Rejected: that pushes a UI-only ObjC dependency *down* into the base shared module — a layering inversion in the other direction — and scatters `#if` scaffolding through shared code. Keeping the screen- and Photon-dependent methods in the UI layer is where they belong. (`WPImageURLHelper`, the other helper `resizeGalleryImageURL` uses, was already in `WordPressShared`.)

### Not in this PR

This removes `WordPressData`'s two *direct* edges to the UI modules. It does not make `WordPressData` build on macOS on its own — it still imports `UIKit` and `MobileCoreServices` directly, and pulls `WordPressSharedUI` transitively through `FormattableContentKit` on iOS. Those are separate changes.

## Testing instructions

Verified locally:

- [x] `swift test --filter RichContentFormatterTests` (macOS host) — 7 text-formatting tests pass. They previously couldn't run on macOS (excluded because the file imported `WordPressSharedUI`); they're now in the cross-platform set.
- [x] `swift build --build-tests` (macOS host) — `WordPressShared` compiles with the moved code.
- [x] `xcodebuild -scheme WordPressData -destination 'generic/platform=iOS Simulator' build` — `BUILD SUCCEEDED`, with `WordPressSharedUI` no longer in `WordPressData`'s dependency graph.
- [x] `WordPressSharedUI` builds with the new extension; `formatContentString` and `resizeGalleryImageURL` appear in the generated `WordPressSharedUI-Swift.h`, so the `@objc` cross-module category is visible to ObjC.

Verified at runtime (Jetpack, iOS 26 simulator). The sanitization logic is a byte-identical `git mv`, so its behavior is covered by the unit tests above — these two checks confirm the thing the move actually changes: that the relocated class and its cross-module `@objc` category link, load, and dispatch in the running app.

- [x] **Reader ingestion — `WordPressData` → `WordPressShared` (Swift).** Opened a post whose content carries a Jetpack tiled gallery, a grid built entirely from inline `flex-basis` styles the app has no CSS fallback for. It renders as a single full-width column (24 images, each at the full content width) — the inline styles are stripped — so `removeInlineStyles` resolves and runs from its new module. (`toadilymagical.wordpress.com` post 347)
- [x] **Comment path — ObjC `CommentService` → the cross-module `@objc` `formatContentString`.** Opened a post with a comment; loading it ran `mergeHierarchicalComments → sanitizeCommentContent → [RichContentFormatter formatContentString:isPrivateSite:]` and the comment rendered, with no unrecognized-selector crash. This confirms the `@objc` category — defined in `WordPressSharedUI` on the class that now lives in `WordPressShared` — registers and dispatches at load time, the one behavior a successful compile implies but doesn't prove. (WordPress.com News "WordCamp US 2026" post)

