### PR TITLE
fix(editor): translate the patterns count and fall back for new editor strings

### DIFF
--- a/Modules/Package.resolved
+++ b/Modules/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "4de2f629319d11e1daef4a746ee727d287951510c0fdc4469215767e9df0361b",
+  "originHash" : "5aaa821f72e65770fd41b53c0fd652330dc9ca29e3bd17557b2eb9812ef74c99",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -131,7 +131,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/wordpress-mobile/GutenbergKit",
       "state" : {
-        "revision" : "b681e106123c9b11b9bdd7923ea18f227dc5a85f"
+        "revision" : "ac9b899d189d20a0d51d20e75da9f5515fc183ab",
+        "version" : "0.19.0-alpha.0"
       }
     },
     {

--- a/Modules/Package.resolved
+++ b/Modules/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "394a1dae231289152fc0a7f94cfb495587468c99f146311d7a94ac6a25772e0b",
+  "originHash" : "e77a9128635d7de8e21c7a3d786fc26258c74c0bfbfdfb0523447e7a66bc163b",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -131,8 +131,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/wordpress-mobile/GutenbergKit",
       "state" : {
-        "revision" : "7180587f49d3c3bfdb34cc3e80b2a9d22a3cd93e",
-        "version" : "0.18.1"
+        "branch" : "pr-build/569",
+        "revision" : "b40026523e455890c070c4844e5fdc6de3e4ae8b"
       }
     },
     {

--- a/Modules/Package.resolved
+++ b/Modules/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "e2f68a933b297d036201a43c6498ec30ca554bb39673797d95def0c6fde0c7f3",
+  "originHash" : "4de2f629319d11e1daef4a746ee727d287951510c0fdc4469215767e9df0361b",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -131,7 +131,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/wordpress-mobile/GutenbergKit",
       "state" : {
-        "revision" : "40f35ecb2c8a88ba8759f911f28cf79571e969a5"
+        "revision" : "b681e106123c9b11b9bdd7923ea18f227dc5a85f"
       }
     },
     {

--- a/Modules/Package.resolved
+++ b/Modules/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "e77a9128635d7de8e21c7a3d786fc26258c74c0bfbfdfb0523447e7a66bc163b",
+  "originHash" : "e2f68a933b297d036201a43c6498ec30ca554bb39673797d95def0c6fde0c7f3",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -131,8 +131,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/wordpress-mobile/GutenbergKit",
       "state" : {
-        "branch" : "pr-build/569",
-        "revision" : "b40026523e455890c070c4844e5fdc6de3e4ae8b"
+        "revision" : "40f35ecb2c8a88ba8759f911f28cf79571e969a5"
       }
     },
     {

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -63,7 +63,8 @@ let package = Package(
         ),
         .package(url: "https://github.com/zendesk/support_sdk_ios", from: "8.0.3"),
         // TODO: Restore a version pin once GutenbergKit#569 ships a release.
-        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", branch: "pr-build/569"),
+        .package(url: "https://github.com/wordpress-mobile/GutenbergKit",
+        revision: "40f35ecb2c8a88ba8759f911f28cf79571e969a5"),
         .package(
             url: "https://github.com/automattic/wordpress-rs",
             exact: "0.6.0"

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -63,8 +63,7 @@ let package = Package(
         ),
         .package(url: "https://github.com/zendesk/support_sdk_ios", from: "8.0.3"),
         // TODO: Restore a version pin once GutenbergKit#569 ships a release.
-        .package(url: "https://github.com/wordpress-mobile/GutenbergKit",
-        revision: "b681e106123c9b11b9bdd7923ea18f227dc5a85f"),
+        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", from: "0.19.0-alpha.0"),
         .package(
             url: "https://github.com/automattic/wordpress-rs",
             exact: "0.6.0"

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -64,7 +64,7 @@ let package = Package(
         .package(url: "https://github.com/zendesk/support_sdk_ios", from: "8.0.3"),
         // TODO: Restore a version pin once GutenbergKit#569 ships a release.
         .package(url: "https://github.com/wordpress-mobile/GutenbergKit",
-        revision: "40f35ecb2c8a88ba8759f911f28cf79571e969a5"),
+        revision: "b681e106123c9b11b9bdd7923ea18f227dc5a85f"),
         .package(
             url: "https://github.com/automattic/wordpress-rs",
             exact: "0.6.0"

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -62,7 +62,8 @@ let package = Package(
             revision: "b34794c9a3f32312e1593d4a3d120572afa0d010"
         ),
         .package(url: "https://github.com/zendesk/support_sdk_ios", from: "8.0.3"),
-        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", from: "0.18.1"),
+        // TODO: Restore a version pin once GutenbergKit#569 ships a release.
+        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", branch: "pr-build/569"),
         .package(
             url: "https://github.com/automattic/wordpress-rs",
             exact: "0.6.0"

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -62,7 +62,6 @@ let package = Package(
             revision: "b34794c9a3f32312e1593d4a3d120572afa0d010"
         ),
         .package(url: "https://github.com/zendesk/support_sdk_ios", from: "8.0.3"),
-        // TODO: Restore a version pin once GutenbergKit#569 ships a release.
         .package(url: "https://github.com/wordpress-mobile/GutenbergKit", from: "0.19.0-alpha.0"),
         .package(
             url: "https://github.com/automattic/wordpress-rs",

--- a/WordPress/Classes/ViewRelated/NewGutenberg/GBKExtensions.swift
+++ b/WordPress/Classes/ViewRelated/NewGutenberg/GBKExtensions.swift
@@ -152,7 +152,10 @@ private func getLocalizedString(for value: GutenbergKit.EditorLocalizableString)
             value: "Dismiss",
             comment: "Button title to dismiss the Lockdown Mode warning"
         )
-    default:
+    // Renders strings added by a newer GutenbergKit in English rather than
+    // breaking this build. `@unknown` because a plain `default` warns that it
+    // will never execute while this switch happens to cover every case.
+    @unknown default:
         EditorLocalization.defaultLocalize(value)
     }
 }

--- a/WordPress/Classes/ViewRelated/NewGutenberg/GBKExtensions.swift
+++ b/WordPress/Classes/ViewRelated/NewGutenberg/GBKExtensions.swift
@@ -33,7 +33,7 @@ extension GutenbergKit.EditorViewControllerDelegate {
     }
 }
 
-private func getLocalizedString(for value: GutenbergKit.EditorLocalizableString) -> String {
+private func getLocalizedString(for value: GutenbergKit.EditorLocalizableString) -> String? {
     switch value {
     case .showMore:
         NSLocalizedString(
@@ -152,16 +152,17 @@ private func getLocalizedString(for value: GutenbergKit.EditorLocalizableString)
             value: "Dismiss",
             comment: "Button title to dismiss the Lockdown Mode warning"
         )
-    // Renders strings added by a newer GutenbergKit in English rather than
-    // breaking this build. `@unknown` because a plain `default` warns that it
-    // will never execute while this switch happens to cover every case.
+    // Declining a key lets the editor render its own string, so strings added
+    // by a newer GutenbergKit appear in English rather than breaking this build.
+    // `@unknown` because a plain `default` warns that it will never execute
+    // while this switch happens to cover every case.
     @unknown default:
-        EditorLocalization.defaultLocalize(value)
+        nil
     }
 }
 
 extension EditorLocalizableString {
-    var localized: String {
+    var localized: String? {
         getLocalizedString(for: self)
     }
 }

--- a/WordPress/Classes/ViewRelated/NewGutenberg/GBKExtensions.swift
+++ b/WordPress/Classes/ViewRelated/NewGutenberg/GBKExtensions.swift
@@ -91,6 +91,24 @@ private func getLocalizedString(for value: GutenbergKit.EditorLocalizableString)
             value: "All",
             comment: "Category name for section showing all patterns"
         )
+    case .patternsCount(let count):
+        if count == 1 {
+            NSLocalizedString(
+                "editor.patterns.count.singular",
+                value: "1 pattern",
+                comment: "Singular label displaying the number of patterns in a category"
+            )
+        } else {
+            String(
+                format: NSLocalizedString(
+                    "editor.patterns.count.plural",
+                    value: "%1$d patterns",
+                    comment:
+                        "Plural label displaying the number of patterns in a category. %1$d is a placeholder for the number of patterns."
+                ),
+                count
+            )
+        }
     case .loadingEditor:
         NSLocalizedString(
             "editor.loading.title",
@@ -134,6 +152,8 @@ private func getLocalizedString(for value: GutenbergKit.EditorLocalizableString)
             value: "Dismiss",
             comment: "Button title to dismiss the Lockdown Mode warning"
         )
+    default:
+        EditorLocalization.defaultLocalize(value)
     }
 }
 


### PR DESCRIPTION
## Description

Adopts [GutenbergKit#569](https://github.com/wordpress-mobile/GutenbergKit/pull/569), which localizes the block inserter's pattern count and lets host apps fall back to the editor's own strings for keys they do not translate.

Two changes here:

**Translate `patternsCount`.** GutenbergKit#569 adds `EditorLocalizableString.patternsCount(Int)` for a string that previously rendered as hardcoded English. Singular and plural are split so each reads naturally rather than forcing "1 pattern(s)".

**Decline unhandled keys.** `getLocalizedString(for:)` switched over the enum exhaustively, so every string the editor added broke this build until someone wrote a translation — and the break surfaced on the dependency bump, not when the string was added. Unhandled keys now return `nil`, and the editor supplies its own string:

```swift
@unknown default:
    nil
```

New editor strings render in English until translated, instead of failing to compile. `@unknown default` rather than a plain `default` because this switch currently covers every case, and a plain one warns "default will never be executed."

`EditorLocalization.localize` now returns `String?`, so `getLocalizedString(for:)` and `EditorLocalizableString.localized` return optionals to match. The install site in `PostGBKEditorViewController` is unchanged — `{ $0.localized }` already fits the new closure type.

Note that `@unknown default` covers only keys added by a *future* GutenbergKit. Skipping a case that exists today is still a compile error, so this cannot silently drop a translation we meant to write.

> [!NOTE]
> `Modules/Package.swift` pins a GutenbergKit revision while that PR is open. The `TODO` there marks restoring a version pin once it ships. This PR should not merge before GutenbergKit#569.

## Testing instructions

The pattern count is the visible change:

1. Open the editor and tap **+** for the block inserter.
2. Switch to the **Patterns** tab on a site that has patterns.
3. Confirm section headers show a localized count, and that a category with exactly one pattern reads "1 pattern" rather than "1 patterns".

To verify the fallback, which has no visible effect until GutenbergKit adds a string:

1. Comment out a case in `getLocalizedString(for:)` — `.patterns` or `.search` render unconditionally and are easy to spot. Return `nil` for it instead, since removing the case outright is a compile error.
2. Run the app and open the block inserter.
3. Confirm the string renders in English rather than crashing or rendering empty.
4. Confirm the console shows `[GutenbergKit:localization] Missing host translation for …`, or filter Console.app on subsystem `GutenbergKit`. Each key reports once per launch, so scrolling a list will not repeat it.
5. Restore the case.

Nothing reports with every case handled, which is the expected state on `trunk`.
