### PR TITLE
fix: prevent the site media picker from dropping gallery media on cancel

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,6 @@
 27.2
 -----
+* [*] Stop the media picker from removing gallery images when you cancel it in the experimental editor [#25866]
 
 
 27.1

--- a/Tests/KeystoneTests/Tests/Features/Gutenberg/PostGBKEditorViewControllerTests.swift
+++ b/Tests/KeystoneTests/Tests/Features/Gutenberg/PostGBKEditorViewControllerTests.swift
@@ -7,6 +7,7 @@ import UIKit
 @testable import WordPressData
 
 @MainActor
+@Suite(.serialized)
 struct PostGBKEditorViewControllerTests {
 
     @Test("presents the site media library for GutenbergKit requests")
@@ -38,5 +39,100 @@ struct PostGBKEditorViewControllerTests {
 
         let navigation = try #require(viewController.presentedViewController as? UINavigationController)
         #expect(navigation.viewControllers.first is SiteMediaPickerViewController)
+    }
+
+    @Test("does not report a selection when the media picker is cancelled")
+    func cancellingReportsEmptySelection() throws {
+        // `mapMediaIdsToMedia` fetches from `ContextManager.shared.mainContext`, so
+        // the blog has to live there for the picker to preselect anything. Without
+        // the override the lookup would return nothing and this would assert that an
+        // empty selection stays empty, which passes even against the pre-fix code.
+        let contextManager = ContextManager.forTesting()
+        let original = ContextManager.overrideInstance
+        ContextManager.overrideInstance = contextManager
+        defer {
+            contextManager.mainContext.reset()
+            if ContextManager.overrideInstance === contextManager {
+                ContextManager.overrideInstance = original
+            }
+        }
+
+        let context = contextManager.mainContext
+        let blog = BlogBuilder(context).build()
+        let media = MediaBuilder(context).build()
+        media.mediaID = 321
+        media.blog = blog
+
+        let picker = try presentSiteMediaPicker(for: blog, requesting: [321])
+        picker.loadViewIfNeeded()
+
+        // The picker preselects the gallery's existing media, so this is the
+        // state a cancel has to leave alone.
+        #expect(try selectedMedia(in: picker).map(\.mediaID) == [321])
+
+        var reported: [Media]?
+        let helper = try #require(picker.delegate as? GutenbergMediaPickerHelper)
+        helper.didPickMediaCallback = { assets in
+            reported = assets as? [Media]
+        }
+
+        // Tap the real Cancel button rather than calling the delegate directly,
+        // so the assertion covers what `buttonCancelTapped` actually reports.
+        let buttonCancel = try #require(picker.navigationItem.leftBarButtonItem)
+        let action = try #require(buttonCancel.primaryAction)
+        action.performWithSender(nil, target: nil)
+
+        // Cancelling must report an empty selection. Reporting `initialSelection`
+        // is indistinguishable from a confirmed selection, and the editor writes
+        // whatever it receives back to the block, so any gallery media missing
+        // from the local cache would be dropped.
+        #expect(reported?.isEmpty == true)
+    }
+
+    /// Returns the media the picker has actually preselected.
+    ///
+    /// Read from the embedded collection view controller, which the picker adds as
+    /// a child, so the assertion sees the selection the user would see.
+    private func selectedMedia(
+        in picker: SiteMediaPickerViewController
+    ) throws -> [Media] {
+        picker.loadViewIfNeeded()
+        let collectionViewController = try #require(
+            picker.children.compactMap { $0 as? SiteMediaCollectionViewController }.first
+        )
+        return collectionViewController.selectedMedia
+    }
+
+    /// Drives the GutenbergKit media-library request and returns the picker it presents.
+    private func presentSiteMediaPicker(
+        for blog: Blog,
+        requesting mediaIds: [Int]
+    ) throws -> SiteMediaPickerViewController {
+        let viewController = PostGBKEditorViewController(
+            postId: nil,
+            postType: .post,
+            title: "",
+            content: "",
+            status: "draft",
+            blog: blog
+        )
+        let window = UIWindow()
+        window.rootViewController = viewController
+        window.makeKeyAndVisible()
+        viewController.loadViewIfNeeded()
+
+        let value = mediaIds.map(String.init).joined(separator: ",")
+        let data = Data(
+            #"{"allowedTypes":["image"],"multiple":true,"value":[\#(value)],"contextId":"test"}"#.utf8
+        )
+        let action = try JSONDecoder().decode(OpenMediaLibraryAction.self, from: data)
+
+        viewController.editor(
+            viewController.editorViewController,
+            didRequestMediaFromSiteMediaLibrary: action
+        )
+
+        let navigation = try #require(viewController.presentedViewController as? UINavigationController)
+        return try #require(navigation.viewControllers.first as? SiteMediaPickerViewController)
     }
 }

--- a/WordPress/Classes/ViewRelated/Media/SiteMedia/SiteMediaPickerViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/SiteMedia/SiteMediaPickerViewController.swift
@@ -70,7 +70,7 @@ final class SiteMediaPickerViewController: UIViewController, SiteMediaCollection
     // MARK: - Actions
 
     private func buttonCancelTapped() {
-        delegate?.siteMediaPickerViewController(self, didFinishWithSelection: initialSelection)
+        delegate?.siteMediaPickerViewController(self, didFinishWithSelection: [])
     }
 
     @objc private func buttonDoneTapped() {


### PR DESCRIPTION
## Description

Follow-up to #25857, which fixed GutenbergKit site media selection.

**Cancelling the media picker dropped media from a gallery** (experimental block editor only). `buttonCancelTapped` reported `initialSelection` back through the same delegate method as `buttonDoneTapped`, so a cancel was indistinguishable from a confirmed selection. `initialSelection` can be a subset of the media a gallery actually references — the picker resolves it up front from the local Core Data store, and the media library syncs asynchronously after presentation, so anything not yet cached resolves to nothing. Cancelling wrote that subset back to the block, silently deleting the rest.

Cancel now reports an empty selection, restoring the behaviour already documented on `SiteMediaPickerViewControllerDelegate` ("If the user cancels the flow, the selection is empty") and matching `ExternalMediaPickerViewController`. All four conformers already treat an empty selection as a cancel.

### Known follow-up

**Confirming with Add has the same root cause** and still drops unsynced media: late-arriving cells are inserted unchecked because the selection is seeded once and never reconciled, so `buttonDoneTapped` reports a set that omits them. Fixing it means having the picker reconcile pending selections as media arrives, which touches `SiteMediaCollectionViewController` (shared with the Media tab) and `MediaPickerMenu` (shared with Aztec, site icon, avatar, and stock photos), and needs a decision on preserving gallery ordering for late arrivals. Left out to keep this PR scoped.

## Testing instructions

**This bug only affects the experimental block editor (GutenbergKit).** The gallery media path runs through `PostGBKEditorViewController`, which is only instantiated when the `newGutenberg` remote feature flag is on. The shipping block editor (Gutenberg Mobile) and Aztec are not affected.

Enable it first: **Me → App Settings → Experimental Features → Experimental Block Editor**.

A regression test is included, verified to fail against the pre-fix code.

To reproduce the bug manually, the gallery needs media that is not yet cached locally:

1. On a test site, upload 4+ images via wp-admin and publish a post with a Gallery block containing all of them.
2. In the app, sign in to that site and **do not** open the Media tab — that syncs the library and caches every row, which defeats the repro.
3. Open the post in the **experimental** editor and tap the Gallery block → **Edit / Add media**. The picker opens with fewer images checked than the gallery contains.
4. Tap **Cancel**.
5. **Before:** the gallery is rewritten to only the images that were checked. **After:** the gallery is unchanged.

Check the block's `ids` attribute before and after via **Switch to code editor**.

Note the picker must be multi-select (a Gallery block, not a single Image block) — `initialSelection` is only applied when `allowsMultipleSelection` is true.

### Regression areas

`GutenbergMediaPickerHelper` is shared with the legacy Gutenberg Mobile editor (`GutenbergViewController`), so that path is worth a smoke test. It calls `presentSiteMediaPicker` without `initialSelection`, so this change is a no-op there — cancel already reported an empty selection — but this was verified by code tracing rather than by running the legacy editor.

Other `SiteMediaPickerViewController` consumers (site icon, Aztec) also pass an empty `initialSelection` and are unaffected.
