### PR TITLE
fix: build the editor assets endpoint for sites using plain permalinks

### DIFF
--- a/Modules/Package.resolved
+++ b/Modules/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "4de2f629319d11e1daef4a746ee727d287951510c0fdc4469215767e9df0361b",
+  "originHash" : "f31432f3579f8c471514d5d994fcbc2a2e5c8dc5d2ca211288c0f9c622bb1da2",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -131,7 +131,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/wordpress-mobile/GutenbergKit",
       "state" : {
-        "revision" : "b681e106123c9b11b9bdd7923ea18f227dc5a85f"
+        "revision" : "9f3a5c203d0d81b4bdfe6851cd1bf3b7454e22c9"
       }
     },
     {

--- a/Modules/Package.resolved
+++ b/Modules/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "394a1dae231289152fc0a7f94cfb495587468c99f146311d7a94ac6a25772e0b",
+  "originHash" : "e77a9128635d7de8e21c7a3d786fc26258c74c0bfbfdfb0523447e7a66bc163b",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -131,8 +131,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/wordpress-mobile/GutenbergKit",
       "state" : {
-        "revision" : "7180587f49d3c3bfdb34cc3e80b2a9d22a3cd93e",
-        "version" : "0.18.1"
+        "branch" : "pr-build/569",
+        "revision" : "b40026523e455890c070c4844e5fdc6de3e4ae8b"
       }
     },
     {

--- a/Modules/Package.resolved
+++ b/Modules/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "e2f68a933b297d036201a43c6498ec30ca554bb39673797d95def0c6fde0c7f3",
+  "originHash" : "4de2f629319d11e1daef4a746ee727d287951510c0fdc4469215767e9df0361b",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -131,7 +131,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/wordpress-mobile/GutenbergKit",
       "state" : {
-        "revision" : "40f35ecb2c8a88ba8759f911f28cf79571e969a5"
+        "revision" : "b681e106123c9b11b9bdd7923ea18f227dc5a85f"
       }
     },
     {

--- a/Modules/Package.resolved
+++ b/Modules/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "e77a9128635d7de8e21c7a3d786fc26258c74c0bfbfdfb0523447e7a66bc163b",
+  "originHash" : "e2f68a933b297d036201a43c6498ec30ca554bb39673797d95def0c6fde0c7f3",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -131,8 +131,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/wordpress-mobile/GutenbergKit",
       "state" : {
-        "branch" : "pr-build/569",
-        "revision" : "b40026523e455890c070c4844e5fdc6de3e4ae8b"
+        "revision" : "40f35ecb2c8a88ba8759f911f28cf79571e969a5"
       }
     },
     {

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -63,7 +63,8 @@ let package = Package(
         ),
         .package(url: "https://github.com/zendesk/support_sdk_ios", from: "8.0.3"),
         // TODO: Restore a version pin once GutenbergKit#569 ships a release.
-        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", branch: "pr-build/569"),
+        .package(url: "https://github.com/wordpress-mobile/GutenbergKit",
+        revision: "40f35ecb2c8a88ba8759f911f28cf79571e969a5"),
         .package(
             url: "https://github.com/automattic/wordpress-rs",
             exact: "0.6.0"

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -64,7 +64,7 @@ let package = Package(
         .package(url: "https://github.com/zendesk/support_sdk_ios", from: "8.0.3"),
         // TODO: Restore a version pin once GutenbergKit#569 ships a release.
         .package(url: "https://github.com/wordpress-mobile/GutenbergKit",
-        revision: "40f35ecb2c8a88ba8759f911f28cf79571e969a5"),
+        revision: "b681e106123c9b11b9bdd7923ea18f227dc5a85f"),
         .package(
             url: "https://github.com/automattic/wordpress-rs",
             exact: "0.6.0"

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -62,7 +62,8 @@ let package = Package(
             revision: "b34794c9a3f32312e1593d4a3d120572afa0d010"
         ),
         .package(url: "https://github.com/zendesk/support_sdk_ios", from: "8.0.3"),
-        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", from: "0.18.1"),
+        // TODO: Restore a version pin once GutenbergKit#569 ships a release.
+        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", branch: "pr-build/569"),
         .package(
             url: "https://github.com/automattic/wordpress-rs",
             exact: "0.6.0"

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -64,7 +64,7 @@ let package = Package(
         .package(url: "https://github.com/zendesk/support_sdk_ios", from: "8.0.3"),
         // TODO: Restore a version pin once GutenbergKit#569 ships a release.
         .package(url: "https://github.com/wordpress-mobile/GutenbergKit",
-        revision: "b681e106123c9b11b9bdd7923ea18f227dc5a85f"),
+        revision: "9f3a5c203d0d81b4bdfe6851cd1bf3b7454e22c9"),
         .package(
             url: "https://github.com/automattic/wordpress-rs",
             exact: "0.6.0"

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,6 @@
 27.2
 -----
+* [*] Experimental Gutenberg editor: fix block assets not loading on self-hosted sites that use plain permalinks [#25859]
 
 
 27.1

--- a/Tests/KeystoneTests/Tests/Features/Gutenberg/EditorConfigurationTests.swift
+++ b/Tests/KeystoneTests/Tests/Features/Gutenberg/EditorConfigurationTests.swift
@@ -134,4 +134,72 @@ struct EditorConfigurationTests {
         #expect(config.authHeader == "Basic \(base64Credentials)", "Should use Basic authentication")
         #expect(config.siteApiNamespace.isEmpty, "Should not have WP.com API namespace")
     }
+
+    // MARK: - Editor Assets Endpoint
+
+    @Test("Editor assets endpoint is appended to a path-based API root")
+    func editorAssetsEndpointWithPathBasedApiRoot() async throws {
+        let context = self.context
+
+        let blog = BlogBuilder(context)
+            .with(atomic: false)
+            .isNotHostedAtWPcom()
+            .with(username: "selfhosteduser")
+            .with(url: "https://self-hosted.org")
+            .withApplicationPassword("test-app-password-1234", using: keychain)
+            .with(restApiRootURL: "https://self-hosted.org/wp-json/")
+            .build()
+
+        let config = EditorConfiguration(blog: blog, postType: .post, keychain: keychain)
+
+        #expect(
+            config.editorAssetsEndpoint
+                == URL(string: "https://self-hosted.org/wp-json/wpcom/v2/editor-assets"),
+            "Should append the endpoint to the path of a path-based API root"
+        )
+    }
+
+    /// Sites using plain permalinks have no path-based REST root, so WordPress advertises the
+    /// query form and the endpoint belongs in the `rest_route` value rather than the URL path.
+    @Test("Editor assets endpoint is appended to the route of a query-based API root")
+    func editorAssetsEndpointWithQueryBasedApiRoot() async throws {
+        let context = self.context
+
+        let blog = BlogBuilder(context)
+            .with(atomic: false)
+            .isNotHostedAtWPcom()
+            .with(username: "selfhosteduser")
+            .with(url: "https://self-hosted.org")
+            .withApplicationPassword("test-app-password-1234", using: keychain)
+            .with(restApiRootURL: "https://self-hosted.org/?rest_route=/")
+            .build()
+
+        let config = EditorConfiguration(blog: blog, postType: .post, keychain: keychain)
+
+        #expect(
+            config.editorAssetsEndpoint
+                == URL(string: "https://self-hosted.org/?rest_route=/wpcom/v2/editor-assets"),
+            "Should append the endpoint to the rest_route value, not the URL path"
+        )
+    }
+
+    @Test("Editor assets endpoint includes the site namespace for WP.com sites")
+    func editorAssetsEndpointIncludesNamespace() async throws {
+        let context = self.context
+
+        let blog = BlogBuilder(context)
+            .with(atomic: false)
+            .isHostedAtWPcom()
+            .withAnAccount(username: "simpleuser", authToken: "simple-bearer-token")
+            .with(dotComID: 12345)
+            .build()
+
+        let config = EditorConfiguration(blog: blog, postType: .post, keychain: keychain)
+
+        #expect(
+            config.editorAssetsEndpoint
+                == URL(string: "https://public-api.wordpress.com/wpcom/v2/sites/12345/editor-assets"),
+            "Should insert the site namespace before the endpoint"
+        )
+    }
 }

--- a/WordPress/Classes/Utility/Editor/EditorConfiguration+Blog.swift
+++ b/WordPress/Classes/Utility/Editor/EditorConfiguration+Blog.swift
@@ -60,15 +60,41 @@ extension EditorConfiguration {
         .setNetworkFallbackMode(.automatic)
 
         // Build editor assets endpoint
-        var editorAssetsEndpoint = siteApiRoot
-        editorAssetsEndpoint.appendPathComponent("wpcom/v2/")
-        if let namespace = siteApiNamespace.first {
-            editorAssetsEndpoint.appendPathComponent(namespace)
-        }
-        editorAssetsEndpoint.appendPathComponent("editor-assets")
-        builder = builder.setEditorAssetsEndpoint(editorAssetsEndpoint)
+        let namespacePath = siteApiNamespace.first.map { $0.hasSuffix("/") ? $0 : $0 + "/" } ?? ""
+        builder = builder.setEditorAssetsEndpoint(
+            Self.appendingRESTPath("wpcom/v2/\(namespacePath)editor-assets", to: siteApiRoot)
+        )
 
         self = builder.build()
+    }
+
+    /// Appends a REST API path to a site's API root.
+    ///
+    /// Sites using plain permalinks have no path-based REST root — WordPress advertises the
+    /// query form `https://example.com/?rest_route=/` instead — so the path belongs in the
+    /// `rest_route` value rather than the URL path:
+    ///
+    /// ```
+    /// https://example.com/?rest_route=/ + wpcom/v2/editor-assets
+    ///     -> https://example.com/?rest_route=/wpcom/v2/editor-assets
+    /// ```
+    ///
+    /// Path-based roots keep the usual behavior. This mirrors `@wordpress/api-fetch`'s root URL
+    /// middleware and GutenbergKit's native URL builders, so every layer resolves the same
+    /// endpoints for a given site.
+    ///
+    /// - Parameters:
+    ///   - path: The REST path to append, without a leading slash.
+    ///   - apiRoot: The site's REST API root.
+    /// - Returns: The endpoint URL, or `apiRoot` unchanged if the result isn't a valid URL.
+    static func appendingRESTPath(_ path: String, to apiRoot: URL) -> URL {
+        // Concatenate onto the root's full string rather than appending path components, so a
+        // query-based root grows its `rest_route` value instead of stranding it behind the path.
+        // One slash is kept between the two whether the root ends in `wp-json/`, `wp-json`,
+        // `?rest_route=/`, or `?rest_route=`.
+        let root = apiRoot.absoluteString
+        let separator = root.hasSuffix("/") ? "" : "/"
+        return URL(string: root + separator + path) ?? apiRoot
     }
 
     /// Returns true if the plugins should be enabled for the given blog.

--- a/WordPress/Classes/ViewRelated/NewGutenberg/GBKExtensions.swift
+++ b/WordPress/Classes/ViewRelated/NewGutenberg/GBKExtensions.swift
@@ -152,7 +152,10 @@ private func getLocalizedString(for value: GutenbergKit.EditorLocalizableString)
             value: "Dismiss",
             comment: "Button title to dismiss the Lockdown Mode warning"
         )
-    default:
+    // Renders strings added by a newer GutenbergKit in English rather than
+    // breaking this build. `@unknown` because a plain `default` warns that it
+    // will never execute while this switch happens to cover every case.
+    @unknown default:
         EditorLocalization.defaultLocalize(value)
     }
 }

--- a/WordPress/Classes/ViewRelated/NewGutenberg/GBKExtensions.swift
+++ b/WordPress/Classes/ViewRelated/NewGutenberg/GBKExtensions.swift
@@ -33,7 +33,7 @@ extension GutenbergKit.EditorViewControllerDelegate {
     }
 }
 
-private func getLocalizedString(for value: GutenbergKit.EditorLocalizableString) -> String {
+private func getLocalizedString(for value: GutenbergKit.EditorLocalizableString) -> String? {
     switch value {
     case .showMore:
         NSLocalizedString(
@@ -152,16 +152,17 @@ private func getLocalizedString(for value: GutenbergKit.EditorLocalizableString)
             value: "Dismiss",
             comment: "Button title to dismiss the Lockdown Mode warning"
         )
-    // Renders strings added by a newer GutenbergKit in English rather than
-    // breaking this build. `@unknown` because a plain `default` warns that it
-    // will never execute while this switch happens to cover every case.
+    // Declining a key lets the editor render its own string, so strings added
+    // by a newer GutenbergKit appear in English rather than breaking this build.
+    // `@unknown` because a plain `default` warns that it will never execute
+    // while this switch happens to cover every case.
     @unknown default:
-        EditorLocalization.defaultLocalize(value)
+        nil
     }
 }
 
 extension EditorLocalizableString {
-    var localized: String {
+    var localized: String? {
         getLocalizedString(for: self)
     }
 }

--- a/WordPress/Classes/ViewRelated/NewGutenberg/GBKExtensions.swift
+++ b/WordPress/Classes/ViewRelated/NewGutenberg/GBKExtensions.swift
@@ -91,6 +91,24 @@ private func getLocalizedString(for value: GutenbergKit.EditorLocalizableString)
             value: "All",
             comment: "Category name for section showing all patterns"
         )
+    case .patternsCount(let count):
+        if count == 1 {
+            NSLocalizedString(
+                "editor.patterns.count.singular",
+                value: "1 pattern",
+                comment: "Singular label displaying the number of patterns in a category"
+            )
+        } else {
+            String(
+                format: NSLocalizedString(
+                    "editor.patterns.count.plural",
+                    value: "%1$d patterns",
+                    comment:
+                        "Plural label displaying the number of patterns in a category. %1$d is a placeholder for the number of patterns."
+                ),
+                count
+            )
+        }
     case .loadingEditor:
         NSLocalizedString(
             "editor.loading.title",
@@ -134,6 +152,8 @@ private func getLocalizedString(for value: GutenbergKit.EditorLocalizableString)
             value: "Dismiss",
             comment: "Button title to dismiss the Lockdown Mode warning"
         )
+    default:
+        EditorLocalization.defaultLocalize(value)
     }
 }
 


### PR DESCRIPTION
## Description

Ref https://github.com/wordpress-mobile/GutenbergKit/issues/563. Fixes the editor assets endpoint for self-hosted sites that use **plain permalinks**.

Such a site has no path-based REST root — `/wp-json/` depends on the rewrite rules that plain permalinks disable, so WordPress advertises the query form `https://site/?rest_route=/`. wordpress-rs discovers that value from the site's `https://api.w.org/` Link header and it's stored verbatim in `Blog.restApiRootURL`, so it reaches `EditorConfiguration` as-is.

`appendPathComponent` appended the endpoint to the URL *path*, stranding the query:

```
https://site/?rest_route=/  ->  https://site/wpcom/v2/editor-assets?rest_route=/   ✗
                            ->  https://site/?rest_route=/wpcom/v2/editor-assets   ✓
```

The malformed URL doesn't 404. A trailing `?rest_route=/` routes to the REST API root and the path is ignored, so the request returns **200** with the API index — the wrong resource. Decoding it as an asset manifest then fails, and the editor doesn't open at all:

> **Editor Error**
> The data couldn't be read because it is missing.

So the symptom is a fatal editor failure for these sites, not merely missing blocks. The endpoint is built here in the host app and passed to GutenbergKit pre-built, so GutenbergKit can't fix it — see wordpress-mobile/GutenbergKit#573, which fixes the equivalent problem in GutenbergKit's own URL builders.

The fix concatenates onto the API root rather than appending path components, so a query-based root grows its `rest_route` value. Path-based and WP.com roots are unchanged. This matches how `@wordpress/api-fetch`'s root URL middleware and GutenbergKit's native builders handle the same case, so all layers resolve identical endpoints.

## Testing instructions

Requires a self-hosted site set to **Settings ▸ Permalinks ▸ Plain**, connected to Jetpack (third-party block assets are limited to Jetpack-connected sites[^1]), and signed in with an **application password**.

[^1]: This is a legacy, overly broad limitation that no longer matches WordPress-Android. It should be updated to to match in a separate PR. 

Confirm the site advertises the query-form root first:

```
curl -sI https://your-site.com/ | grep -i '^link'
```

The `rel="https://api.w.org/"` value should contain `?rest_route=/` rather than `/wp-json/`.

1. Sign in to that site and open a post in the experimental Gutenberg editor.
2. Confirm the editor opens and the post's content renders.
3. Confirm third-party blocks (e.g. Jetpack blocks) appear in the inserter and render correctly.

Before this change the editor failed to open on step 2, showing an "Editor Error" screen reading "The data couldn't be read because it is missing." — so step 3 was unreachable.

Also confirm no regression for a self-hosted site with pretty permalinks and for a WP.com site — both build the same endpoint as before.

Unit tests cover all three root shapes in `EditorConfigurationTests`.
