### PR TITLE
Redact GutenbergKit requests

### DIFF
--- a/Tests/KeystoneTests/Tests/Networking/PulseNetworkLoggerTests.swift
+++ b/Tests/KeystoneTests/Tests/Networking/PulseNetworkLoggerTests.swift
@@ -1,0 +1,203 @@
+import Combine
+import Foundation
+import Pulse
+import Support
+import Testing
+@testable import WordPress
+
+@Suite(.serialized)
+struct PulseNetworkLoggerTests {
+    @Test
+    func storeRequestRedactsSensitiveHeadersBeforeStoring() throws {
+        let promptKeys = [
+            "pulse-disable-settings-prompts",
+            "pulse-disable-support-prompts",
+            "pulse-disable-report-issue-prompts"
+        ]
+        let promptValues = promptKeys.map { UserDefaults.standard.object(forKey: $0) }
+        let wasExtensiveLoggingEnabled = ExtensiveLogging.enabled
+        ExtensiveLogging.enabled = true
+        defer {
+            ExtensiveLogging.enabled = wasExtensiveLoggingEnabled
+            for (key, value) in zip(promptKeys, promptValues) {
+                if let value {
+                    UserDefaults.standard.set(value, forKey: key)
+                } else {
+                    UserDefaults.standard.removeObject(forKey: key)
+                }
+            }
+        }
+
+        let storeURL = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: storeURL, withIntermediateDirectories: false)
+        defer { try? FileManager.default.removeItem(at: storeURL) }
+
+        let store = try LoggerStore(storeURL: storeURL, options: [.create, .inMemory])
+        let logger = PulseNetworkLogger.forTesting(store: store)
+        let url = URL(string: "https://example.com/wp-json/wp/v2/settings")!
+        var request = URLRequest(url: url)
+        request.allHTTPHeaderFields = [
+            "authorization": "Basic secret",
+            "COOKIE": "session=secret",
+            "Set-Cookie": "response-cookie-in-request",
+            "x-WP-nonce": "request-nonce",
+            "X-Request-ID": "request-id"
+        ]
+        let response = HTTPURLResponse(
+            url: url,
+            statusCode: 200,
+            httpVersion: nil,
+            headerFields: [
+                "AUTHORIZATION": "response-authorization",
+                "Cookie": "response-cookie",
+                "set-cookie": "session=secret",
+                "x-wp-nonce": "nonce",
+                "X-Response-ID": "response-id"
+            ]
+        )!
+
+        var receivedEvent: LoggerStore.Event.NetworkTaskCompleted?
+        let events = store.events.sink { event in
+            guard case let .networkTaskCompleted(event) = event else { return }
+            receivedEvent = event
+        }
+
+        logger.storeRequest(
+            request,
+            response: response,
+            error: nil,
+            data: nil
+        )
+
+        withExtendedLifetime(events) {}
+        let storedEvent = try #require(receivedEvent)
+
+        #expect(storedEvent.originalRequest.headers?.value(forHTTPHeaderField: "Authorization") == "<private>")
+        #expect(storedEvent.originalRequest.headers?.value(forHTTPHeaderField: "Cookie") == "<private>")
+        #expect(storedEvent.originalRequest.headers?.value(forHTTPHeaderField: "Set-Cookie") == "<private>")
+        #expect(storedEvent.originalRequest.headers?.value(forHTTPHeaderField: "X-WP-Nonce") == "<private>")
+        #expect(storedEvent.originalRequest.headers?.value(forHTTPHeaderField: "X-Request-ID") == "request-id")
+        #expect(storedEvent.response?.headers?.value(forHTTPHeaderField: "Authorization") == "<private>")
+        #expect(storedEvent.response?.headers?.value(forHTTPHeaderField: "Cookie") == "<private>")
+        #expect(storedEvent.response?.headers?.value(forHTTPHeaderField: "Set-Cookie") == "<private>")
+        #expect(storedEvent.response?.headers?.value(forHTTPHeaderField: "X-WP-Nonce") == "<private>")
+        #expect(storedEvent.response?.headers?.value(forHTTPHeaderField: "X-Response-ID") == "response-id")
+    }
+
+    @Test
+    func storeRequestIgnoresRequestsWhenExtensiveLoggingIsDisabled() throws {
+        let promptKeys = [
+            "pulse-disable-settings-prompts",
+            "pulse-disable-support-prompts",
+            "pulse-disable-report-issue-prompts"
+        ]
+        let promptValues = promptKeys.map { UserDefaults.standard.object(forKey: $0) }
+        let wasExtensiveLoggingEnabled = ExtensiveLogging.enabled
+        ExtensiveLogging.enabled = false
+        defer {
+            ExtensiveLogging.enabled = wasExtensiveLoggingEnabled
+            for (key, value) in zip(promptKeys, promptValues) {
+                if let value {
+                    UserDefaults.standard.set(value, forKey: key)
+                } else {
+                    UserDefaults.standard.removeObject(forKey: key)
+                }
+            }
+        }
+
+        let storeURL = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: storeURL, withIntermediateDirectories: false)
+        defer { try? FileManager.default.removeItem(at: storeURL) }
+
+        let store = try LoggerStore(storeURL: storeURL, options: [.create, .inMemory])
+        let logger = PulseNetworkLogger.forTesting(store: store)
+        var receivedEvent: LoggerStore.Event.NetworkTaskCompleted?
+        let events = store.events.sink { event in
+            guard case let .networkTaskCompleted(event) = event else { return }
+            receivedEvent = event
+        }
+
+        logger.storeRequest(
+            URLRequest(url: URL(string: "https://example.com")!),
+            response: nil,
+            error: nil,
+            data: nil
+        )
+
+        withExtendedLifetime(events) {}
+        #expect(receivedEvent == nil)
+    }
+
+    @Test
+    func existingInstanceChecksExtensiveLoggingForEveryNativeCallback() throws {
+        let promptKeys = [
+            "pulse-disable-settings-prompts",
+            "pulse-disable-support-prompts",
+            "pulse-disable-report-issue-prompts"
+        ]
+        let promptValues = promptKeys.map { UserDefaults.standard.object(forKey: $0) }
+        let wasExtensiveLoggingEnabled = ExtensiveLogging.enabled
+        ExtensiveLogging.enabled = false
+        defer {
+            ExtensiveLogging.enabled = wasExtensiveLoggingEnabled
+            for (key, value) in zip(promptKeys, promptValues) {
+                if let value {
+                    UserDefaults.standard.set(value, forKey: key)
+                } else {
+                    UserDefaults.standard.removeObject(forKey: key)
+                }
+            }
+        }
+
+        let storeURL = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: storeURL, withIntermediateDirectories: false)
+        defer { try? FileManager.default.removeItem(at: storeURL) }
+
+        let store = try LoggerStore(storeURL: storeURL, options: [.create, .inMemory])
+        let logger = PulseNetworkLogger.forTesting(store: store)
+        let session = URLSession(configuration: .ephemeral)
+        let url = URL(string: "https://example.com")!
+        var request = URLRequest(url: url)
+        request.setValue("Basic secret", forHTTPHeaderField: "authorization")
+        var createdRequests: [LoggerStore.Event.NetworkTaskCreated] = []
+        var completedRequestCount = 0
+        let events = store.events.sink { event in
+            switch event {
+            case let .networkTaskCreated(event):
+                createdRequests.append(event)
+            case .networkTaskCompleted:
+                completedRequestCount += 1
+            default:
+                break
+            }
+        }
+
+        let disabledTask = session.dataTask(with: request)
+        logger.urlSession(session, didCreateTask: disabledTask)
+        #expect(createdRequests.isEmpty)
+
+        ExtensiveLogging.enabled = true
+        let enabledTask = session.dataTask(with: request)
+        logger.urlSession(session, didCreateTask: enabledTask)
+        #expect(createdRequests.count == 1)
+        #expect(
+            createdRequests.first?.originalRequest.headers?.value(forHTTPHeaderField: "Authorization") == "<private>"
+        )
+
+        ExtensiveLogging.enabled = false
+        logger.urlSession(session, task: enabledTask, didCompleteWithError: nil)
+        #expect(completedRequestCount == 0)
+
+        ExtensiveLogging.enabled = true
+        logger.urlSession(session, task: disabledTask, didCompleteWithError: nil)
+        #expect(completedRequestCount == 1)
+
+        withExtendedLifetime(events) {}
+    }
+}
+
+private extension Dictionary where Key == String, Value == String {
+    func value(forHTTPHeaderField name: String) -> String? {
+        first { $0.key.caseInsensitiveCompare(name) == .orderedSame }?.value
+    }
+}

--- a/WordPress/Classes/Networking/PulseNetworkLogger.swift
+++ b/WordPress/Classes/Networking/PulseNetworkLogger.swift
@@ -4,28 +4,63 @@ import Support
 
 public final class PulseNetworkLogger: NSObject, URLSessionTaskDelegate, URLSessionDataDelegate {
 
+    static let shared = PulseNetworkLogger(store: .shared)
+
+    private static let sensitiveHeaders: Set<String> = [
+        "Authorization",
+        "Cookie",
+        "Set-Cookie",
+        "X-WP-Nonce"
+    ]
+
+    private let store: LoggerStore
     private let _logger: NetworkLogger
+    // A request can be left incomplete in Pulse if logging is disabled while it is in flight.
+    // This rare debug-only edge case does not justify tracking logging state for every task.
     private var logger: NetworkLogger? {
         ExtensiveLogging.enabled ? _logger : nil
     }
 
-    override public init() {
+    static func forTesting(store: LoggerStore) -> PulseNetworkLogger {
+        PulseNetworkLogger(store: store)
+    }
+
+    private init(store: LoggerStore) {
+        self.store = store
         var configuration = NetworkLogger.Configuration()
-        configuration.sensitiveHeaders = [
-            "Authorization",
-            "Cookie",
-            "Set-Cookie",
-            "X-WP-Nonce"
-        ]
-        _logger = NetworkLogger(configuration: configuration)
+        configuration.sensitiveHeaders = Self.sensitiveHeaders
+        _logger = NetworkLogger(store: store, configuration: configuration)
         super.init()
+    }
+
+    func storeRequest(
+        _ request: URLRequest,
+        response: HTTPURLResponse?,
+        error: (any Error)?,
+        data: Data?
+    ) {
+        guard logger != nil else { return }
+
+        var request = request
+        request.allHTTPHeaderFields = Self.redactedHeaders(request.allHTTPHeaderFields)
+
+        store.storeRequest(
+            request,
+            response: Self.redactedResponse(response),
+            error: error,
+            data: data
+        )
     }
 
     public func urlSession(_ session: URLSession, didCreateTask task: URLSessionTask) {
         logger?.logTaskCreated(task)
     }
 
-    public func urlSession(_ session: URLSession, task: URLSessionTask, didFinishCollecting metrics: URLSessionTaskMetrics) {
+    public func urlSession(
+        _ session: URLSession,
+        task: URLSessionTask,
+        didFinishCollecting metrics: URLSessionTaskMetrics
+    ) {
         logger?.logTask(task, didFinishCollecting: metrics)
     }
 
@@ -35,5 +70,31 @@ public final class PulseNetworkLogger: NSObject, URLSessionTaskDelegate, URLSess
 
     public func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive data: Data) {
         logger?.logDataTask(dataTask, didReceive: data)
+    }
+
+    private static func redactedResponse(_ response: HTTPURLResponse?) -> HTTPURLResponse? {
+        guard let response, let url = response.url else { return nil }
+
+        let headers = response.allHeaderFields.reduce(into: [String: String]()) { result, header in
+            guard let name = header.key as? String else { return }
+            result[name] = String(describing: header.value)
+        }
+
+        return HTTPURLResponse(
+            url: url,
+            statusCode: response.statusCode,
+            httpVersion: nil,
+            headerFields: redactedHeaders(headers)
+        )
+    }
+
+    private static func redactedHeaders(_ headers: [String: String]?) -> [String: String]? {
+        headers?
+            .reduce(into: [:]) { result, header in
+                let isSensitive = sensitiveHeaders.contains {
+                    $0.caseInsensitiveCompare(header.key) == .orderedSame
+                }
+                result[header.key] = isSensitive ? "<private>" : header.value
+            }
     }
 }

--- a/WordPress/Classes/Networking/WordPressClient.swift
+++ b/WordPress/Classes/Networking/WordPressClient.swift
@@ -64,7 +64,7 @@ extension WordPressClient {
         }
         let api = WordPressAPI(
             urlSession: session,
-            notifyingDelegate: PulseNetworkLogger(),
+            notifyingDelegate: PulseNetworkLogger.shared,
             siteInfo: siteInfo,
             authenticationProvider: provider,
             appNotifier: notifier,

--- a/WordPress/Classes/Services/ApplicationPasswordRepository.swift
+++ b/WordPress/Classes/Services/ApplicationPasswordRepository.swift
@@ -76,7 +76,7 @@ actor ApplicationPasswordRepository {
         // No need to propagate the API request error.
         let api = WordPressAPI(
             urlSession: URLSession(configuration: .ephemeral),
-            notifyingDelegate: PulseNetworkLogger(),
+            notifyingDelegate: PulseNetworkLogger.shared,
             siteInfo: .selfHosted(siteUrl: try .from(url: site.siteURL), apiRoot: credentials.apiRootURL),
             authentication: .init(username: credentials.username, password: credentials.token)
         )
@@ -179,7 +179,7 @@ private extension ApplicationPasswordRepository {
         for password in passwords {
             let api = WordPressAPI(
                 urlSession: session,
-                notifyingDelegate: PulseNetworkLogger(),
+                notifyingDelegate: PulseNetworkLogger.shared,
                 siteInfo: .selfHosted(siteUrl: parsedSiteURL, apiRoot: apiRootURL),
                 authentication: .init(username: siteUsername, password: password.password)
             )

--- a/WordPress/Classes/System/WordPressAppDelegate.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate.swift
@@ -105,7 +105,7 @@ public class WordPressAppDelegate: UIResponder, UIApplicationDelegate {
         UITestConfigurator.prepareApplicationForUITests()
 
         // The following extensive logging configuration detects if extensive logging is enabled internally.
-        wpkURLSessionNotifyingDelegate = PulseNetworkLogger()
+        wpkURLSessionNotifyingDelegate = PulseNetworkLogger.shared
 
         MemoryCache.shared.register()
         MediaImageService.migrateCacheIfNeeded()

--- a/WordPress/Classes/ViewRelated/NewGutenberg/GBKExtensions.swift
+++ b/WordPress/Classes/ViewRelated/NewGutenberg/GBKExtensions.swift
@@ -7,7 +7,7 @@ extension GutenbergKit.EditorViewControllerDelegate {
         _ viewController: GutenbergKit.EditorViewController,
         didLogNetworkRequest request: GutenbergKit.RecordedNetworkRequest
     ) {
-        guard let url = URL(string: request.url) else {
+        guard ExtensiveLogging.enabled, let url = URL(string: request.url) else {
             return
         }
 

--- a/WordPress/Classes/ViewRelated/NewGutenberg/GBKExtensions.swift
+++ b/WordPress/Classes/ViewRelated/NewGutenberg/GBKExtensions.swift
@@ -1,6 +1,5 @@
 import Foundation
 import GutenbergKit
-import Pulse
 import Support
 
 extension GutenbergKit.EditorViewControllerDelegate {
@@ -8,7 +7,7 @@ extension GutenbergKit.EditorViewControllerDelegate {
         _ viewController: GutenbergKit.EditorViewController,
         didLogNetworkRequest request: GutenbergKit.RecordedNetworkRequest
     ) {
-        guard ExtensiveLogging.enabled, let url = URL(string: request.url) else {
+        guard let url = URL(string: request.url) else {
             return
         }
 
@@ -24,12 +23,13 @@ extension GutenbergKit.EditorViewControllerDelegate {
             headerFields: request.responseHeaders
         )
 
-        LoggerStore.shared.storeRequest(
-            urlRequest,
-            response: httpResponse,
-            error: nil,
-            data: request.responseBody?.data(using: .utf8)
-        )
+        PulseNetworkLogger.shared
+            .storeRequest(
+                urlRequest,
+                response: httpResponse,
+                error: nil,
+                data: request.responseBody?.data(using: .utf8)
+            )
     }
 }
 


### PR DESCRIPTION
## Description

Fixes https://linear.app/a8c/issue/CMM-2191.

The GBK requests went directly to the log store, without redacting sensitive headers.