### PR TITLE
Restrict WP.com media request authentication to WP.com hosts

### DIFF
--- a/Modules/Sources/WordPressShared/URL+Helpers.swift
+++ b/Modules/Sources/WordPressShared/URL+Helpers.swift
@@ -69,6 +69,31 @@ public extension URL {
         return host.hasSuffix(".wordpress.com")
     }
 
+    /// Whether the URL's host is WordPress.com infrastructure — a `wordpress.com` or
+    /// `wp.com` host, or a subdomain of either.
+    ///
+    /// This is the allowlist for sending the account-wide WordPress.com OAuth token: that
+    /// token authenticates every WP.com REST call for the account, so it must never be
+    /// attached to a host outside this set — including a private site's own mapped custom
+    /// domain, which the site owner controls.
+    ///
+    /// The host is matched exactly or as a subdomain, never as a substring, so a lookalike
+    /// such as `wordpress.com.attacker.example` or `myevilwp.com` is rejected. It is
+    /// lowercased first because DNS hostnames are case-insensitive (RFC 4343) while
+    /// `URL.host` preserves the input casing.
+    ///
+    /// - Note: This is broader than `isHostedAtWPCom`, which matches only `.wordpress.com`
+    ///   subdomains for a narrower routing decision. Prefer this property for any check that
+    ///   gates sending WordPress.com credentials.
+    var isWordPressComHost: Bool {
+        guard let host = host?.lowercased() else {
+            return false
+        }
+
+        return host == "wordpress.com" || host.hasSuffix(".wordpress.com")
+            || host == "wp.com" || host.hasSuffix(".wp.com")
+    }
+
     var isWordPressDotComPost: Bool {
         // year, month, day, slug
         let components = pathComponents.filter({ $0 != "/" })

--- a/Modules/Tests/WordPressSharedTests/URL+WordPressComHostTests.swift
+++ b/Modules/Tests/WordPressSharedTests/URL+WordPressComHostTests.swift
@@ -1,0 +1,42 @@
+import Foundation
+import Testing
+import WordPressShared
+
+struct URLWordPressComHostTests {
+
+    @Test func allowsWordPressComHosts() {
+        #expect(URL(string: "https://wordpress.com/img.png")!.isWordPressComHost)
+        #expect(URL(string: "https://example.wordpress.com/img.png")!.isWordPressComHost)
+        #expect(URL(string: "https://example.files.wordpress.com/img.png")!.isWordPressComHost)
+        #expect(URL(string: "https://public-api.wordpress.com/file")!.isWordPressComHost)
+        #expect(URL(string: "https://i0.wp.com/example.com/img.png")!.isWordPressComHost)
+        #expect(URL(string: "https://wp.com/img.png")!.isWordPressComHost)
+    }
+
+    @Test func matchesHostCaseInsensitively() {
+        #expect(URL(string: "https://example.files.WORDPRESS.COM/img.png")!.isWordPressComHost)
+        #expect(URL(string: "https://I0.WP.COM/img.png")!.isWordPressComHost)
+    }
+
+    @Test func rejectsUnrelatedHosts() {
+        #expect(!URL(string: "https://attacker.example.com/img.png")!.isWordPressComHost)
+    }
+
+    @Test func rejectsSubstringLookalikeHosts() {
+        // `contains`-style checks would wrongly accept all of these.
+        #expect(!URL(string: "https://evilwordpress.com/img.png")!.isWordPressComHost)
+        #expect(!URL(string: "https://evilwp.com/img.png")!.isWordPressComHost)
+        #expect(!URL(string: "https://myevilwp.com/img.png")!.isWordPressComHost)
+        #expect(!URL(string: "https://wordpress.com.attacker.example/img.png")!.isWordPressComHost)
+        #expect(!URL(string: "https://wp.com.attacker.example/img.png")!.isWordPressComHost)
+    }
+
+    @Test func rejectsUserinfoSpoofedHost() {
+        // The real destination host is `attacker.example`, not `wordpress.com`.
+        #expect(!URL(string: "https://wordpress.com@attacker.example/img.png")!.isWordPressComHost)
+    }
+
+    @Test func rejectsHostlessURLs() {
+        #expect(!URL(string: "file:///var/img.png")!.isWordPressComHost)
+    }
+}

--- a/Tests/KeystoneTests/Tests/Networking/MediaRequestAuthenticatorTests.swift
+++ b/Tests/KeystoneTests/Tests/Networking/MediaRequestAuthenticatorTests.swift
@@ -154,6 +154,7 @@ class MediaRequestAuthenticatorTests: CoreDataTestCase {
         XCTAssertTrue(authenticator.isTokenAllowed(for: URL(string: "https://public-api.wordpress.com/file")!))
         XCTAssertTrue(authenticator.isTokenAllowed(for: URL(string: "https://i0.wp.com/example.com/img.png")!))
         XCTAssertTrue(authenticator.isTokenAllowed(for: URL(string: "https://wp.com/img.png")!))
+        XCTAssertTrue(authenticator.isTokenAllowed(for: URL(string: "https://example.files.WORDPRESS.COM/img.png")!))
 
         XCTAssertFalse(authenticator.isTokenAllowed(for: URL(string: "https://attacker.example.com/img.png")!))
         XCTAssertFalse(authenticator.isTokenAllowed(for: URL(string: "https://evilwordpress.com/img.png")!))

--- a/Tests/KeystoneTests/Tests/Networking/MediaRequestAuthenticatorTests.swift
+++ b/Tests/KeystoneTests/Tests/Networking/MediaRequestAuthenticatorTests.swift
@@ -144,4 +144,77 @@ class MediaRequestAuthenticatorTests: CoreDataTestCase {
 
         waitForExpectations(timeout: 0.5)
     }
+
+    func testTokenAllowedHosts() {
+        let authenticator = MediaRequestAuthenticator()
+
+        XCTAssertTrue(authenticator.isTokenAllowed(for: URL(string: "https://wordpress.com/img.png")!))
+        XCTAssertTrue(authenticator.isTokenAllowed(for: URL(string: "https://example.wordpress.com/img.png")!))
+        XCTAssertTrue(authenticator.isTokenAllowed(for: URL(string: "https://example.files.wordpress.com/img.png")!))
+        XCTAssertTrue(authenticator.isTokenAllowed(for: URL(string: "https://public-api.wordpress.com/file")!))
+        XCTAssertTrue(authenticator.isTokenAllowed(for: URL(string: "https://i0.wp.com/example.com/img.png")!))
+        XCTAssertTrue(authenticator.isTokenAllowed(for: URL(string: "https://wp.com/img.png")!))
+
+        XCTAssertFalse(authenticator.isTokenAllowed(for: URL(string: "https://attacker.example.com/img.png")!))
+        XCTAssertFalse(authenticator.isTokenAllowed(for: URL(string: "https://evilwordpress.com/img.png")!))
+        XCTAssertFalse(authenticator.isTokenAllowed(for: URL(string: "https://evilwp.com/img.png")!))
+        XCTAssertFalse(authenticator.isTokenAllowed(for: URL(string: "https://wordpress.com.attacker.example/img.png")!))
+        XCTAssertFalse(authenticator.isTokenAllowed(for: URL(string: "file:///var/img.png")!))
+    }
+
+    func testPrivateWPComSiteAuthenticationDoesNotLeakTokenToExternalHost() {
+        let authToken = "letMeIn!"
+        let url = URL(string: "https://attacker.example.com/image.png")!
+        let authenticator = MediaRequestAuthenticator()
+
+        authenticator.authenticatedRequest(
+            for: url,
+            from: .privateWPComSite(authToken: authToken),
+            onComplete: { request in
+                let hasAuthorizationHeader = request.allHTTPHeaderFields?.contains(where: { $0.key == "Authorization" }) ?? false
+
+                XCTAssertFalse(hasAuthorizationHeader)
+                XCTAssertEqual(request.url, url)
+        }) { _ in
+            XCTFail("This should not be called")
+        }
+    }
+
+    func testPrivateWPComSiteAuthenticationDoesNotLeakTokenToLookalikeHost() {
+        let authToken = "letMeIn!"
+        let url = URL(string: "https://evilwordpress.com/image.png")!
+        let authenticator = MediaRequestAuthenticator()
+
+        authenticator.authenticatedRequest(
+            for: url,
+            from: .privateWPComSite(authToken: authToken),
+            onComplete: { request in
+                let hasAuthorizationHeader = request.allHTTPHeaderFields?.contains(where: { $0.key == "Authorization" }) ?? false
+
+                XCTAssertFalse(hasAuthorizationHeader)
+                XCTAssertEqual(request.url, url)
+        }) { _ in
+            XCTFail("This should not be called")
+        }
+    }
+
+    func testPrivateWPComSiteAuthenticationForPhotonURL() {
+        let authToken = "letMeIn!"
+        let url = URL(string: "https://i0.wp.com/example.files.wordpress.com/image.png")!
+        let authenticator = MediaRequestAuthenticator()
+
+        authenticator.authenticatedRequest(
+            for: url,
+            from: .privateWPComSite(authToken: authToken),
+            onComplete: { request in
+                let hasAuthorizationHeader = request.allHTTPHeaderFields?.contains(where: {
+                    $0.key == "Authorization" && $0.value == "Bearer \(authToken)"
+                }) ?? false
+
+                XCTAssertTrue(hasAuthorizationHeader)
+                XCTAssertEqual(request.url, url)
+        }) { _ in
+            XCTFail("This should not be called")
+        }
+    }
 }

--- a/Tests/KeystoneTests/Tests/Networking/MediaRequestAuthenticatorTests.swift
+++ b/Tests/KeystoneTests/Tests/Networking/MediaRequestAuthenticatorTests.swift
@@ -145,24 +145,6 @@ class MediaRequestAuthenticatorTests: CoreDataTestCase {
         waitForExpectations(timeout: 0.5)
     }
 
-    func testTokenAllowedHosts() {
-        let authenticator = MediaRequestAuthenticator()
-
-        XCTAssertTrue(authenticator.isTokenAllowed(for: URL(string: "https://wordpress.com/img.png")!))
-        XCTAssertTrue(authenticator.isTokenAllowed(for: URL(string: "https://example.wordpress.com/img.png")!))
-        XCTAssertTrue(authenticator.isTokenAllowed(for: URL(string: "https://example.files.wordpress.com/img.png")!))
-        XCTAssertTrue(authenticator.isTokenAllowed(for: URL(string: "https://public-api.wordpress.com/file")!))
-        XCTAssertTrue(authenticator.isTokenAllowed(for: URL(string: "https://i0.wp.com/example.com/img.png")!))
-        XCTAssertTrue(authenticator.isTokenAllowed(for: URL(string: "https://wp.com/img.png")!))
-        XCTAssertTrue(authenticator.isTokenAllowed(for: URL(string: "https://example.files.WORDPRESS.COM/img.png")!))
-
-        XCTAssertFalse(authenticator.isTokenAllowed(for: URL(string: "https://attacker.example.com/img.png")!))
-        XCTAssertFalse(authenticator.isTokenAllowed(for: URL(string: "https://evilwordpress.com/img.png")!))
-        XCTAssertFalse(authenticator.isTokenAllowed(for: URL(string: "https://evilwp.com/img.png")!))
-        XCTAssertFalse(authenticator.isTokenAllowed(for: URL(string: "https://wordpress.com.attacker.example/img.png")!))
-        XCTAssertFalse(authenticator.isTokenAllowed(for: URL(string: "file:///var/img.png")!))
-    }
-
     func testPrivateWPComSiteAuthenticationDoesNotLeakTokenToExternalHost() {
         let authToken = "letMeIn!"
         let url = URL(string: "https://attacker.example.com/image.png")!

--- a/Tests/KeystoneTests/Tests/Networking/MediaRequestAuthenticatorTests.swift
+++ b/Tests/KeystoneTests/Tests/Networking/MediaRequestAuthenticatorTests.swift
@@ -217,4 +217,25 @@ class MediaRequestAuthenticatorTests: CoreDataTestCase {
             XCTFail("This should not be called")
         }
     }
+
+    /// `AVURLAsset` does not expose its options dictionary, so the tests use the URL as the
+    /// observable: the authenticated branch upgrades http to https, the unauthenticated
+    /// branch leaves the URL untouched. `testTokenAllowedHosts` covers the allowlist itself.
+    func testPrivateWPComSiteAssetForExternalHostIsNotAuthenticated() async throws {
+        let authenticator = MediaRequestAuthenticator()
+        let url = URL(string: "http://attacker.example.com/video.mp4")!
+
+        let asset = try await authenticator.authenticatedAsset(for: url, host: .privateWPComSite(authToken: "letMeIn!"))
+
+        XCTAssertEqual(asset.url, url)
+    }
+
+    func testPrivateWPComSiteAssetForWPComHostIsAuthenticated() async throws {
+        let authenticator = MediaRequestAuthenticator()
+        let url = URL(string: "http://example.files.wordpress.com/video.mp4")!
+
+        let asset = try await authenticator.authenticatedAsset(for: url, host: .privateWPComSite(authToken: "letMeIn!"))
+
+        XCTAssertEqual(asset.url, URL(string: "https://example.files.wordpress.com/video.mp4")!)
+    }
 }

--- a/Tests/KeystoneTests/Tests/Utility/SiteIconViewModelTests.swift
+++ b/Tests/KeystoneTests/Tests/Utility/SiteIconViewModelTests.swift
@@ -9,42 +9,42 @@ final class SiteIconViewModelTests: XCTestCase {
     /// Tests that a dotcom image URL with default image size is valid.
     func testDotcomURLWithDefaultSize() {
         // Given
-        let path = Constants.dotcomPath
+        let url = Constants.dotcomURL
 
         // When
-        let optimizedURL = SiteIconViewModel.optimizedURL(for: path)
+        let optimizedURL = SiteIconViewModel.optimizedURL(for: url)
 
         // Then
         let size = 40 * Int(UIScreen.main.scale)
-        let expectedURL = URL(string: "\(path)?w=\(size)&h=\(size)")
+        let expectedURL = URL(string: "\(url.absoluteString)?w=\(size)&h=\(size)")
         XCTAssertEqual(optimizedURL, expectedURL)
     }
 
     /// Tests that a gravatar image URL with default image size is valid.
     func testBlavatarURLWithDefaultSize() {
         // Given
-        let path = Constants.gravatarPath
+        let url = Constants.gravatarURL
 
         // When
-        let optimizedURL = SiteIconViewModel.optimizedURL(for: path)
+        let optimizedURL = SiteIconViewModel.optimizedURL(for: url)
 
         // Then
         let size = 40 * Int(UIScreen.main.scale)
-        let expectedURL = URL(string: "\(path)?d=404&s=\(size)")
+        let expectedURL = URL(string: "\(url.absoluteString)?d=404&s=\(size)")
         XCTAssertEqual(optimizedURL, expectedURL)
     }
 
     /// Tests that a photon image URL with default image size is valid.
     func testPhotonURLWithDefaultSize() {
         // Given
-        let path = Constants.photonPath
+        let url = Constants.photonURL
 
         // When
-        let optimizedURL = SiteIconViewModel.optimizedURL(for: path)
+        let optimizedURL = SiteIconViewModel.optimizedURL(for: url)
 
         // Then
         let size = 40 * Int(UIScreen.main.scale)
-        let expectedURL = URL(string: "\(path)?w=\(size)&h=\(size)")
+        let expectedURL = URL(string: "\(url.absoluteString)?w=\(size)&h=\(size)")
         XCTAssertEqual(optimizedURL, expectedURL)
     }
 
@@ -52,14 +52,14 @@ final class SiteIconViewModelTests: XCTestCase {
     func testDotcomURLWithCustomSize() {
         // Given
         let sizeInPoints = Constants.customImageSize
-        let path = Constants.dotcomPath
+        let url = Constants.dotcomURL
 
         // When
-        let optimizedURL = SiteIconViewModel.optimizedURL(for: path, imageSize: sizeInPoints)
+        let optimizedURL = SiteIconViewModel.optimizedURL(for: url, imageSize: sizeInPoints)
 
         // Then
         let size = Int(sizeInPoints.width) * Int(UIScreen.main.scale)
-        let expectedURL = URL(string: "\(path)?w=\(size)&h=\(size)")
+        let expectedURL = URL(string: "\(url.absoluteString)?w=\(size)&h=\(size)")
         XCTAssertEqual(optimizedURL, expectedURL)
     }
 
@@ -67,14 +67,14 @@ final class SiteIconViewModelTests: XCTestCase {
     func testBlavatarURLWithCustomSize() {
         // Given
         let sizeInPoints = Constants.customImageSize
-        let path = Constants.gravatarPath
+        let url = Constants.gravatarURL
 
         // When
-        let optimizedURL = SiteIconViewModel.optimizedURL(for: path, imageSize: sizeInPoints)
+        let optimizedURL = SiteIconViewModel.optimizedURL(for: url, imageSize: sizeInPoints)
 
         // Then
         let size = Int(sizeInPoints.width) * Int(UIScreen.main.scale)
-        let expectedURL = URL(string: "\(path)?d=404&s=\(size)")
+        let expectedURL = URL(string: "\(url.absoluteString)?d=404&s=\(size)")
         XCTAssertEqual(optimizedURL, expectedURL)
     }
 
@@ -82,23 +82,78 @@ final class SiteIconViewModelTests: XCTestCase {
     func testPhotonURLWithCustomSize() {
         // Given
         let sizeInPoints = Constants.customImageSize
-        let path = Constants.photonPath
+        let url = Constants.photonURL
 
         // When
-        let optimizedURL = SiteIconViewModel.optimizedURL(for: path, imageSize: sizeInPoints)
+        let optimizedURL = SiteIconViewModel.optimizedURL(for: url, imageSize: sizeInPoints)
 
         // Then
         let size = Int(sizeInPoints.width) * Int(UIScreen.main.scale)
-        let expectedURL = URL(string: "\(path)?w=\(size)&h=\(size)")
+        let expectedURL = URL(string: "\(url.absoluteString)?w=\(size)&h=\(size)")
         XCTAssertEqual(optimizedURL, expectedURL)
+    }
+
+    // MARK: - Host matching
+
+    /// Tests that a third-party URL whose query mentions a WP.com host is still wrapped in Photon.
+    func testLookalikeQueryIsNotTreatedAsDotcom() {
+        // Given
+        let url = URL(string: "https://attacker.example.com/icon.png?u=.files.wordpress.com")!
+
+        // When
+        let optimizedURL = SiteIconViewModel.optimizedURL(for: url)
+
+        // Then
+        XCTAssertEqual(optimizedURL?.host, "i0.wp.com")
+    }
+
+    /// Tests that a Gravatar-lookalike path on a third-party host is still wrapped in Photon.
+    /// The path needs an image extension: `PhotonImageURLHelper` declines to wrap
+    /// extension-less URLs and returns them unchanged.
+    func testLookalikePathIsNotTreatedAsBlavatar() {
+        // Given
+        let url = URL(string: "https://attacker.example.com/gravatar.com/blavatar/123.png")!
+
+        // When
+        let optimizedURL = SiteIconViewModel.optimizedURL(for: url)
+
+        // Then
+        XCTAssertEqual(optimizedURL?.host, "i0.wp.com")
+    }
+
+    /// Tests that a WordPress.com subdomain is sized directly rather than wrapped in Photon.
+    func testWPComSubdomainIsTreatedAsDotcom() {
+        // Given
+        let url = URL(string: "https://example.wordpress.com/icon.png")!
+
+        // When
+        let optimizedURL = SiteIconViewModel.optimizedURL(for: url)
+
+        // Then
+        let size = 40 * Int(UIScreen.main.scale)
+        XCTAssertEqual(optimizedURL, URL(string: "\(url.absoluteString)?w=\(size)&h=\(size)"))
+    }
+
+    /// Tests that a URL relative to a base URL is resolved before its query is replaced.
+    func testURLRelativeToBaseURLIsResolvedBeforeOptimization() {
+        // Given
+        let baseURL = URL(string: "https://example.wordpress.com")!
+        let url = URL(string: "icon.png?existing=value", relativeTo: baseURL)!
+
+        // When
+        let optimizedURL = SiteIconViewModel.optimizedURL(for: url)
+
+        // Then
+        let size = 40 * Int(UIScreen.main.scale)
+        XCTAssertEqual(optimizedURL, URL(string: "https://example.wordpress.com/icon.png?w=\(size)&h=\(size)"))
     }
 
     // MARK: - Constants
 
     private struct Constants {
         static let customImageSize = CGSize(width: 60, height: 60)
-        static let dotcomPath = "https://fake.files.wordpress.com/fake.png"
-        static let gravatarPath = "https://secure.gravatar.com/blavatar/123"
-        static let photonPath = "https://fake.wp.com/fake.png"
+        static let dotcomURL = URL(string: "https://fake.files.wordpress.com/fake.png")!
+        static let gravatarURL = URL(string: "https://secure.gravatar.com/blavatar/123")!
+        static let photonURL = URL(string: "https://fake.wp.com/fake.png")!
     }
 }

--- a/WordPress/Classes/Networking/MediaRequestAuthenticator.swift
+++ b/WordPress/Classes/Networking/MediaRequestAuthenticator.swift
@@ -65,7 +65,7 @@ struct MediaRequestAuthenticator {
 
         // We want to make sure we're never sending credentials
         // to a URL that's not safe.
-        guard isTokenAllowed(for: url) else {
+        guard url.isWordPressComHost else {
             let request = URLRequest(url: url)
             provide(request)
             return
@@ -117,7 +117,7 @@ struct MediaRequestAuthenticator {
     }
 
     private func authenticatedAsset(for url: URL, authToken: String) -> AVURLAsset {
-        guard isTokenAllowed(for: url) else {
+        guard url.isWordPressComHost else {
             Loggers.networking.warning("Refusing to attach the WP.com token to a non-WP.com host: \(url.host ?? "no host")")
             return AVURLAsset(url: url)
         }
@@ -282,7 +282,7 @@ struct MediaRequestAuthenticator {
     ///     - authToken: the Bearer token to add to the resulting request.
     ///
     private func tokenAuthenticatedWPComRequest(for url: URL, authToken: String) -> URLRequest {
-        guard isTokenAllowed(for: url) else {
+        guard url.isWordPressComHost else {
             Loggers.networking.warning("Refusing to attach the WP.com token to a non-WP.com host: \(url.host ?? "no host")")
             return URLRequest(url: url)
         }
@@ -290,21 +290,5 @@ struct MediaRequestAuthenticator {
         var request = URLRequest(url: url)
         request.addValue("Bearer \(authToken)", forHTTPHeaderField: "Authorization")
         return request
-    }
-
-    /// Whether the URL's host is WordPress.com infrastructure that may receive the WP.com
-    /// Bearer token. The token is account-wide, so sending it to any host outside this
-    /// allowlist (including a private site's own mapped custom domain, which the site owner
-    /// controls) would let a malicious site owner capture it.
-    ///
-    /// Internal rather than private so unit tests can exercise the allowlist directly.
-    func isTokenAllowed(for url: URL) -> Bool {
-        // DNS hostnames are case-insensitive (RFC 4343), but URL.host preserves the
-        // input casing, so lowercase before matching the allowlist.
-        guard let host = url.host?.lowercased() else {
-            return false
-        }
-        return host == "wordpress.com" || host.hasSuffix(".wordpress.com")
-            || host == "wp.com" || host.hasSuffix(".wp.com")
     }
 }

--- a/WordPress/Classes/Networking/MediaRequestAuthenticator.swift
+++ b/WordPress/Classes/Networking/MediaRequestAuthenticator.swift
@@ -299,7 +299,9 @@ struct MediaRequestAuthenticator {
     ///
     /// Internal rather than private so unit tests can exercise the allowlist directly.
     func isTokenAllowed(for url: URL) -> Bool {
-        guard let host = url.host else {
+        // DNS hostnames are case-insensitive (RFC 4343), but URL.host preserves the
+        // input casing, so lowercase before matching the allowlist.
+        guard let host = url.host?.lowercased() else {
             return false
         }
         return host == "wordpress.com" || host.hasSuffix(".wordpress.com")

--- a/WordPress/Classes/Networking/MediaRequestAuthenticator.swift
+++ b/WordPress/Classes/Networking/MediaRequestAuthenticator.swift
@@ -65,7 +65,7 @@ struct MediaRequestAuthenticator {
 
         // We want to make sure we're never sending credentials
         // to a URL that's not safe.
-        guard !url.isFileURL || url.isHostedAtWPCom || url.isPhoton() else {
+        guard isTokenAllowed(for: url) else {
             let request = URLRequest(url: url)
             provide(request)
             return
@@ -270,8 +270,27 @@ struct MediaRequestAuthenticator {
     ///     - authToken: the Bearer token to add to the resulting request.
     ///
     private func tokenAuthenticatedWPComRequest(for url: URL, authToken: String) -> URLRequest {
+        guard isTokenAllowed(for: url) else {
+            Loggers.networking.warning("Refusing to attach the WP.com token to a non-WP.com host: \(url.host ?? "no host")")
+            return URLRequest(url: url)
+        }
+
         var request = URLRequest(url: url)
         request.addValue("Bearer \(authToken)", forHTTPHeaderField: "Authorization")
         return request
+    }
+
+    /// Whether the URL's host is WordPress.com infrastructure that may receive the WP.com
+    /// Bearer token. The token is account-wide, so sending it to any host outside this
+    /// allowlist (including a private site's own mapped custom domain, which the site owner
+    /// controls) would let a malicious site owner capture it.
+    ///
+    /// Internal rather than private so unit tests can exercise the allowlist directly.
+    func isTokenAllowed(for url: URL) -> Bool {
+        guard let host = url.host else {
+            return false
+        }
+        return host == "wordpress.com" || host.hasSuffix(".wordpress.com")
+            || host == "wp.com" || host.hasSuffix(".wp.com")
     }
 }

--- a/WordPress/Classes/Networking/MediaRequestAuthenticator.swift
+++ b/WordPress/Classes/Networking/MediaRequestAuthenticator.swift
@@ -117,9 +117,21 @@ struct MediaRequestAuthenticator {
     }
 
     private func authenticatedAsset(for url: URL, authToken: String) -> AVURLAsset {
+        guard isTokenAllowed(for: url) else {
+            Loggers.networking.warning("Refusing to attach the WP.com token to a non-WP.com host: \(url.host ?? "no host")")
+            return AVURLAsset(url: url)
+        }
+
+        // Just in case, enforce HTTPs
+        var finalURL = url
+        if var components = URLComponents(url: url, resolvingAgainstBaseURL: true) {
+            components.scheme = secureHttpScheme
+            finalURL = components.url ?? url
+        }
+
         let headers: [String: String] = ["Authorization": "Bearer \(authToken)"]
 
-        return AVURLAsset(url: url, options: [
+        return AVURLAsset(url: finalURL, options: [
             "AVURLAssetHTTPHeaderFieldsKey": headers
         ])
     }

--- a/WordPress/Classes/ViewRelated/Blog/Site Picker/BlogList/SiteIconViewModel+Extensions.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Picker/BlogList/SiteIconViewModel+Extensions.swift
@@ -13,7 +13,7 @@ extension SiteIconViewModel {
         self.firstLetter = blog.title?.first
 
         if let icon = blog.iconURL {
-            self.imageURL = SiteIconViewModel.optimizedURL(for: icon.absoluteString, imageSize: size.size, isP2: blog.isAutomatticP2)
+            self.imageURL = SiteIconViewModel.optimizedURL(for: icon, imageSize: size.size, isP2: blog.isAutomatticP2)
             self.host = MediaHost(blog)
         }
     }
@@ -33,56 +33,50 @@ extension SiteIconViewModel {
 // MARK: - SiteIconViewModel (Optimized URL)
 
 extension SiteIconViewModel {
-    /// Returns the Size Optimized URL for a given Path.
-    static func optimizedURL(for path: String, imageSize: CGSize = SiteIconViewModel.Size.regular.size, isP2: Bool = false) -> URL? {
-        if isPhotonURL(path) || isDotcomURL(path) || isP2 {
-            return optimizedDotcomURL(from: path, imageSize: imageSize)
+    /// Returns the size-optimized URL for a given URL.
+    static func optimizedURL(
+        for url: URL,
+        imageSize: CGSize = SiteIconViewModel.Size.regular.size,
+        isP2: Bool = false
+    ) -> URL? {
+        if url.isWordPressComHost || isP2 {
+            return optimizedDotcomURL(from: url, imageSize: imageSize)
         }
-        if isBlavatarURL(path) {
-            return optimizedBlavatarURL(from: path, imageSize: imageSize)
+        if isBlavatarURL(url) {
+            return optimizedBlavatarURL(from: url, imageSize: imageSize)
         }
-        return optimizedPhotonURL(from: path, imageSize: imageSize)
+        return optimizedPhotonURL(from: url, imageSize: imageSize)
     }
 
-    private static func optimizedDotcomURL(from path: String, imageSize: CGSize) -> URL? {
+    private static func optimizedDotcomURL(from url: URL, imageSize: CGSize) -> URL? {
         let size = imageSize.scaled(by: UITraitCollection.current.displayScale)
         let query = String(format: "w=%d&h=%d", Int(size.width), Int(size.height))
-        return parseURL(path: path, query: query)
+        return parseURL(url: url, query: query)
     }
 
-    static func optimizedBlavatarURL(from path: String, imageSize: CGSize) -> URL? {
+    static func optimizedBlavatarURL(from url: URL, imageSize: CGSize) -> URL? {
         let size = imageSize.scaled(by: UITraitCollection.current.displayScale)
         let query = String(format: "d=404&s=%d", Int(max(size.width, size.height)))
-        return parseURL(path: path, query: query)
+        return parseURL(url: url, query: query)
     }
 
-    private static func optimizedPhotonURL(from path: String, imageSize: CGSize) -> URL? {
-        guard let url = URL(string: path) else { return nil }
-        return PhotonImageURLHelper.photonURL(with: imageSize, forImageURL: url)
+    private static func optimizedPhotonURL(from url: URL, imageSize: CGSize) -> URL? {
+        PhotonImageURLHelper.photonURL(with: imageSize, forImageURL: url)
     }
 
-    /// Indicates if the received URL is hosted at WordPress.com
+    /// Indicates if the received URL is a Gravatar blavatar. Matches the host exactly or as
+    /// a subdomain, never as a substring, so a lookalike URL can't skip the Photon proxy.
     ///
-    private static func isDotcomURL(_ path: String) -> Bool {
-        path.contains(".files.wordpress.com")
+    private static func isBlavatarURL(_ url: URL) -> Bool {
+        guard let host = url.host?.lowercased() else {
+            return false
+        }
+        return (host == "gravatar.com" || host.hasSuffix(".gravatar.com")) && url.path.hasPrefix("/blavatar")
     }
 
-    /// Indicates if the received URL is hosted at Gravatar.com
-    ///
-    private static func isBlavatarURL(_ path: String) -> Bool {
-        path.contains("gravatar.com/blavatar")
-    }
-
-    /// Indicates if the received URL is a Photon Endpoint
-    /// Possible matches are "i0.wp.com", "i1.wp.com" & "i2.wp.com" -> https://developer.wordpress.com/docs/photon/
-    ///
-    private static func isPhotonURL(_ path: String) -> Bool {
-        path.contains(".wp.com")
-    }
-
-    /// Attempts to parse the URL contained within a Path, with a given query. Returns nil on failure.
-    private static func parseURL(path: String, query: String) -> URL? {
-        guard var components = URLComponents(string: path) else {
+    /// Attempts to update a URL with a given query. Returns nil on failure.
+    private static func parseURL(url: URL, query: String) -> URL? {
+        guard var components = URLComponents(url: url, resolvingAgainstBaseURL: true) else {
             return nil
         }
         components.query = query
@@ -107,10 +101,13 @@ extension SiteIconViewModel {
             }
             return nil
         }
-        if isBlavatarURL(iconURL) {
-            return optimizedBlavatarURL(from: iconURL, imageSize: size)
+        guard let url = URL(string: iconURL) else {
+            return nil
         }
-        return URL(string: iconURL)
+        if isBlavatarURL(url) {
+            return optimizedBlavatarURL(from: url, imageSize: size)
+        }
+        return url
     }
 
     private static func getHardcodedSiteIconURL(siteID: Int) -> URL? {

--- a/WordPress/Classes/ViewRelated/Reader/Controllers/ReaderFeedCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Controllers/ReaderFeedCell.swift
@@ -60,7 +60,7 @@ extension SiteIconViewModel {
     init(feed: ReaderFeed, faviconURL: URL? = nil, size: Size = .regular) {
         self.init(size: size)
         if let iconURL = feed.iconURL {
-            self.imageURL = SiteIconViewModel.optimizedURL(for: iconURL.absoluteString, imageSize: size.size)
+            self.imageURL = SiteIconViewModel.optimizedURL(for: iconURL, imageSize: size.size)
         } else if let faviconURL {
             self.imageURL = faviconURL
         }
@@ -75,7 +75,8 @@ private extension ReaderFeed {
             return nil
         }
         guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
-            let host = components.host else {
+            let host = components.host
+        else {
             return url.absoluteString
         }
 

--- a/WordPress/WordPressNotificationServiceExtension/Sources/NotificationService.swift
+++ b/WordPress/WordPressNotificationServiceExtension/Sources/NotificationService.swift
@@ -245,10 +245,10 @@ private extension NotificationService {
         var request = URLRequest(url: url)
         request.addValue("image/*", forHTTPHeaderField: "Accept")
 
-        // Allow private images to pulled from WordPress sites.
-        if isWPComSite(url: url), let token = self.readExtensionToken() {
+        // Allow private images to be pulled from WordPress.com sites. The token is
+        // account-wide, so only attach it to WordPress.com hosts.
+        if url.isWordPressComHost, let token = self.readExtensionToken() {
             request.addValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
-            print("AuthorizationAuthorizationAuthorizationAuthorizationAuthorizationAuthorization")
         }
 
         let session = URLSession(configuration: .default)
@@ -296,21 +296,6 @@ private extension NotificationService {
         } catch {
             return nil
         }
-    }
-
-    /// Perform a simple check to see if the URL is a WP.com site
-    /// This isn't meant to be extensive and has a few flaws, but since we don't know
-    /// much information about the URL and if it's a blog without having to do another request
-    /// this works for the current usecases.
-    ///
-    /// - Parameter url: The URL to check
-    /// - Returns: True if it's a WP.com site, False if not.
-    private func isWPComSite(url: URL) -> Bool {
-        guard let host = url.host else {
-            return false
-        }
-
-        return host.contains("wordpress.com") || host.contains("wp.com")
     }
 }
 // MARK: - Keychain support


### PR DESCRIPTION
## Description

Fixes https://linear.app/a8c/issue/CMM-2195.

See the Linear issue for details.