### PR TITLE
Fix My Site navigation during modal presentation

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -185,7 +185,10 @@ final class MySiteViewController: UIViewController, UIScrollViewDelegate, NoSite
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
 
-        resetNavBarAppearance(animated: animated)
+        // Only reset for a push to avoid animating the My Site title behind a presented modal.
+        if navigationController?.topViewController !== self {
+            resetNavBarAppearance(animated: animated)
+        }
         createButtonCoordinator?.hideCreateButton()
     }
 


### PR DESCRIPTION
## Description

When presenting a modal from the My Site tab, the title would slide down from the top. See the screenshot below.

<img width="1484" height="1069" alt="animation" src="https://github.com/user-attachments/assets/2be2acb8-52c9-45ac-bb37-6b40dc827110" />
