### PR TITLE
Prevent trunk builds from expiring TestFlight submissions

### DIFF
--- a/fastlane/lanes/build.rb
+++ b/fastlane/lanes/build.rb
@@ -540,17 +540,18 @@ platform :ios do
     # richer notes generated from the PRs merged since the previous public build.
     changelog = "Automated build from `#{ENV.fetch('BUILDKITE_BRANCH', 'unknown branch')}` (#{ENV.fetch('BUILDKITE_COMMIT', 'unknown commit')[0...7]})."
 
-    Dir.mktmpdir do |dir|
-      whats_new_path = File.join(dir, 'testflight_whats_new.txt')
-      File.write(whats_new_path, changelog)
-
-      upload_build_to_testflight(
-        ipa_path: ipa_path,
-        whats_new_path: whats_new_path,
-        distribution_groups: [],
-        beta_app_description_path: beta_app_description_path
-      )
-    end
+    upload_to_testflight(
+      api_key: app_store_connect_api_key,
+      ipa: ipa_path,
+      beta_app_description: File.read(beta_app_description_path),
+      changelog: changelog,
+      distribute_external: false,
+      notify_external_testers: false,
+      # Internal builds don't participate in beta review and must not disturb an
+      # existing external review submission.
+      submit_beta_review: false,
+      reject_build_waiting_for_review: false
+    )
   end
 
   # Send a Slack message to the specified channel

--- a/fastlane/lanes/promote.rb
+++ b/fastlane/lanes/promote.rb
@@ -220,7 +220,8 @@ def promote_existing_build_to_groups(app:, app_version:, build_code:, changelog:
     changelog: changelog,
     # Fail (rather than hang forever) if the build never resolves — see PROMOTION_PROCESSING_TIMEOUT_SECONDS.
     wait_processing_timeout_duration: PROMOTION_PROCESSING_TIMEOUT_SECONDS,
-    # Don't disrupt a submission already in review.
+    # If another build for this version is already in review, let this unattended
+    # promotion fail instead of expiring the existing submission.
     reject_build_waiting_for_review: false
   )
 end


### PR DESCRIPTION
## Description

Relates to p1785026857205379-slack-CC7L49W13

Here is an illustration of the issue.

```mermaid
sequenceDiagram
      autonumber

      participant Release as Release Scenario
      participant GitHub
      participant Trunk as Trunk pipeline
      participant Helper as Shared upload helper
      participant TestFlight

      Release->>Helper: Publish release beta build
      Helper->>TestFlight: Upload and submit for Beta App Review
      TestFlight-->>Release: Release build is Waiting for Review

      GitHub->>GitHub: Pull request merged into trunk
      GitHub->>Trunk: Trigger new trunk build
      Trunk->>Trunk: Build app for internal testing
      Trunk->>Helper: Upload internal trunk build

      rect rgba(255, 80, 80, 0.18)
          Note over Helper,TestFlight: Problematic behavior
          Helper->>TestFlight: Upload with<br/>reject_build_waiting_for_review: true
          TestFlight->>TestFlight: Reject existing release beta submission
          TestFlight-->>Release: Release beta build becomes Expired
      end

      TestFlight-->>Trunk: Trunk build available to internal testers
```

The fix is leave the shared helper for the release pipeline. The night promotion build does not use it, and now the trunk builds also don't use it. They now all pass `reject_build_waiting_for_review: false`, which means they can fail if there is a build waiting for review, which I think is acceptable.