### PR TITLE
Share the WP.com host check and apply it to notification media

### DIFF
--- a/Modules/Sources/WordPressShared/URL+Helpers.swift
+++ b/Modules/Sources/WordPressShared/URL+Helpers.swift
@@ -69,6 +69,31 @@ public extension URL {
         return host.hasSuffix(".wordpress.com")
     }
 
+    /// Whether the URL's host is WordPress.com infrastructure — a `wordpress.com` or
+    /// `wp.com` host, or a subdomain of either.
+    ///
+    /// This is the allowlist for sending the account-wide WordPress.com OAuth token: that
+    /// token authenticates every WP.com REST call for the account, so it must never be
+    /// attached to a host outside this set — including a private site's own mapped custom
+    /// domain, which the site owner controls.
+    ///
+    /// The host is matched exactly or as a subdomain, never as a substring, so a lookalike
+    /// such as `wordpress.com.attacker.example` or `myevilwp.com` is rejected. It is
+    /// lowercased first because DNS hostnames are case-insensitive (RFC 4343) while
+    /// `URL.host` preserves the input casing.
+    ///
+    /// - Note: This is broader than `isHostedAtWPCom`, which matches only `.wordpress.com`
+    ///   subdomains for a narrower routing decision. Prefer this property for any check that
+    ///   gates sending WordPress.com credentials.
+    var isWordPressComHost: Bool {
+        guard let host = host?.lowercased() else {
+            return false
+        }
+
+        return host == "wordpress.com" || host.hasSuffix(".wordpress.com")
+            || host == "wp.com" || host.hasSuffix(".wp.com")
+    }
+
     var isWordPressDotComPost: Bool {
         // year, month, day, slug
         let components = pathComponents.filter({ $0 != "/" })

--- a/Modules/Tests/WordPressSharedTests/URL+WordPressComHostTests.swift
+++ b/Modules/Tests/WordPressSharedTests/URL+WordPressComHostTests.swift
@@ -1,0 +1,42 @@
+import Foundation
+import Testing
+import WordPressShared
+
+struct URLWordPressComHostTests {
+
+    @Test func allowsWordPressComHosts() {
+        #expect(URL(string: "https://wordpress.com/img.png")!.isWordPressComHost)
+        #expect(URL(string: "https://example.wordpress.com/img.png")!.isWordPressComHost)
+        #expect(URL(string: "https://example.files.wordpress.com/img.png")!.isWordPressComHost)
+        #expect(URL(string: "https://public-api.wordpress.com/file")!.isWordPressComHost)
+        #expect(URL(string: "https://i0.wp.com/example.com/img.png")!.isWordPressComHost)
+        #expect(URL(string: "https://wp.com/img.png")!.isWordPressComHost)
+    }
+
+    @Test func matchesHostCaseInsensitively() {
+        #expect(URL(string: "https://example.files.WORDPRESS.COM/img.png")!.isWordPressComHost)
+        #expect(URL(string: "https://I0.WP.COM/img.png")!.isWordPressComHost)
+    }
+
+    @Test func rejectsUnrelatedHosts() {
+        #expect(!URL(string: "https://attacker.example.com/img.png")!.isWordPressComHost)
+    }
+
+    @Test func rejectsSubstringLookalikeHosts() {
+        // `contains`-style checks would wrongly accept all of these.
+        #expect(!URL(string: "https://evilwordpress.com/img.png")!.isWordPressComHost)
+        #expect(!URL(string: "https://evilwp.com/img.png")!.isWordPressComHost)
+        #expect(!URL(string: "https://myevilwp.com/img.png")!.isWordPressComHost)
+        #expect(!URL(string: "https://wordpress.com.attacker.example/img.png")!.isWordPressComHost)
+        #expect(!URL(string: "https://wp.com.attacker.example/img.png")!.isWordPressComHost)
+    }
+
+    @Test func rejectsUserinfoSpoofedHost() {
+        // The real destination host is `attacker.example`, not `wordpress.com`.
+        #expect(!URL(string: "https://wordpress.com@attacker.example/img.png")!.isWordPressComHost)
+    }
+
+    @Test func rejectsHostlessURLs() {
+        #expect(!URL(string: "file:///var/img.png")!.isWordPressComHost)
+    }
+}

--- a/Tests/KeystoneTests/Tests/Networking/MediaRequestAuthenticatorTests.swift
+++ b/Tests/KeystoneTests/Tests/Networking/MediaRequestAuthenticatorTests.swift
@@ -145,24 +145,6 @@ class MediaRequestAuthenticatorTests: CoreDataTestCase {
         waitForExpectations(timeout: 0.5)
     }
 
-    func testTokenAllowedHosts() {
-        let authenticator = MediaRequestAuthenticator()
-
-        XCTAssertTrue(authenticator.isTokenAllowed(for: URL(string: "https://wordpress.com/img.png")!))
-        XCTAssertTrue(authenticator.isTokenAllowed(for: URL(string: "https://example.wordpress.com/img.png")!))
-        XCTAssertTrue(authenticator.isTokenAllowed(for: URL(string: "https://example.files.wordpress.com/img.png")!))
-        XCTAssertTrue(authenticator.isTokenAllowed(for: URL(string: "https://public-api.wordpress.com/file")!))
-        XCTAssertTrue(authenticator.isTokenAllowed(for: URL(string: "https://i0.wp.com/example.com/img.png")!))
-        XCTAssertTrue(authenticator.isTokenAllowed(for: URL(string: "https://wp.com/img.png")!))
-        XCTAssertTrue(authenticator.isTokenAllowed(for: URL(string: "https://example.files.WORDPRESS.COM/img.png")!))
-
-        XCTAssertFalse(authenticator.isTokenAllowed(for: URL(string: "https://attacker.example.com/img.png")!))
-        XCTAssertFalse(authenticator.isTokenAllowed(for: URL(string: "https://evilwordpress.com/img.png")!))
-        XCTAssertFalse(authenticator.isTokenAllowed(for: URL(string: "https://evilwp.com/img.png")!))
-        XCTAssertFalse(authenticator.isTokenAllowed(for: URL(string: "https://wordpress.com.attacker.example/img.png")!))
-        XCTAssertFalse(authenticator.isTokenAllowed(for: URL(string: "file:///var/img.png")!))
-    }
-
     func testPrivateWPComSiteAuthenticationDoesNotLeakTokenToExternalHost() {
         let authToken = "letMeIn!"
         let url = URL(string: "https://attacker.example.com/image.png")!

--- a/Tests/KeystoneTests/Tests/Utility/SiteIconViewModelTests.swift
+++ b/Tests/KeystoneTests/Tests/Utility/SiteIconViewModelTests.swift
@@ -93,6 +93,45 @@ final class SiteIconViewModelTests: XCTestCase {
         XCTAssertEqual(optimizedURL, expectedURL)
     }
 
+    // MARK: - Host matching
+
+    /// Tests that a third-party URL whose query mentions a WP.com host is still wrapped in Photon.
+    func testLookalikeQueryIsNotTreatedAsDotcom() {
+        // Given
+        let path = "https://attacker.example.com/icon.png?u=.files.wordpress.com"
+
+        // When
+        let optimizedURL = SiteIconViewModel.optimizedURL(for: path)
+
+        // Then
+        XCTAssertEqual(optimizedURL?.host, "i0.wp.com")
+    }
+
+    /// Tests that a Gravatar-lookalike path on a third-party host is still wrapped in Photon.
+    func testLookalikePathIsNotTreatedAsBlavatar() {
+        // Given
+        let path = "https://attacker.example.com/gravatar.com/blavatar/123"
+
+        // When
+        let optimizedURL = SiteIconViewModel.optimizedURL(for: path)
+
+        // Then
+        XCTAssertEqual(optimizedURL?.host, "i0.wp.com")
+    }
+
+    /// Tests that a WordPress.com subdomain is sized directly rather than wrapped in Photon.
+    func testWPComSubdomainIsTreatedAsDotcom() {
+        // Given
+        let path = "https://example.wordpress.com/icon.png"
+
+        // When
+        let optimizedURL = SiteIconViewModel.optimizedURL(for: path)
+
+        // Then
+        let size = 40 * Int(UIScreen.main.scale)
+        XCTAssertEqual(optimizedURL, URL(string: "\(path)?w=\(size)&h=\(size)"))
+    }
+
     // MARK: - Constants
 
     private struct Constants {

--- a/Tests/KeystoneTests/Tests/Utility/SiteIconViewModelTests.swift
+++ b/Tests/KeystoneTests/Tests/Utility/SiteIconViewModelTests.swift
@@ -108,9 +108,11 @@ final class SiteIconViewModelTests: XCTestCase {
     }
 
     /// Tests that a Gravatar-lookalike path on a third-party host is still wrapped in Photon.
+    /// The path needs an image extension: `PhotonImageURLHelper` declines to wrap
+    /// extension-less URLs and returns them unchanged.
     func testLookalikePathIsNotTreatedAsBlavatar() {
         // Given
-        let path = "https://attacker.example.com/gravatar.com/blavatar/123"
+        let path = "https://attacker.example.com/gravatar.com/blavatar/123.png"
 
         // When
         let optimizedURL = SiteIconViewModel.optimizedURL(for: path)

--- a/Tests/KeystoneTests/Tests/Utility/SiteIconViewModelTests.swift
+++ b/Tests/KeystoneTests/Tests/Utility/SiteIconViewModelTests.swift
@@ -9,42 +9,42 @@ final class SiteIconViewModelTests: XCTestCase {
     /// Tests that a dotcom image URL with default image size is valid.
     func testDotcomURLWithDefaultSize() {
         // Given
-        let path = Constants.dotcomPath
+        let url = Constants.dotcomURL
 
         // When
-        let optimizedURL = SiteIconViewModel.optimizedURL(for: path)
+        let optimizedURL = SiteIconViewModel.optimizedURL(for: url)
 
         // Then
         let size = 40 * Int(UIScreen.main.scale)
-        let expectedURL = URL(string: "\(path)?w=\(size)&h=\(size)")
+        let expectedURL = URL(string: "\(url.absoluteString)?w=\(size)&h=\(size)")
         XCTAssertEqual(optimizedURL, expectedURL)
     }
 
     /// Tests that a gravatar image URL with default image size is valid.
     func testBlavatarURLWithDefaultSize() {
         // Given
-        let path = Constants.gravatarPath
+        let url = Constants.gravatarURL
 
         // When
-        let optimizedURL = SiteIconViewModel.optimizedURL(for: path)
+        let optimizedURL = SiteIconViewModel.optimizedURL(for: url)
 
         // Then
         let size = 40 * Int(UIScreen.main.scale)
-        let expectedURL = URL(string: "\(path)?d=404&s=\(size)")
+        let expectedURL = URL(string: "\(url.absoluteString)?d=404&s=\(size)")
         XCTAssertEqual(optimizedURL, expectedURL)
     }
 
     /// Tests that a photon image URL with default image size is valid.
     func testPhotonURLWithDefaultSize() {
         // Given
-        let path = Constants.photonPath
+        let url = Constants.photonURL
 
         // When
-        let optimizedURL = SiteIconViewModel.optimizedURL(for: path)
+        let optimizedURL = SiteIconViewModel.optimizedURL(for: url)
 
         // Then
         let size = 40 * Int(UIScreen.main.scale)
-        let expectedURL = URL(string: "\(path)?w=\(size)&h=\(size)")
+        let expectedURL = URL(string: "\(url.absoluteString)?w=\(size)&h=\(size)")
         XCTAssertEqual(optimizedURL, expectedURL)
     }
 
@@ -52,14 +52,14 @@ final class SiteIconViewModelTests: XCTestCase {
     func testDotcomURLWithCustomSize() {
         // Given
         let sizeInPoints = Constants.customImageSize
-        let path = Constants.dotcomPath
+        let url = Constants.dotcomURL
 
         // When
-        let optimizedURL = SiteIconViewModel.optimizedURL(for: path, imageSize: sizeInPoints)
+        let optimizedURL = SiteIconViewModel.optimizedURL(for: url, imageSize: sizeInPoints)
 
         // Then
         let size = Int(sizeInPoints.width) * Int(UIScreen.main.scale)
-        let expectedURL = URL(string: "\(path)?w=\(size)&h=\(size)")
+        let expectedURL = URL(string: "\(url.absoluteString)?w=\(size)&h=\(size)")
         XCTAssertEqual(optimizedURL, expectedURL)
     }
 
@@ -67,14 +67,14 @@ final class SiteIconViewModelTests: XCTestCase {
     func testBlavatarURLWithCustomSize() {
         // Given
         let sizeInPoints = Constants.customImageSize
-        let path = Constants.gravatarPath
+        let url = Constants.gravatarURL
 
         // When
-        let optimizedURL = SiteIconViewModel.optimizedURL(for: path, imageSize: sizeInPoints)
+        let optimizedURL = SiteIconViewModel.optimizedURL(for: url, imageSize: sizeInPoints)
 
         // Then
         let size = Int(sizeInPoints.width) * Int(UIScreen.main.scale)
-        let expectedURL = URL(string: "\(path)?d=404&s=\(size)")
+        let expectedURL = URL(string: "\(url.absoluteString)?d=404&s=\(size)")
         XCTAssertEqual(optimizedURL, expectedURL)
     }
 
@@ -82,14 +82,14 @@ final class SiteIconViewModelTests: XCTestCase {
     func testPhotonURLWithCustomSize() {
         // Given
         let sizeInPoints = Constants.customImageSize
-        let path = Constants.photonPath
+        let url = Constants.photonURL
 
         // When
-        let optimizedURL = SiteIconViewModel.optimizedURL(for: path, imageSize: sizeInPoints)
+        let optimizedURL = SiteIconViewModel.optimizedURL(for: url, imageSize: sizeInPoints)
 
         // Then
         let size = Int(sizeInPoints.width) * Int(UIScreen.main.scale)
-        let expectedURL = URL(string: "\(path)?w=\(size)&h=\(size)")
+        let expectedURL = URL(string: "\(url.absoluteString)?w=\(size)&h=\(size)")
         XCTAssertEqual(optimizedURL, expectedURL)
     }
 
@@ -98,10 +98,10 @@ final class SiteIconViewModelTests: XCTestCase {
     /// Tests that a third-party URL whose query mentions a WP.com host is still wrapped in Photon.
     func testLookalikeQueryIsNotTreatedAsDotcom() {
         // Given
-        let path = "https://attacker.example.com/icon.png?u=.files.wordpress.com"
+        let url = URL(string: "https://attacker.example.com/icon.png?u=.files.wordpress.com")!
 
         // When
-        let optimizedURL = SiteIconViewModel.optimizedURL(for: path)
+        let optimizedURL = SiteIconViewModel.optimizedURL(for: url)
 
         // Then
         XCTAssertEqual(optimizedURL?.host, "i0.wp.com")
@@ -112,10 +112,10 @@ final class SiteIconViewModelTests: XCTestCase {
     /// extension-less URLs and returns them unchanged.
     func testLookalikePathIsNotTreatedAsBlavatar() {
         // Given
-        let path = "https://attacker.example.com/gravatar.com/blavatar/123.png"
+        let url = URL(string: "https://attacker.example.com/gravatar.com/blavatar/123.png")!
 
         // When
-        let optimizedURL = SiteIconViewModel.optimizedURL(for: path)
+        let optimizedURL = SiteIconViewModel.optimizedURL(for: url)
 
         // Then
         XCTAssertEqual(optimizedURL?.host, "i0.wp.com")
@@ -124,22 +124,36 @@ final class SiteIconViewModelTests: XCTestCase {
     /// Tests that a WordPress.com subdomain is sized directly rather than wrapped in Photon.
     func testWPComSubdomainIsTreatedAsDotcom() {
         // Given
-        let path = "https://example.wordpress.com/icon.png"
+        let url = URL(string: "https://example.wordpress.com/icon.png")!
 
         // When
-        let optimizedURL = SiteIconViewModel.optimizedURL(for: path)
+        let optimizedURL = SiteIconViewModel.optimizedURL(for: url)
 
         // Then
         let size = 40 * Int(UIScreen.main.scale)
-        XCTAssertEqual(optimizedURL, URL(string: "\(path)?w=\(size)&h=\(size)"))
+        XCTAssertEqual(optimizedURL, URL(string: "\(url.absoluteString)?w=\(size)&h=\(size)"))
+    }
+
+    /// Tests that a URL relative to a base URL is resolved before its query is replaced.
+    func testURLRelativeToBaseURLIsResolvedBeforeOptimization() {
+        // Given
+        let baseURL = URL(string: "https://example.wordpress.com")!
+        let url = URL(string: "icon.png?existing=value", relativeTo: baseURL)!
+
+        // When
+        let optimizedURL = SiteIconViewModel.optimizedURL(for: url)
+
+        // Then
+        let size = 40 * Int(UIScreen.main.scale)
+        XCTAssertEqual(optimizedURL, URL(string: "https://example.wordpress.com/icon.png?w=\(size)&h=\(size)"))
     }
 
     // MARK: - Constants
 
     private struct Constants {
         static let customImageSize = CGSize(width: 60, height: 60)
-        static let dotcomPath = "https://fake.files.wordpress.com/fake.png"
-        static let gravatarPath = "https://secure.gravatar.com/blavatar/123"
-        static let photonPath = "https://fake.wp.com/fake.png"
+        static let dotcomURL = URL(string: "https://fake.files.wordpress.com/fake.png")!
+        static let gravatarURL = URL(string: "https://secure.gravatar.com/blavatar/123")!
+        static let photonURL = URL(string: "https://fake.wp.com/fake.png")!
     }
 }

--- a/WordPress/Classes/Networking/MediaRequestAuthenticator.swift
+++ b/WordPress/Classes/Networking/MediaRequestAuthenticator.swift
@@ -65,7 +65,7 @@ struct MediaRequestAuthenticator {
 
         // We want to make sure we're never sending credentials
         // to a URL that's not safe.
-        guard isTokenAllowed(for: url) else {
+        guard url.isWordPressComHost else {
             let request = URLRequest(url: url)
             provide(request)
             return
@@ -117,7 +117,7 @@ struct MediaRequestAuthenticator {
     }
 
     private func authenticatedAsset(for url: URL, authToken: String) -> AVURLAsset {
-        guard isTokenAllowed(for: url) else {
+        guard url.isWordPressComHost else {
             Loggers.networking.warning("Refusing to attach the WP.com token to a non-WP.com host: \(url.host ?? "no host")")
             return AVURLAsset(url: url)
         }
@@ -282,7 +282,7 @@ struct MediaRequestAuthenticator {
     ///     - authToken: the Bearer token to add to the resulting request.
     ///
     private func tokenAuthenticatedWPComRequest(for url: URL, authToken: String) -> URLRequest {
-        guard isTokenAllowed(for: url) else {
+        guard url.isWordPressComHost else {
             Loggers.networking.warning("Refusing to attach the WP.com token to a non-WP.com host: \(url.host ?? "no host")")
             return URLRequest(url: url)
         }
@@ -290,21 +290,5 @@ struct MediaRequestAuthenticator {
         var request = URLRequest(url: url)
         request.addValue("Bearer \(authToken)", forHTTPHeaderField: "Authorization")
         return request
-    }
-
-    /// Whether the URL's host is WordPress.com infrastructure that may receive the WP.com
-    /// Bearer token. The token is account-wide, so sending it to any host outside this
-    /// allowlist (including a private site's own mapped custom domain, which the site owner
-    /// controls) would let a malicious site owner capture it.
-    ///
-    /// Internal rather than private so unit tests can exercise the allowlist directly.
-    func isTokenAllowed(for url: URL) -> Bool {
-        // DNS hostnames are case-insensitive (RFC 4343), but URL.host preserves the
-        // input casing, so lowercase before matching the allowlist.
-        guard let host = url.host?.lowercased() else {
-            return false
-        }
-        return host == "wordpress.com" || host.hasSuffix(".wordpress.com")
-            || host == "wp.com" || host.hasSuffix(".wp.com")
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/Site Picker/BlogList/SiteIconViewModel+Extensions.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Picker/BlogList/SiteIconViewModel+Extensions.swift
@@ -13,7 +13,7 @@ extension SiteIconViewModel {
         self.firstLetter = blog.title?.first
 
         if let icon = blog.iconURL {
-            self.imageURL = SiteIconViewModel.optimizedURL(for: icon.absoluteString, imageSize: size.size, isP2: blog.isAutomatticP2)
+            self.imageURL = SiteIconViewModel.optimizedURL(for: icon, imageSize: size.size, isP2: blog.isAutomatticP2)
             self.host = MediaHost(blog)
         }
     }
@@ -33,35 +33,35 @@ extension SiteIconViewModel {
 // MARK: - SiteIconViewModel (Optimized URL)
 
 extension SiteIconViewModel {
-    /// Returns the Size Optimized URL for a given Path.
-    static func optimizedURL(for path: String, imageSize: CGSize = SiteIconViewModel.Size.regular.size, isP2: Bool = false) -> URL? {
-        guard let url = URL(string: path) else {
-            return nil
-        }
+    /// Returns the size-optimized URL for a given URL.
+    static func optimizedURL(
+        for url: URL,
+        imageSize: CGSize = SiteIconViewModel.Size.regular.size,
+        isP2: Bool = false
+    ) -> URL? {
         if url.isWordPressComHost || isP2 {
-            return optimizedDotcomURL(from: path, imageSize: imageSize)
+            return optimizedDotcomURL(from: url, imageSize: imageSize)
         }
         if isBlavatarURL(url) {
-            return optimizedBlavatarURL(from: path, imageSize: imageSize)
+            return optimizedBlavatarURL(from: url, imageSize: imageSize)
         }
-        return optimizedPhotonURL(from: path, imageSize: imageSize)
+        return optimizedPhotonURL(from: url, imageSize: imageSize)
     }
 
-    private static func optimizedDotcomURL(from path: String, imageSize: CGSize) -> URL? {
+    private static func optimizedDotcomURL(from url: URL, imageSize: CGSize) -> URL? {
         let size = imageSize.scaled(by: UITraitCollection.current.displayScale)
         let query = String(format: "w=%d&h=%d", Int(size.width), Int(size.height))
-        return parseURL(path: path, query: query)
+        return parseURL(url: url, query: query)
     }
 
-    static func optimizedBlavatarURL(from path: String, imageSize: CGSize) -> URL? {
+    static func optimizedBlavatarURL(from url: URL, imageSize: CGSize) -> URL? {
         let size = imageSize.scaled(by: UITraitCollection.current.displayScale)
         let query = String(format: "d=404&s=%d", Int(max(size.width, size.height)))
-        return parseURL(path: path, query: query)
+        return parseURL(url: url, query: query)
     }
 
-    private static func optimizedPhotonURL(from path: String, imageSize: CGSize) -> URL? {
-        guard let url = URL(string: path) else { return nil }
-        return PhotonImageURLHelper.photonURL(with: imageSize, forImageURL: url)
+    private static func optimizedPhotonURL(from url: URL, imageSize: CGSize) -> URL? {
+        PhotonImageURLHelper.photonURL(with: imageSize, forImageURL: url)
     }
 
     /// Indicates if the received URL is a Gravatar blavatar. Matches the host exactly or as
@@ -74,9 +74,9 @@ extension SiteIconViewModel {
         return (host == "gravatar.com" || host.hasSuffix(".gravatar.com")) && url.path.hasPrefix("/blavatar")
     }
 
-    /// Attempts to parse the URL contained within a Path, with a given query. Returns nil on failure.
-    private static func parseURL(path: String, query: String) -> URL? {
-        guard var components = URLComponents(string: path) else {
+    /// Attempts to update a URL with a given query. Returns nil on failure.
+    private static func parseURL(url: URL, query: String) -> URL? {
+        guard var components = URLComponents(url: url, resolvingAgainstBaseURL: true) else {
             return nil
         }
         components.query = query
@@ -101,10 +101,13 @@ extension SiteIconViewModel {
             }
             return nil
         }
-        if let url = URL(string: iconURL), isBlavatarURL(url) {
-            return optimizedBlavatarURL(from: iconURL, imageSize: size)
+        guard let url = URL(string: iconURL) else {
+            return nil
         }
-        return URL(string: iconURL)
+        if isBlavatarURL(url) {
+            return optimizedBlavatarURL(from: url, imageSize: size)
+        }
+        return url
     }
 
     private static func getHardcodedSiteIconURL(siteID: Int) -> URL? {

--- a/WordPress/Classes/ViewRelated/Blog/Site Picker/BlogList/SiteIconViewModel+Extensions.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Picker/BlogList/SiteIconViewModel+Extensions.swift
@@ -35,10 +35,13 @@ extension SiteIconViewModel {
 extension SiteIconViewModel {
     /// Returns the Size Optimized URL for a given Path.
     static func optimizedURL(for path: String, imageSize: CGSize = SiteIconViewModel.Size.regular.size, isP2: Bool = false) -> URL? {
-        if isPhotonURL(path) || isDotcomURL(path) || isP2 {
+        guard let url = URL(string: path) else {
+            return nil
+        }
+        if url.isWordPressComHost || isP2 {
             return optimizedDotcomURL(from: path, imageSize: imageSize)
         }
-        if isBlavatarURL(path) {
+        if isBlavatarURL(url) {
             return optimizedBlavatarURL(from: path, imageSize: imageSize)
         }
         return optimizedPhotonURL(from: path, imageSize: imageSize)
@@ -61,23 +64,14 @@ extension SiteIconViewModel {
         return PhotonImageURLHelper.photonURL(with: imageSize, forImageURL: url)
     }
 
-    /// Indicates if the received URL is hosted at WordPress.com
+    /// Indicates if the received URL is a Gravatar blavatar. Matches the host exactly or as
+    /// a subdomain, never as a substring, so a lookalike URL can't skip the Photon proxy.
     ///
-    private static func isDotcomURL(_ path: String) -> Bool {
-        path.contains(".files.wordpress.com")
-    }
-
-    /// Indicates if the received URL is hosted at Gravatar.com
-    ///
-    private static func isBlavatarURL(_ path: String) -> Bool {
-        path.contains("gravatar.com/blavatar")
-    }
-
-    /// Indicates if the received URL is a Photon Endpoint
-    /// Possible matches are "i0.wp.com", "i1.wp.com" & "i2.wp.com" -> https://developer.wordpress.com/docs/photon/
-    ///
-    private static func isPhotonURL(_ path: String) -> Bool {
-        path.contains(".wp.com")
+    private static func isBlavatarURL(_ url: URL) -> Bool {
+        guard let host = url.host?.lowercased() else {
+            return false
+        }
+        return (host == "gravatar.com" || host.hasSuffix(".gravatar.com")) && url.path.hasPrefix("/blavatar")
     }
 
     /// Attempts to parse the URL contained within a Path, with a given query. Returns nil on failure.
@@ -107,7 +101,7 @@ extension SiteIconViewModel {
             }
             return nil
         }
-        if isBlavatarURL(iconURL) {
+        if let url = URL(string: iconURL), isBlavatarURL(url) {
             return optimizedBlavatarURL(from: iconURL, imageSize: size)
         }
         return URL(string: iconURL)

--- a/WordPress/Classes/ViewRelated/Reader/Controllers/ReaderFeedCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Controllers/ReaderFeedCell.swift
@@ -60,7 +60,7 @@ extension SiteIconViewModel {
     init(feed: ReaderFeed, faviconURL: URL? = nil, size: Size = .regular) {
         self.init(size: size)
         if let iconURL = feed.iconURL {
-            self.imageURL = SiteIconViewModel.optimizedURL(for: iconURL.absoluteString, imageSize: size.size)
+            self.imageURL = SiteIconViewModel.optimizedURL(for: iconURL, imageSize: size.size)
         } else if let faviconURL {
             self.imageURL = faviconURL
         }
@@ -75,7 +75,8 @@ private extension ReaderFeed {
             return nil
         }
         guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
-            let host = components.host else {
+            let host = components.host
+        else {
             return url.absoluteString
         }
 

--- a/WordPress/WordPressNotificationServiceExtension/Sources/NotificationService.swift
+++ b/WordPress/WordPressNotificationServiceExtension/Sources/NotificationService.swift
@@ -245,10 +245,10 @@ private extension NotificationService {
         var request = URLRequest(url: url)
         request.addValue("image/*", forHTTPHeaderField: "Accept")
 
-        // Allow private images to pulled from WordPress sites.
-        if isWPComSite(url: url), let token = self.readExtensionToken() {
+        // Allow private images to be pulled from WordPress.com sites. The token is
+        // account-wide, so only attach it to WordPress.com hosts.
+        if url.isWordPressComHost, let token = self.readExtensionToken() {
             request.addValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
-            print("AuthorizationAuthorizationAuthorizationAuthorizationAuthorizationAuthorization")
         }
 
         let session = URLSession(configuration: .default)
@@ -296,21 +296,6 @@ private extension NotificationService {
         } catch {
             return nil
         }
-    }
-
-    /// Perform a simple check to see if the URL is a WP.com site
-    /// This isn't meant to be extensive and has a few flaws, but since we don't know
-    /// much information about the URL and if it's a blog without having to do another request
-    /// this works for the current usecases.
-    ///
-    /// - Parameter url: The URL to check
-    /// - Returns: True if it's a WP.com site, False if not.
-    private func isWPComSite(url: URL) -> Bool {
-        guard let host = url.host else {
-            return false
-        }
-
-        return host.contains("wordpress.com") || host.contains("wp.com")
     }
 }
 // MARK: - Keychain support


### PR DESCRIPTION
Stacked on #25863 — this targets that branch, not `trunk`. Merge #25863 first.

## Summary

- Consolidates the WordPress.com host check into a single `URL.isWordPressComHost` helper in `WordPressShared`, replacing the copies that had grown up in `MediaRequestAuthenticator` and the notification service extension.
- Applies the same exact/subdomain allowlist to the notification service extension's media requests, extending the hardening from #25863 to that path.
- Replaces substring-based URL routing in `SiteIconViewModel` with host comparisons.

## Changes

### 1. `WordPressShared/URL+Helpers.swift`
Add `isWordPressComHost` — matches `wordpress.com`/`wp.com` exactly or as a subdomain, lowercased first (hostnames are case-insensitive, RFC 4343). Documented as the allowlist for attaching the account-wide WP.com token, and why it is deliberately broader than the neighbouring `isHostedAtWPCom`.

### 2. `MediaRequestAuthenticator.swift`
Replace the local `isTokenAllowed` (added in #25863) with `url.isWordPressComHost` at all three call sites.

### 3. `NotificationService.swift`
Gate the media token header on `url.isWordPressComHost` in place of a `host.contains(...)` match, remove the now-unused `isWPComSite`, and drop a leftover debug `print`.

### 4. `SiteIconViewModel+Extensions.swift`
Route icon URLs by parsed host instead of `contains` over the whole URL string. The two WP.com checks (`isDotcomURL`, `isPhotonURL`) fed the same branch and collapse into `isWordPressComHost`; the Gravatar check becomes a host-anchored comparison. No credentials flow here — the stake is that a crafted URL could previously skip the Photon proxy and be fetched directly. Note one deliberate broadening: non-`.files` `*.wordpress.com` hosts are now sized directly (`?w=&h=`) rather than Photon-wrapped; both are WP.com infrastructure and both resize.

### 5. Tests
New `URLWordPressComHostTests` in `WordPressSharedTests` covers the allowlist, case-insensitivity, subdomain lookalikes, userinfo-spoofed hosts, and hostless URLs. The equivalent unit test moves out of `MediaRequestAuthenticatorTests`; its behavioural checks stay. `SiteIconViewModelTests` gains lookalike-routing cases and pins the `*.wordpress.com` broadening.

Kept in `WordPressShared` rather than `WordPressCore` on purpose: the notification service extension links `WordPressShared` but not `WordPressCore`, and `WordPressCore` pulls in `wordpress-rs` — too heavy for a memory-capped extension.

## Test plan

- [x] `swift test` → `URLWordPressComHostTests` passes (6/6, verified locally)
- [ ] `WordPressUnitTests` (CI) → `MediaRequestAuthenticatorTests` and `SiteIconViewModelTests`, plus the app and notification extension compiling against the shared helper

## Related

- Stacked on #25863