### PR TITLE
Fix grapheme-vs-UTF-16 range bug in RichContentFormatter

### DIFF
--- a/Modules/Sources/WordPressShared/Utility/RichContentFormatter.swift
+++ b/Modules/Sources/WordPressShared/Utility/RichContentFormatter.swift
@@ -50,17 +50,17 @@ import Foundation
 
         content = RegEx.styleTags.stringByReplacingMatches(in: content,
                                                            options: .reportCompletion,
-                                                           range: NSRange(location: 0, length: content.count),
+                                                           range: NSRange(location: 0, length: content.utf16.count),
                                                            withTemplate: "")
 
         content = RegEx.scriptTags.stringByReplacingMatches(in: content,
                                                             options: .reportCompletion,
-                                                            range: NSRange(location: 0, length: content.count),
+                                                            range: NSRange(location: 0, length: content.utf16.count),
                                                             withTemplate: "")
 
         content = RegEx.gutenbergComments.stringByReplacingMatches(in: content,
                                                                    options: .reportCompletion,
-                                                                   range: NSRange(location: 0, length: content.count),
+                                                                   range: NSRange(location: 0, length: content.utf16.count),
                                                                    withTemplate: "")
 
         return content
@@ -84,23 +84,23 @@ import Foundation
         // Convert div tags to p tags
         content = RegEx.divTagsStart.stringByReplacingMatches(in: content,
                                                               options: .reportCompletion,
-                                                              range: NSRange(location: 0, length: content.count),
+                                                              range: NSRange(location: 0, length: content.utf16.count),
                                                               withTemplate: openPTag)
 
         content = RegEx.divTagsEnd.stringByReplacingMatches(in: content,
                                                             options: .reportCompletion,
-                                                            range: NSRange(location: 0, length: content.count),
+                                                            range: NSRange(location: 0, length: content.utf16.count),
                                                             withTemplate: closePTag)
 
         // Remove duplicate/redundant p tags.
         content = RegEx.pTagsStart.stringByReplacingMatches(in: content,
                                                             options: .reportCompletion,
-                                                            range: NSRange(location: 0, length: content.count),
+                                                            range: NSRange(location: 0, length: content.utf16.count),
                                                             withTemplate: openPTag)
 
         content = RegEx.pTagsEnd.stringByReplacingMatches(in: content,
                                                           options: .reportCompletion,
-                                                          range: NSRange(location: 0, length: content.count),
+                                                          range: NSRange(location: 0, length: content.utf16.count),
                                                           withTemplate: closePTag)
 
         content = filterNewLines(content)
@@ -114,11 +114,11 @@ import Foundation
         var ranges = [NSRange]()
         // We don't want to remove new lines from preformatted tag blocks,
         // so get the ranges of such blocks.
-        let matches = RegEx.preTags.matches(in: content, options: .reportCompletion, range: NSRange(location: 0, length: content.count))
+        let matches = RegEx.preTags.matches(in: content, options: .reportCompletion, range: NSRange(location: 0, length: content.utf16.count))
         if matches.isEmpty {
 
             // No blocks found, so we'll parse the whole string.
-            ranges.append(NSRange(location: 0, length: content.count))
+            ranges.append(NSRange(location: 0, length: content.utf16.count))
         } else {
 
             // One or more preformatted blocks found, we don't want to remove new lines
@@ -133,7 +133,7 @@ import Foundation
                 location = match.range.location + match.range.length
             }
 
-            length = content.count - location
+            length = content.utf16.count - location
             ranges.append(NSRange(location: location, length: length))
         }
 
@@ -163,7 +163,7 @@ import Foundation
 
         content = RegEx.styleAttr.stringByReplacingMatches(in: content,
                                                            options: .reportCompletion,
-                                                           range: NSRange(location: 0, length: content.count),
+                                                           range: NSRange(location: 0, length: content.utf16.count),
                                                            withTemplate: "")
 
         return content
@@ -206,10 +206,9 @@ import Foundation
         }
 
         var content = string.trim()
-        let matches = RegEx.trailingBRTags.matches(in: content, options: .reportCompletion, range: NSRange(location: 0, length: content.count))
-        if let match = matches.first {
-            let index = content.index(content.startIndex, offsetBy: match.range.location)
-            content = String(content.prefix(upTo: index))
+        let matches = RegEx.trailingBRTags.matches(in: content, options: .reportCompletion, range: NSRange(location: 0, length: content.utf16.count))
+        if let match = matches.first, let matchRange = Range(match.range, in: content) {
+            content = String(content[..<matchRange.lowerBound])
         }
 
         return content

--- a/Modules/Sources/WordPressShared/Utility/RichContentFormatter.swift
+++ b/Modules/Sources/WordPressShared/Utility/RichContentFormatter.swift
@@ -187,7 +187,9 @@ import Foundation
             let location = attrRange.location + attrRange.length
             let length = elementStr.length - location
             let ending = elementStr.range(of: "\"", options: .caseInsensitive, range: NSRange(location: location, length: length))
-            value = elementStr.substring(with: NSRange(location: location, length: ending.location - location))
+            if ending.location != NSNotFound {
+                value = elementStr.substring(with: NSRange(location: location, length: ending.location - location))
+            }
         }
 
         return value

--- a/Modules/Sources/WordPressSharedUI/RichContentFormatter+DisplayPipeline.swift
+++ b/Modules/Sources/WordPressSharedUI/RichContentFormatter+DisplayPipeline.swift
@@ -86,7 +86,7 @@ extension RichContentFormatter {
                 of: srcImgURLStr,
                 with: modifiedURL.absoluteString,
                 options: .literal,
-                range: NSRange(location: 0, length: imgElementStr.count)
+                range: NSRange(location: 0, length: imgElementStr.utf16.count)
             )
 
             mContent.replaceCharacters(in: match.range, with: mImageStr as String)

--- a/Modules/Tests/WordPressSharedTests/RichContentFormatterTests.swift
+++ b/Modules/Tests/WordPressSharedTests/RichContentFormatterTests.swift
@@ -65,4 +65,114 @@ class RichContentFormatterTests: XCTestCase {
         let sanitizedStr3 = RichContentFormatter.formatVideoTags(str3) as NSString
         XCTAssert(!sanitizedStr3.contains("controls controls"))
     }
+
+    // MARK: - Multi-code-unit input
+    //
+    // The bug sized each search range from the grapheme count (`content.count`) rather than the
+    // UTF-16 length. A cluster that is one grapheme but several UTF-16 units — emoji, a ZWJ
+    // sequence, a flag, a keycap, a skin-tone modifier, or a decomposed accent — therefore leaves
+    // a token near the end of the string just past the range, so the search never reaches it.
+    // Each test drives one such spot; the exact-output check also confirms the cluster is intact.
+
+    func testRegionalFlagStyleBlockSurvivesInTail() {
+        // A <style> block after a flag emoji is stripped; the neighbouring <b> stays.
+        let out = RichContentFormatter.removeForbiddenTags("🇺🇸<b>hi</b><style>zz</style>")
+        XCTAssertEqual(out, "🇺🇸<b>hi</b>")
+    }
+
+    func testZWJFamilyScriptTagSurvivesInTail() {
+        // A <script> after a family emoji — one grapheme but 11 UTF-16 units, the widest gap here.
+        let out = RichContentFormatter.removeForbiddenTags("👨‍👩‍👧‍👦<script>x</script>")
+        XCTAssertEqual(out, "👨‍👩‍👧‍👦")
+    }
+
+    func testKeycapGutenbergCommentSurvivesInTail() {
+        // A Gutenberg block comment after a keycap emoji is stripped.
+        let out = RichContentFormatter.removeForbiddenTags("1️⃣<p><!-- wp:paragraph --></p>")
+        XCTAssertEqual(out, "1️⃣")
+    }
+
+    func testSkinToneDivStartNotConvertedInTail() {
+        // <div> is converted to <p> even after a skin-tone emoji.
+        let out = RichContentFormatter.normalizeParagraphs("👍🏽<div>")
+        XCTAssertEqual(out, "👍🏽<p>")
+    }
+
+    func testNFDCombiningDivEndNotConvertedInTail() {
+        // </div> is converted to </p> after a decomposed "é" (e + a combining accent). A composed
+        // "é" is a single UTF-16 unit and would not reach past the range, so the decomposition matters.
+        let out = RichContentFormatter.normalizeParagraphs("cafe\u{301}</div>")
+        XCTAssertEqual(out, "cafe\u{301}</p>")
+    }
+
+    func testNormalizeParagraphsMergesTrailingDoubleOpenParagraph() {
+        // A redundant <p><p> is collapsed to a single <p>.
+        let out = RichContentFormatter.normalizeParagraphs("😀<p><p>")
+        XCTAssertEqual(out, "😀<p>")
+    }
+
+    func testNormalizeParagraphsMergesTrailingDoubleCloseParagraph() {
+        // A redundant </p></p> is collapsed to a single </p>.
+        let out = RichContentFormatter.normalizeParagraphs("😀</p></p>")
+        XCTAssertEqual(out, "😀</p>")
+    }
+
+    func testFilterNewLinesNoPreFallbackRemovesNewlinePastWideCluster() {
+        // A newline outside any <pre> block is removed.
+        let out = RichContentFormatter.filterNewLines("👨‍👩‍👧‍👦\nA")
+        XCTAssertEqual(out, "👨‍👩‍👧‍👦A")
+    }
+
+    func testFilterNewLinesElseBranchPreservesTrailingNewlineAfterWideCluster() {
+        // With a <pre> block present, a newline that follows it (outside the block) is still removed.
+        let out = RichContentFormatter.filterNewLines("<pre>\n</pre>👨‍👩‍👧‍👦\nZ")
+        XCTAssertEqual(out, "<pre>\n</pre>👨‍👩‍👧‍👦Z")
+    }
+
+    func testFilterNewLinesMultiPreInverseRanges() {
+        // Across several <pre> blocks: newlines inside them are kept, newlines outside are removed.
+        let out = RichContentFormatter.filterNewLines("👨‍👩‍👧‍👦\n<pre>a\nb</pre>\n😀\n<pre>c\nd</pre>\n🇺🇸\n")
+        XCTAssertEqual(out, "👨‍👩‍👧‍👦<pre>a\nb</pre>😀<pre>c\nd</pre>🇺🇸")
+    }
+
+    func testZWJFamilyStyleAttrSurvivesInTruncatedTail() {
+        // An inline style attribute after a family emoji is stripped.
+        let out = RichContentFormatter.removeInlineStyles("👨‍👩‍👧‍👦<div style=\"x\">")
+        XCTAssertEqual(out, "👨‍👩‍👧‍👦<div>")
+    }
+
+    func testZWJFamilyTrailingBreakSurvivesAndCutsCleanly() {
+        // A trailing <br> after a family emoji is removed, and the emoji before it stays intact.
+        let out = RichContentFormatter.removeTrailingBreakTags("👨‍👩‍👧‍👦text<br>")
+        XCTAssertEqual(out, "👨‍👩‍👧‍👦text")
+    }
+
+    func testTrailingBreakOnlyFinalRemovedEmojiIntact() {
+        // Only the trailing <br> is removed; an earlier <br> in the middle of the text stays.
+        let out = RichContentFormatter.removeTrailingBreakTags("😀<br>text<br>")
+        XCTAssertEqual(out, "😀<br>text")
+    }
+
+    func testForbiddenCleanMultibyteUnchanged() {
+        // Content with no tags to strip passes through unchanged.
+        let out = RichContentFormatter.removeForbiddenTags("Hello 👨‍👩‍👧‍👦 world 😀!")
+        XCTAssertEqual(out, "Hello 👨‍👩‍👧‍👦 world 😀!")
+    }
+
+    // MARK: - Boundary + selectivity (not new fix sites)
+
+    func testBoundaryStraddleOffByOne() {
+        // One emoji makes the range exactly one UTF-16 unit short, and the token's closing ">"
+        // is exactly that dropped unit — pins the off-by-one where the wide-gap cases have slack.
+        let out = RichContentFormatter.removeForbiddenTags("text<script>😀</script>")
+        XCTAssertEqual(out, "text")
+    }
+
+    func testStripsTagInRangeAndInTailNotJustEverything() {
+        // The first style attribute is always in range; the ZWJ family pushes the second into the
+        // truncated tail. The fix strips both; the bug strips only the first — so the range, not a
+        // blanket "strip everything", decides which tags go.
+        let out = RichContentFormatter.removeInlineStyles("<a style=\"one\">👨‍👩‍👧‍👦<b style=\"two\">")
+        XCTAssertEqual(out, "<a>👨‍👩‍👧‍👦<b>")
+    }
 }

--- a/Modules/Tests/WordPressSharedTests/RichContentFormatterTests.swift
+++ b/Modules/Tests/WordPressSharedTests/RichContentFormatterTests.swift
@@ -1,69 +1,73 @@
-import XCTest
+import Foundation
+import Testing
+
 @testable import WordPressShared
 
-class RichContentFormatterTests: XCTestCase {
+struct RichContentFormatterTests {
 
-    func testRemoveInlineStyles() {
+    @Test func testRemoveInlineStyles() {
         let str = "<p>test</p><p>test</p>"
         let styleStr = "<p style=\"background-color:#fff;\">test</p><p style=\"background-color:#fff;\">test</p>"
         let sanitizedStr = RichContentFormatter.removeInlineStyles(styleStr)
-        XCTAssertTrue(str == sanitizedStr, "The inline styles were not removed.")
+        #expect(str == sanitizedStr, "The inline styles were not removed.")
     }
 
-    func testRemoveForbiddenTags() {
+    @Test func testRemoveForbiddenTags() {
         let str = "<p>test</p><p>test</p><img>"
-        let styleStr = "<script>alert();</script><style>body{color:#000;}</style><p>test</p><script>alert();</script><style>body{color:#000;}</style><p>test</p><p><!-- wp:paragraph {\"fontSize\":\"large\"}--></p><p><!-- /wp:paragraph --></p>\n<img><p><!-- wp:self-closing-tag /--></p><script>alert();</script><style>body{color:#000;}</style>"
+        let styleStr =
+            "<script>alert();</script><style>body{color:#000;}</style><p>test</p><script>alert();</script><style>body{color:#000;}</style><p>test</p><p><!-- wp:paragraph {\"fontSize\":\"large\"}--></p><p><!-- /wp:paragraph --></p>\n<img><p><!-- wp:self-closing-tag /--></p><script>alert();</script><style>body{color:#000;}</style>"
         let sanitizedStr = RichContentFormatter.removeForbiddenTags(styleStr)
-        XCTAssertTrue(str == sanitizedStr, "The forbidden tags were not removed.")
+        #expect(str == sanitizedStr, "The forbidden tags were not removed.")
     }
 
-    func testNormalizeParagraphs() {
+    @Test func testNormalizeParagraphs() {
         let str = "<p>test</p><pre>\n\ntest\n\n</pre><p>test</p>"
         let styleStr = "<div><p>test</p></div><pre>\n\ntest\n\n</pre>\n<p><div>test</div></p>\n"
         let sanitizedStr = RichContentFormatter.normalizeParagraphs(styleStr)
-        XCTAssertTrue(str == sanitizedStr, "Not all paragraphs were normalized.")
+        #expect(str == sanitizedStr, "Not all paragraphs were normalized.")
     }
 
-    func testFilterNewLines() {
+    @Test func testFilterNewLines() {
         let str = "<div><p>test</p></div><pre>\n\ntest\n\n</pre><p><div>test</div></p>"
         let styleStr = "<div><p>test</p></div><pre>\n\ntest\n\n</pre>\n<p><div>test</div></p>\n"
         let sanitizedStr = RichContentFormatter.filterNewLines(styleStr)
-        XCTAssertTrue(str == sanitizedStr, "Not all paragraphs were normalized.")
+        #expect(str == sanitizedStr, "Not all paragraphs were normalized.")
     }
 
-    func testRemoveTrailingBRTags() {
+    @Test func testRemoveTrailingBRTags() {
         let str = "<p>test</p><br><p>test</p>"
         let styleStr = "<p>test</p><br><p>test</p><br><br> "
         let sanitizedStr = RichContentFormatter.removeTrailingBreakTags(styleStr)
-        XCTAssertTrue(str == sanitizedStr, "The inline styles were not removed.")
+        #expect(str == sanitizedStr, "The inline styles were not removed.")
     }
 
-    func testRemoveGutenbergGalleryListMarkup() {
-        let str = "Some text. <ul class=\"wp-block-gallery columns-3 is-cropped\"><li class=\"blocks-gallery-item\"><figure><img src=\"https://example.com/wp-content/uploads/2017/05/IMG_1364.jpg\" alt=\"\" data-id=\"103\" data-link=\"https://example.com/img_1364/\" class=\"wp-image-103\" srcset=\"https://example.com/wp-content/uploads/2017/05/IMG_1364.jpg 2048w, https://example.com/wp-content/uploads/2017/05/IMG_1364-300x225.jpg 300w, https://example.com/wp-content/uploads/2017/05/IMG_1364-768x576.jpg 768w, https://example.com/wp-content/uploads/2017/05/IMG_1364-1024x768.jpg 1024w, https://example.com/wp-content/uploads/2017/05/IMG_1364-1200x900.jpg 1200w\" sizes=\"(max-width: 2048px) 100vw, 2048px\" /><figcaption>Plants<br></figcaption></figure></li><li class=\"blocks-gallery-item\"><figure><img src=\"https://example.com/wp-content/uploads/2017/05/IMG_1215.jpg\" alt=\"\" data-id=\"102\" data-link=\"https://example.com/img_1215/\" class=\"wp-image-102\" srcset=\"https://example.com/wp-content/uploads/2017/05/IMG_1215.jpg 2048w, https://example.com/wp-content/uploads/2017/05/IMG_1215-300x225.jpg 300w, https://example.com/wp-content/uploads/2017/05/IMG_1215-768x576.jpg 768w, https://example.com/wp-content/uploads/2017/05/IMG_1215-1024x768.jpg 1024w, https://example.com/wp-content/uploads/2017/05/IMG_1215-1200x900.jpg 1200w\" sizes=\"(max-width: 2048px) 100vw, 2048px\" /></figure></li><li class=\"blocks-gallery-item\"><figure><img src=\"https://example.com/wp-content/uploads/2017/05/img_5918.jpg\" alt=\"\" data-id=\"101\" data-link=\"https://example.com/img_5918-jpg/\" class=\"wp-image-101\" srcset=\"https://example.com/wp-content/uploads/2017/05/img_5918.jpg 1000w, https://example.com/wp-content/uploads/2017/05/img_5918-225x300.jpg 225w, https://example.com/wp-content/uploads/2017/05/img_5918-768x1024.jpg 768w\" sizes=\"(max-width: 1000px) 100vw, 1000px\" /></figure></li></ul> Some text."
+    @Test func testRemoveGutenbergGalleryListMarkup() {
+        let str =
+            "Some text. <ul class=\"wp-block-gallery columns-3 is-cropped\"><li class=\"blocks-gallery-item\"><figure><img src=\"https://example.com/wp-content/uploads/2017/05/IMG_1364.jpg\" alt=\"\" data-id=\"103\" data-link=\"https://example.com/img_1364/\" class=\"wp-image-103\" srcset=\"https://example.com/wp-content/uploads/2017/05/IMG_1364.jpg 2048w, https://example.com/wp-content/uploads/2017/05/IMG_1364-300x225.jpg 300w, https://example.com/wp-content/uploads/2017/05/IMG_1364-768x576.jpg 768w, https://example.com/wp-content/uploads/2017/05/IMG_1364-1024x768.jpg 1024w, https://example.com/wp-content/uploads/2017/05/IMG_1364-1200x900.jpg 1200w\" sizes=\"(max-width: 2048px) 100vw, 2048px\" /><figcaption>Plants<br></figcaption></figure></li><li class=\"blocks-gallery-item\"><figure><img src=\"https://example.com/wp-content/uploads/2017/05/IMG_1215.jpg\" alt=\"\" data-id=\"102\" data-link=\"https://example.com/img_1215/\" class=\"wp-image-102\" srcset=\"https://example.com/wp-content/uploads/2017/05/IMG_1215.jpg 2048w, https://example.com/wp-content/uploads/2017/05/IMG_1215-300x225.jpg 300w, https://example.com/wp-content/uploads/2017/05/IMG_1215-768x576.jpg 768w, https://example.com/wp-content/uploads/2017/05/IMG_1215-1024x768.jpg 1024w, https://example.com/wp-content/uploads/2017/05/IMG_1215-1200x900.jpg 1200w\" sizes=\"(max-width: 2048px) 100vw, 2048px\" /></figure></li><li class=\"blocks-gallery-item\"><figure><img src=\"https://example.com/wp-content/uploads/2017/05/img_5918.jpg\" alt=\"\" data-id=\"101\" data-link=\"https://example.com/img_5918-jpg/\" class=\"wp-image-101\" srcset=\"https://example.com/wp-content/uploads/2017/05/img_5918.jpg 1000w, https://example.com/wp-content/uploads/2017/05/img_5918-225x300.jpg 225w, https://example.com/wp-content/uploads/2017/05/img_5918-768x1024.jpg 768w\" sizes=\"(max-width: 1000px) 100vw, 1000px\" /></figure></li></ul> Some text."
         let sanitizedString = RichContentFormatter.formatGutenbergGallery(str) as NSString
         // Checks if the UL was removed.
         var range = sanitizedString.range(of: "block-gallery")
-        XCTAssertTrue(range.location == NSNotFound)
+        #expect(range.location == NSNotFound)
         // Checks if the LI was removed
         range = sanitizedString.range(of: "blocks-gallery")
-        XCTAssertTrue(range.location == NSNotFound)
+        #expect(range.location == NSNotFound)
         // Checks if the FIGCAPTION was kept.
         range = sanitizedString.range(of: "figcaption")
-        XCTAssertTrue(range.location != NSNotFound)
+        #expect(range.location != NSNotFound)
     }
 
-    func testFormatVideoTags() {
+    @Test func testFormatVideoTags() {
         let str1 = "<p>Some text.</p><video></video><p>Some text.</p>"
         let sanitizedStr1 = RichContentFormatter.formatVideoTags(str1) as NSString
-        XCTAssert(sanitizedStr1.contains("controls"))
+        #expect(sanitizedStr1.contains("controls"))
 
         let str2 = "<p>Some text.</p><video autoplay></video><p>Some text.</p>"
         let sanitizedStr2 = RichContentFormatter.formatVideoTags(str2) as NSString
-        XCTAssert(sanitizedStr2.contains(" controls "))
+        #expect(sanitizedStr2.contains(" controls "))
 
         let str3 = "<p>Some text.</p><video controls></video><p>Some text.</p>"
         let sanitizedStr3 = RichContentFormatter.formatVideoTags(str3) as NSString
-        XCTAssert(!sanitizedStr3.contains("controls controls"))
+        #expect(!sanitizedStr3.contains("controls controls"))
     }
 
     // MARK: - Multi-code-unit input
@@ -74,105 +78,105 @@ class RichContentFormatterTests: XCTestCase {
     // a token near the end of the string just past the range, so the search never reaches it.
     // Each test drives one such spot; the exact-output check also confirms the cluster is intact.
 
-    func testRegionalFlagStyleBlockSurvivesInTail() {
+    @Test func testRegionalFlagStyleBlockSurvivesInTail() {
         // A <style> block after a flag emoji is stripped; the neighbouring <b> stays.
         let out = RichContentFormatter.removeForbiddenTags("🇺🇸<b>hi</b><style>zz</style>")
-        XCTAssertEqual(out, "🇺🇸<b>hi</b>")
+        #expect(out == "🇺🇸<b>hi</b>")
     }
 
-    func testZWJFamilyScriptTagSurvivesInTail() {
+    @Test func testZWJFamilyScriptTagSurvivesInTail() {
         // A <script> after a family emoji — one grapheme but 11 UTF-16 units, the widest gap here.
         let out = RichContentFormatter.removeForbiddenTags("👨‍👩‍👧‍👦<script>x</script>")
-        XCTAssertEqual(out, "👨‍👩‍👧‍👦")
+        #expect(out == "👨‍👩‍👧‍👦")
     }
 
-    func testKeycapGutenbergCommentSurvivesInTail() {
+    @Test func testKeycapGutenbergCommentSurvivesInTail() {
         // A Gutenberg block comment after a keycap emoji is stripped.
         let out = RichContentFormatter.removeForbiddenTags("1️⃣<p><!-- wp:paragraph --></p>")
-        XCTAssertEqual(out, "1️⃣")
+        #expect(out == "1️⃣")
     }
 
-    func testSkinToneDivStartNotConvertedInTail() {
+    @Test func testSkinToneDivStartNotConvertedInTail() {
         // <div> is converted to <p> even after a skin-tone emoji.
         let out = RichContentFormatter.normalizeParagraphs("👍🏽<div>")
-        XCTAssertEqual(out, "👍🏽<p>")
+        #expect(out == "👍🏽<p>")
     }
 
-    func testNFDCombiningDivEndNotConvertedInTail() {
+    @Test func testNFDCombiningDivEndNotConvertedInTail() {
         // </div> is converted to </p> after a decomposed "é" (e + a combining accent). A composed
         // "é" is a single UTF-16 unit and would not reach past the range, so the decomposition matters.
         let out = RichContentFormatter.normalizeParagraphs("cafe\u{301}</div>")
-        XCTAssertEqual(out, "cafe\u{301}</p>")
+        #expect(out == "cafe\u{301}</p>")
     }
 
-    func testNormalizeParagraphsMergesTrailingDoubleOpenParagraph() {
+    @Test func testNormalizeParagraphsMergesTrailingDoubleOpenParagraph() {
         // A redundant <p><p> is collapsed to a single <p>.
         let out = RichContentFormatter.normalizeParagraphs("😀<p><p>")
-        XCTAssertEqual(out, "😀<p>")
+        #expect(out == "😀<p>")
     }
 
-    func testNormalizeParagraphsMergesTrailingDoubleCloseParagraph() {
+    @Test func testNormalizeParagraphsMergesTrailingDoubleCloseParagraph() {
         // A redundant </p></p> is collapsed to a single </p>.
         let out = RichContentFormatter.normalizeParagraphs("😀</p></p>")
-        XCTAssertEqual(out, "😀</p>")
+        #expect(out == "😀</p>")
     }
 
-    func testFilterNewLinesNoPreFallbackRemovesNewlinePastWideCluster() {
+    @Test func testFilterNewLinesNoPreFallbackRemovesNewlinePastWideCluster() {
         // A newline outside any <pre> block is removed.
         let out = RichContentFormatter.filterNewLines("👨‍👩‍👧‍👦\nA")
-        XCTAssertEqual(out, "👨‍👩‍👧‍👦A")
+        #expect(out == "👨‍👩‍👧‍👦A")
     }
 
-    func testFilterNewLinesElseBranchPreservesTrailingNewlineAfterWideCluster() {
+    @Test func testFilterNewLinesElseBranchPreservesTrailingNewlineAfterWideCluster() {
         // With a <pre> block present, a newline that follows it (outside the block) is still removed.
         let out = RichContentFormatter.filterNewLines("<pre>\n</pre>👨‍👩‍👧‍👦\nZ")
-        XCTAssertEqual(out, "<pre>\n</pre>👨‍👩‍👧‍👦Z")
+        #expect(out == "<pre>\n</pre>👨‍👩‍👧‍👦Z")
     }
 
-    func testFilterNewLinesMultiPreInverseRanges() {
+    @Test func testFilterNewLinesMultiPreInverseRanges() {
         // Across several <pre> blocks: newlines inside them are kept, newlines outside are removed.
         let out = RichContentFormatter.filterNewLines("👨‍👩‍👧‍👦\n<pre>a\nb</pre>\n😀\n<pre>c\nd</pre>\n🇺🇸\n")
-        XCTAssertEqual(out, "👨‍👩‍👧‍👦<pre>a\nb</pre>😀<pre>c\nd</pre>🇺🇸")
+        #expect(out == "👨‍👩‍👧‍👦<pre>a\nb</pre>😀<pre>c\nd</pre>🇺🇸")
     }
 
-    func testZWJFamilyStyleAttrSurvivesInTruncatedTail() {
+    @Test func testZWJFamilyStyleAttrSurvivesInTruncatedTail() {
         // An inline style attribute after a family emoji is stripped.
         let out = RichContentFormatter.removeInlineStyles("👨‍👩‍👧‍👦<div style=\"x\">")
-        XCTAssertEqual(out, "👨‍👩‍👧‍👦<div>")
+        #expect(out == "👨‍👩‍👧‍👦<div>")
     }
 
-    func testZWJFamilyTrailingBreakSurvivesAndCutsCleanly() {
+    @Test func testZWJFamilyTrailingBreakSurvivesAndCutsCleanly() {
         // A trailing <br> after a family emoji is removed, and the emoji before it stays intact.
         let out = RichContentFormatter.removeTrailingBreakTags("👨‍👩‍👧‍👦text<br>")
-        XCTAssertEqual(out, "👨‍👩‍👧‍👦text")
+        #expect(out == "👨‍👩‍👧‍👦text")
     }
 
-    func testTrailingBreakOnlyFinalRemovedEmojiIntact() {
+    @Test func testTrailingBreakOnlyFinalRemovedEmojiIntact() {
         // Only the trailing <br> is removed; an earlier <br> in the middle of the text stays.
         let out = RichContentFormatter.removeTrailingBreakTags("😀<br>text<br>")
-        XCTAssertEqual(out, "😀<br>text")
+        #expect(out == "😀<br>text")
     }
 
-    func testForbiddenCleanMultibyteUnchanged() {
+    @Test func testForbiddenCleanMultibyteUnchanged() {
         // Content with no tags to strip passes through unchanged.
         let out = RichContentFormatter.removeForbiddenTags("Hello 👨‍👩‍👧‍👦 world 😀!")
-        XCTAssertEqual(out, "Hello 👨‍👩‍👧‍👦 world 😀!")
+        #expect(out == "Hello 👨‍👩‍👧‍👦 world 😀!")
     }
 
     // MARK: - Boundary + selectivity (not new fix sites)
 
-    func testBoundaryStraddleOffByOne() {
+    @Test func testBoundaryStraddleOffByOne() {
         // One emoji makes the range exactly one UTF-16 unit short, and the token's closing ">"
         // is exactly that dropped unit — pins the off-by-one where the wide-gap cases have slack.
         let out = RichContentFormatter.removeForbiddenTags("text<script>😀</script>")
-        XCTAssertEqual(out, "text")
+        #expect(out == "text")
     }
 
-    func testStripsTagInRangeAndInTailNotJustEverything() {
+    @Test func testStripsTagInRangeAndInTailNotJustEverything() {
         // The first style attribute is always in range; the ZWJ family pushes the second into the
         // truncated tail. The fix strips both; the bug strips only the first — so the range, not a
         // blanket "strip everything", decides which tags go.
         let out = RichContentFormatter.removeInlineStyles("<a style=\"one\">👨‍👩‍👧‍👦<b style=\"two\">")
-        XCTAssertEqual(out, "<a>👨‍👩‍👧‍👦<b>")
+        #expect(out == "<a>👨‍👩‍👧‍👦<b>")
     }
 }

--- a/Modules/Tests/WordPressSharedTests/RichContentFormatterTests.swift
+++ b/Modules/Tests/WordPressSharedTests/RichContentFormatterTests.swift
@@ -179,4 +179,23 @@ struct RichContentFormatterTests {
         let out = RichContentFormatter.removeInlineStyles("<a style=\"one\">👨‍👩‍👧‍👦<b style=\"two\">")
         #expect(out == "<a>👨‍👩‍👧‍👦<b>")
     }
+
+    // MARK: - parseValueForAttribute robustness
+
+    @Test func testParseValueForAttributeReturnsValue() {
+        let value = RichContentFormatter.parseValueForAttribute("src", inElement: "<img src=\"http://x/a.jpg\">")
+        #expect(value == "http://x/a.jpg")
+    }
+
+    @Test func testParseValueForAttributeMissingClosingQuoteReturnsEmpty() {
+        // Opening quote but no closing quote: the closing-quote search returns NSNotFound, so the
+        // range length would underflow to a huge value and crash substring(with:). Return "" instead.
+        let value = RichContentFormatter.parseValueForAttribute("src", inElement: "<img src=\"http://x/a.jpg>")
+        #expect(value.isEmpty)
+    }
+
+    @Test func testParseValueForAttributeAbsentReturnsEmpty() {
+        let value = RichContentFormatter.parseValueForAttribute("src", inElement: "<img alt=\"x\">")
+        #expect(value.isEmpty)
+    }
 }

--- a/Modules/Tests/WordPressSharedTests/RichContentFormatterUITests.swift
+++ b/Modules/Tests/WordPressSharedTests/RichContentFormatterUITests.swift
@@ -1,11 +1,13 @@
-import XCTest
+import Foundation
+import Testing
+
 @testable import WordPressShared
 @testable import WordPressSharedUI
 
-class RichContentFormatterUITests: XCTestCase {
+struct RichContentFormatterUITests {
 
-    func testResizeGalleryImageURLsForContentEmptyString() {
-        XCTAssertTrue("" == RichContentFormatter.resizeGalleryImageURL("", isPrivateSite: false))
+    @Test func testResizeGalleryImageURLsForContentEmptyString() {
+        #expect(RichContentFormatter.resizeGalleryImageURL("", isPrivateSite: false).isEmpty)
     }
 
     // The gallery-image src rewrite sized its search range from the grapheme count
@@ -13,16 +15,16 @@ class RichContentFormatterUITests: XCTestCase {
     // multi-code-unit cluster fell outside the range and was never swapped for the resized
     // URL. Here five emoji in `alt` (10 UTF-16 units, 5 graphemes) push the trailing `src`
     // past a grapheme-count range; the resized URL must still replace it, cluster intact.
-    func testResizeGalleryImageURLReplacesSrcPastMultibyteCluster() {
+    @Test func testResizeGalleryImageURLReplacesSrcPastMultibyteCluster() {
         let input =
             "<img data-orig-file=\"https://example.com/orig.jpg\" alt=\"😀😀😀😀😀\" src=\"https://example.com/small.jpg\"/>"
 
         let output = RichContentFormatter.resizeGalleryImageURL(input, isPrivateSite: false)
 
         // The original src was found and rewritten to a resized (Photon) URL...
-        XCTAssertFalse(output.contains("https://example.com/small.jpg"))
-        XCTAssertTrue(output.contains(".wp.com"))
+        #expect(!output.contains("https://example.com/small.jpg"))
+        #expect(output.contains(".wp.com"))
         // ...and the emoji cluster survived byte-for-byte.
-        XCTAssertTrue(output.contains("😀😀😀😀😀"))
+        #expect(output.contains("😀😀😀😀😀"))
     }
 }

--- a/Modules/Tests/WordPressSharedTests/RichContentFormatterUITests.swift
+++ b/Modules/Tests/WordPressSharedTests/RichContentFormatterUITests.swift
@@ -7,4 +7,22 @@ class RichContentFormatterUITests: XCTestCase {
     func testResizeGalleryImageURLsForContentEmptyString() {
         XCTAssertTrue("" == RichContentFormatter.resizeGalleryImageURL("", isPrivateSite: false))
     }
+
+    // The gallery-image src rewrite sized its search range from the grapheme count
+    // (`imgElementStr.count`) rather than the UTF-16 length, so a `src` sitting past a
+    // multi-code-unit cluster fell outside the range and was never swapped for the resized
+    // URL. Here five emoji in `alt` (10 UTF-16 units, 5 graphemes) push the trailing `src`
+    // past a grapheme-count range; the resized URL must still replace it, cluster intact.
+    func testResizeGalleryImageURLReplacesSrcPastMultibyteCluster() {
+        let input =
+            "<img data-orig-file=\"https://example.com/orig.jpg\" alt=\"😀😀😀😀😀\" src=\"https://example.com/small.jpg\"/>"
+
+        let output = RichContentFormatter.resizeGalleryImageURL(input, isPrivateSite: false)
+
+        // The original src was found and rewritten to a resized (Photon) URL...
+        XCTAssertFalse(output.contains("https://example.com/small.jpg"))
+        XCTAssertTrue(output.contains(".wp.com"))
+        // ...and the emoji cluster survived byte-for-byte.
+        XCTAssertTrue(output.contains("😀😀😀😀😀"))
+    }
 }


### PR DESCRIPTION
## What this fixes

`RichContentFormatter` sized the `NSRange` it hands to `NSRegularExpression` from `content.count` — Swift's *grapheme-cluster* count — but `NSRegularExpression` matches over **UTF-16**. When content contains multi-code-unit characters (emoji, flags, ZWJ/combining sequences) the grapheme count is shorter than the UTF-16 length, so the search range stops short of the end and any forbidden tag, inline style, or gallery-image `src` near the end is **silently left untouched** — unsanitized markup then reaches the rendered Reader post or comment.

A single family emoji `👨‍👩‍👧‍👦` is one grapheme but eleven UTF-16 units, so a `<script>` placed right after it begins ten units past where the grapheme-count range ends: the whole tag falls outside the search and survives.

**ASCII content is unaffected** — there the grapheme count equals the UTF-16 length, which is why this went unnoticed.

## Changes

- **Size every search range in UTF-16.** The whole-string ranges across `removeForbiddenTags`, `normalizeParagraphs`, `filterNewLines`, and `removeInlineStyles` now come from `String.utf16.count`, and `removeTrailingBreakTags` ranges over UTF-16 too.
- **`removeTrailingBreakTags` no longer mixes offset spaces.** It fed a UTF-16 `match.range.location` to `String.index(_:offsetBy:)`, which counts graphemes — already wrong for multibyte content, and a hard crash (`String index is out of bounds`) once the range widened. It now converts the match with `Range(match.range, in: content)`.
- **`resizeGalleryImageURL` had the same bug.** This display-pipeline step rewrites a gallery image's `src` to a Photon/resized URL; it sized the replacement range from `imgElementStr.count`, so a `src` sitting past a multibyte cluster was never rewritten and the full-size original loaded instead. It runs on rendered comments (`CommentService` → `formatContentString`). Now sized in UTF-16.
- **Harden `parseValueForAttribute` against malformed markup.** A separate crash in the same file: it searched for an attribute's closing quote and passed the result to `substring(with:)` unguarded, so an opening quote with no close (`NSNotFound`) underflowed the range length to an out-of-bounds `NSRange` and trapped. It now returns `""` when the closing quote is missing, matching the attribute-not-found default.
- **Migrate the tests to Swift Testing.** The `RichContentFormatter` test files move from XCTest to `@Test`/`#expect`, matching the rest of the `WordPressSharedTests` target — same inputs, same assertions.

`formatGutenbergGallery` and `formatVideoTags` already ranged over `NSString.length` and are untouched.

The whole-string ranges are sized with `content.utf16.count` inline, matching the convention #25341 established across the rest of the codebase.

Split into three commits for review: the fix (with regression tests), the Swift Testing migration, and the `parseValueForAttribute` hardening.

## Tests

One isolated test per fix site — each forbidden-tag regex, each `normalizeParagraphs` sub-site, the three `filterNewLines` paths, the inline-style site, and the trailing-break range plus its index-offset cut — using a spread of multi-code-unit clusters (astral emoji, a ZWJ family, a flag, a keycap, a skin-tone modifier, and an NFD combining mark), positioned so the target token lands in the tail the grapheme-count range dropped. Each input holds one tag type, so reverting any single site breaks exactly one test; the exact-output assertions also confirm the cluster survives byte-for-byte. Two further tests pin the exact off-by-one boundary and confirm the corrected range strips the *intended* tag rather than everything.

`parseValueForAttribute` gets three direct tests, including a malformed element (opening quote, no close) that crashes the pre-fix code with an out-of-bounds `NSRange` and returns `""` after the fix.

`resizeGalleryImageURL`'s regression lives in `RichContentFormatterUITests` — it needs UIKit, so it runs in the iOS `WordPressUnitTests` plan, not the macOS `swift test` set.

## Stacking

Stacked on #25832 (base `jkmassel/wordpressdata-swift-test`), which removes WordPressData's `WordPressUI`/`WordPressSharedUI` dependencies and, as part of that, splits `RichContentFormatter`'s platform-independent core into cross-platform `WordPressShared` — which is what lets this fix and its regression tests run on macOS under `swift test`. The bug is pre-existing; it's also on `trunk`, in the pre-split `WordPressSharedUI` copy. This PR retargets to `trunk` once #25832 merges.

## Test plan

- [x] `swift test --filter RichContentFormatterTests` (macOS host) → 26/26. 15 of the 16 multibyte tests fail on the pre-fix source (the 16th is a no-tags idempotence guard that passes either way); the `parseValueForAttribute` missing-closing-quote test traps the pre-fix code with an out-of-bounds `NSRange`.
- [ ] Run the iOS `WordPressUnitTests` plan (or rely on CI): `RichContentFormatterUITests.testResizeGalleryImageURLReplacesSrcPastMultibyteCluster` — a gallery `<img data-orig-file=… alt="😀😀😀😀😀" src=…/>` comes back with its `src` swapped to a `*.wp.com` URL (0 replacements on the pre-fix source).
