### PR TITLE
Evict WordPress clients during account and site removal

### DIFF
--- a/Tests/KeystoneTests/Tests/Networking/WordPressClientFactoryTests.swift
+++ b/Tests/KeystoneTests/Tests/Networking/WordPressClientFactoryTests.swift
@@ -1,0 +1,90 @@
+import OHHTTPStubs
+import OHHTTPStubsSwift
+import XCTest
+
+@testable import WordPress
+@testable import WordPressData
+
+final class WordPressClientFactoryTests: CoreDataTestCase {
+    override func setUp() {
+        super.setUp()
+        contextManager.useAsSharedInstance(untilTestFinished: self)
+        WordPressClientFactory.shared.reset()
+        HTTPStubs.removeAllStubs()
+        stub(condition: { _ in true }) { _ in
+            HTTPStubsResponse(
+                jsonObject: [:],
+                statusCode: 200,
+                headers: ["Content-Type": "application/json"]
+            )
+        }
+    }
+
+    override func tearDown() {
+        WordPressClientFactory.shared.reset()
+        HTTPStubs.removeAllStubs()
+        super.tearDown()
+    }
+
+    func testEvictInstanceIsIdempotentAndCreatesANewClient() throws {
+        let site = try makeSite(dotComID: 123)
+        let otherSite = try makeSite(dotComID: 456)
+        let original = WordPressClientFactory.shared.instance(for: site)
+        let otherOriginal = WordPressClientFactory.shared.instance(for: otherSite)
+
+        WordPressClientFactory.shared.evictInstance(for: site.blogId)
+        WordPressClientFactory.shared.evictInstance(for: site.blogId)
+
+        let replacement = WordPressClientFactory.shared.instance(for: site)
+        XCTAssertFalse(original === replacement)
+        XCTAssertTrue(replacement === WordPressClientFactory.shared.instance(for: site))
+        XCTAssertTrue(otherOriginal === WordPressClientFactory.shared.instance(for: otherSite))
+    }
+
+    func testResetCreatesANewClient() throws {
+        let site = try makeSite(dotComID: 123)
+        let original = WordPressClientFactory.shared.instance(for: site)
+
+        WordPressClientFactory.shared.reset()
+
+        XCTAssertFalse(original === WordPressClientFactory.shared.instance(for: site))
+    }
+
+    func testRemovingDefaultAccountEvictsBlogClient() throws {
+        let blog = makeBlog(dotComID: 123)
+        try mainContext.save()
+        let site = try WordPressSite(blog: blog)
+        let original = WordPressClientFactory.shared.instance(for: site)
+        let service = AccountService(coreDataStack: contextManager)
+        service.setDefaultWordPressComAccount(try XCTUnwrap(blog.account))
+
+        service.removeDefaultWordPressComAccount()
+
+        XCTAssertFalse(original === WordPressClientFactory.shared.instance(for: site))
+    }
+
+    func testRemovingBlogEvictsClient() throws {
+        let blog = makeBlog(dotComID: 123)
+        try mainContext.save()
+        let site = try WordPressSite(blog: blog)
+        let original = WordPressClientFactory.shared.instance(for: site)
+
+        BlogService(coreDataStack: contextManager).remove(blog)
+
+        XCTAssertFalse(original === WordPressClientFactory.shared.instance(for: site))
+    }
+
+    private func makeSite(dotComID: Int) throws -> WordPressSite {
+        try WordPressSite(blog: makeBlog(dotComID: dotComID))
+    }
+
+    private func makeBlog(dotComID: Int) -> Blog {
+        let blog = BlogBuilder(mainContext, dotComID: NSNumber(value: dotComID))
+            .with(url: "https://example.wordpress.com")
+            .isHostedAtWPcom()
+            .withAnAccount(username: "test-user", authToken: "test-token")
+            .build()
+        blog.account?.uuid = UUID().uuidString
+        return blog
+    }
+}

--- a/Tests/KeystoneTests/Tests/Services/BlogServiceTest.m
+++ b/Tests/KeystoneTests/Tests/Services/BlogServiceTest.m
@@ -8,6 +8,14 @@
 
 @import OCMock;
 
+@interface BlogService (Testing)
+
+- (void)mergeBlogs:(NSArray<RemoteBlog *> *)blogs
+      withAccountID:(NSManagedObjectID *)accountID
+          inContext:(NSManagedObjectContext *)context;
+
+@end
+
 @interface BlogServiceTest : XCTestCase
 
 @property (nonatomic, strong) BlogService *blogService;
@@ -67,6 +75,21 @@
 - (void)cleanUpNSUserDefaultValues
 {
     [UserSettings setDefaultDotComUUID:nil];
+}
+
+- (void)testMergeBlogsEvictsClientForDeletedBlog
+{
+    self.blog.dotComID = @1;
+    WPAccount *account = self.blog.account;
+
+    OCMExpect([self.blogServiceMock evictWordPressClientForBlog:self.blog]);
+
+    [self.blogServiceMock mergeBlogs:@[]
+                       withAccountID:account.objectID
+                           inContext:self.coreDataStack.mainContext];
+
+    OCMVerifyAll(self.blogServiceMock);
+    XCTAssertTrue(self.blog.isDeleted);
 }
 
 - (void)testUpdateSettingsAppliesPresentValuesIncludingFalse

--- a/WordPress/Classes/Networking/WordPressClient.swift
+++ b/WordPress/Classes/Networking/WordPressClient.swift
@@ -53,8 +53,8 @@ public final class WordPressClientFactory: Sendable {
     }
 
     public func evictInstance(for blogID: TaggedManagedObjectID<Blog>) {
-        instances.withLock { instances in
-            instances.removeValue(forKey: blogID)
+        instances.withLock { dict in
+            dict = dict.filter { $0.key.blogId != blogID }
         }
     }
 

--- a/WordPress/Classes/Networking/WordPressClient.swift
+++ b/WordPress/Classes/Networking/WordPressClient.swift
@@ -52,6 +52,12 @@ public final class WordPressClientFactory: Sendable {
         }
     }
 
+    public func evictInstance(for blogID: TaggedManagedObjectID<Blog>) {
+        instances.withLock { instances in
+            instances.removeValue(forKey: blogID)
+        }
+    }
+
     public func reset() {
         instances.withLock { dict in
             dict.removeAll()

--- a/WordPress/Classes/Services/AccountService+Swift.swift
+++ b/WordPress/Classes/Services/AccountService+Swift.swift
@@ -18,7 +18,8 @@ extension AccountService {
             return
         }
 
-        UserPersistentStoreFactory.instance().set(account.uuid, forKey: AccountService.defaultDotcomAccountUUIDDefaultsKey)
+        UserPersistentStoreFactory.instance()
+            .set(account.uuid, forKey: AccountService.defaultDotcomAccountUUIDDefaultsKey)
 
         let objectID = TaggedManagedObjectID(account)
         let notifyAccountChange = {

--- a/WordPress/Classes/Services/AccountService+Swift.swift
+++ b/WordPress/Classes/Services/AccountService+Swift.swift
@@ -53,6 +53,11 @@ extension AccountService {
 
         WordPressApiCache.shared.removeCachedData(for: account.blogs ?? [])
 
+        account.blogs?
+            .forEach {
+                WordPressClientFactory.shared.evictInstance(for: TaggedManagedObjectID($0))
+            }
+
         let objectID = TaggedManagedObjectID(account)
         coreDataStack.performAndSave { context in
             do {

--- a/WordPress/Classes/Services/BlogService+Swift.swift
+++ b/WordPress/Classes/Services/BlogService+Swift.swift
@@ -20,11 +20,12 @@ extension BlogService {
 
     @objc public func updatePromptSettings(for blog: RemoteBlog?, context: NSManagedObjectContext) {
         guard let blog,
-              let jsonSettings = blog.options["blogging_prompts_settings"] as? [String: Any],
-              let settingsValue = jsonSettings["value"] as? [String: Any],
-              JSONSerialization.isValidJSONObject(settingsValue),
-              let data = try? JSONSerialization.data(withJSONObject: settingsValue),
-              let remoteSettings = try? JSONDecoder().decode(RemoteBloggingPromptsSettings.self, from: data) else {
+            let jsonSettings = blog.options["blogging_prompts_settings"] as? [String: Any],
+            let settingsValue = jsonSettings["value"] as? [String: Any],
+            JSONSerialization.isValidJSONObject(settingsValue),
+            let data = try? JSONSerialization.data(withJSONObject: settingsValue),
+            let remoteSettings = try? JSONDecoder().decode(RemoteBloggingPromptsSettings.self, from: data)
+        else {
             return
         }
 
@@ -190,7 +191,10 @@ extension BlogService {
         }
     }
 
-    static func blog(with site: JetpackSiteRef, context: NSManagedObjectContext = ContextManager.shared.mainContext) -> Blog? {
+    static func blog(
+        with site: JetpackSiteRef,
+        context: NSManagedObjectContext = ContextManager.shared.mainContext
+    ) -> Blog? {
         let blog: Blog?
 
         if site.isSelfHostedWithoutJetpack, let xmlRPC = site.xmlRPC {
@@ -204,7 +208,18 @@ extension BlogService {
 }
 
 private extension BlogService {
-    private func findBlogAuthor(with userId: NSNumber, and blog: Blog, in context: NSManagedObjectContext) -> BlogAuthor {
-        return context.entity(of: BlogAuthor.self, with: NSPredicate(format: "\(#keyPath(BlogAuthor.userID)) = %@ AND \(#keyPath(BlogAuthor.blog)) = %@", userId, blog))
+    private func findBlogAuthor(
+        with userId: NSNumber,
+        and blog: Blog,
+        in context: NSManagedObjectContext
+    ) -> BlogAuthor {
+        context.entity(
+            of: BlogAuthor.self,
+            with: NSPredicate(
+                format: "\(#keyPath(BlogAuthor.userID)) = %@ AND \(#keyPath(BlogAuthor.blog)) = %@",
+                userId,
+                blog
+            )
+        )
     }
 }

--- a/WordPress/Classes/Services/BlogService+Swift.swift
+++ b/WordPress/Classes/Services/BlogService+Swift.swift
@@ -6,6 +6,11 @@ import WordPressCore
 import WordPressAPI
 
 extension BlogService {
+    @objc(evictWordPressClientForBlog:)
+    public func evictWordPressClient(for blog: Blog) {
+        WordPressClientFactory.shared.evictInstance(for: TaggedManagedObjectID(blog))
+    }
+
     @objc public func unscheduleBloggingReminders(for blog: Blog) {
         do {
             let scheduler = try ReminderScheduleCoordinator()

--- a/WordPress/Classes/Services/BlogService.m
+++ b/WordPress/Classes/Services/BlogService.m
@@ -375,6 +375,7 @@ NSString *const WPBlogSettingsUpdatedNotification = @"WPBlogSettingsUpdatedNotif
         for (Blog *blog in account.blogs) {
             if ([toDelete containsObject:blog.dotComID]) {
                 [self unscheduleBloggingRemindersFor:blog];
+                [self evictWordPressClientForBlog:blog];
                 // Consider switching this to a call to removeBlog in the future
                 // to consolidate behaviour @frosty
                 [context deleteObject:blog];

--- a/WordPress/Classes/Services/BlogService.m
+++ b/WordPress/Classes/Services/BlogService.m
@@ -307,6 +307,7 @@ NSString *const WPBlogSettingsUpdatedNotification = @"WPBlogSettingsUpdatedNotif
     [blog.xmlrpcApi invalidateAndCancelTasks];
     [self unscheduleBloggingRemindersFor:blog];
     [self removeWordPressApiCachedDataForBlog:blog];
+    [self evictWordPressClientForBlog:blog];
 
     WPAccount *account = blog.account;
 


### PR DESCRIPTION
`WordPressClientFactory` caches clients by blog ID. Removing an account or site currently leaves its client cached for the rest of the app session.

This PR evicts clients when removing the default WordPress.com account, explicitly removing a site, or deleting a site that is no longer returned during account sync.