### PR TITLE
Accept URLs when optimizing site icons

### DIFF
--- a/Tests/KeystoneTests/Tests/Utility/SiteIconViewModelTests.swift
+++ b/Tests/KeystoneTests/Tests/Utility/SiteIconViewModelTests.swift
@@ -9,42 +9,42 @@ final class SiteIconViewModelTests: XCTestCase {
     /// Tests that a dotcom image URL with default image size is valid.
     func testDotcomURLWithDefaultSize() {
         // Given
-        let path = Constants.dotcomPath
+        let url = Constants.dotcomURL
 
         // When
-        let optimizedURL = SiteIconViewModel.optimizedURL(for: path)
+        let optimizedURL = SiteIconViewModel.optimizedURL(for: url)
 
         // Then
         let size = 40 * Int(UIScreen.main.scale)
-        let expectedURL = URL(string: "\(path)?w=\(size)&h=\(size)")
+        let expectedURL = URL(string: "\(url.absoluteString)?w=\(size)&h=\(size)")
         XCTAssertEqual(optimizedURL, expectedURL)
     }
 
     /// Tests that a gravatar image URL with default image size is valid.
     func testBlavatarURLWithDefaultSize() {
         // Given
-        let path = Constants.gravatarPath
+        let url = Constants.gravatarURL
 
         // When
-        let optimizedURL = SiteIconViewModel.optimizedURL(for: path)
+        let optimizedURL = SiteIconViewModel.optimizedURL(for: url)
 
         // Then
         let size = 40 * Int(UIScreen.main.scale)
-        let expectedURL = URL(string: "\(path)?d=404&s=\(size)")
+        let expectedURL = URL(string: "\(url.absoluteString)?d=404&s=\(size)")
         XCTAssertEqual(optimizedURL, expectedURL)
     }
 
     /// Tests that a photon image URL with default image size is valid.
     func testPhotonURLWithDefaultSize() {
         // Given
-        let path = Constants.photonPath
+        let url = Constants.photonURL
 
         // When
-        let optimizedURL = SiteIconViewModel.optimizedURL(for: path)
+        let optimizedURL = SiteIconViewModel.optimizedURL(for: url)
 
         // Then
         let size = 40 * Int(UIScreen.main.scale)
-        let expectedURL = URL(string: "\(path)?w=\(size)&h=\(size)")
+        let expectedURL = URL(string: "\(url.absoluteString)?w=\(size)&h=\(size)")
         XCTAssertEqual(optimizedURL, expectedURL)
     }
 
@@ -52,14 +52,14 @@ final class SiteIconViewModelTests: XCTestCase {
     func testDotcomURLWithCustomSize() {
         // Given
         let sizeInPoints = Constants.customImageSize
-        let path = Constants.dotcomPath
+        let url = Constants.dotcomURL
 
         // When
-        let optimizedURL = SiteIconViewModel.optimizedURL(for: path, imageSize: sizeInPoints)
+        let optimizedURL = SiteIconViewModel.optimizedURL(for: url, imageSize: sizeInPoints)
 
         // Then
         let size = Int(sizeInPoints.width) * Int(UIScreen.main.scale)
-        let expectedURL = URL(string: "\(path)?w=\(size)&h=\(size)")
+        let expectedURL = URL(string: "\(url.absoluteString)?w=\(size)&h=\(size)")
         XCTAssertEqual(optimizedURL, expectedURL)
     }
 
@@ -67,14 +67,14 @@ final class SiteIconViewModelTests: XCTestCase {
     func testBlavatarURLWithCustomSize() {
         // Given
         let sizeInPoints = Constants.customImageSize
-        let path = Constants.gravatarPath
+        let url = Constants.gravatarURL
 
         // When
-        let optimizedURL = SiteIconViewModel.optimizedURL(for: path, imageSize: sizeInPoints)
+        let optimizedURL = SiteIconViewModel.optimizedURL(for: url, imageSize: sizeInPoints)
 
         // Then
         let size = Int(sizeInPoints.width) * Int(UIScreen.main.scale)
-        let expectedURL = URL(string: "\(path)?d=404&s=\(size)")
+        let expectedURL = URL(string: "\(url.absoluteString)?d=404&s=\(size)")
         XCTAssertEqual(optimizedURL, expectedURL)
     }
 
@@ -82,14 +82,14 @@ final class SiteIconViewModelTests: XCTestCase {
     func testPhotonURLWithCustomSize() {
         // Given
         let sizeInPoints = Constants.customImageSize
-        let path = Constants.photonPath
+        let url = Constants.photonURL
 
         // When
-        let optimizedURL = SiteIconViewModel.optimizedURL(for: path, imageSize: sizeInPoints)
+        let optimizedURL = SiteIconViewModel.optimizedURL(for: url, imageSize: sizeInPoints)
 
         // Then
         let size = Int(sizeInPoints.width) * Int(UIScreen.main.scale)
-        let expectedURL = URL(string: "\(path)?w=\(size)&h=\(size)")
+        let expectedURL = URL(string: "\(url.absoluteString)?w=\(size)&h=\(size)")
         XCTAssertEqual(optimizedURL, expectedURL)
     }
 
@@ -98,10 +98,10 @@ final class SiteIconViewModelTests: XCTestCase {
     /// Tests that a third-party URL whose query mentions a WP.com host is still wrapped in Photon.
     func testLookalikeQueryIsNotTreatedAsDotcom() {
         // Given
-        let path = "https://attacker.example.com/icon.png?u=.files.wordpress.com"
+        let url = URL(string: "https://attacker.example.com/icon.png?u=.files.wordpress.com")!
 
         // When
-        let optimizedURL = SiteIconViewModel.optimizedURL(for: path)
+        let optimizedURL = SiteIconViewModel.optimizedURL(for: url)
 
         // Then
         XCTAssertEqual(optimizedURL?.host, "i0.wp.com")
@@ -112,10 +112,10 @@ final class SiteIconViewModelTests: XCTestCase {
     /// extension-less URLs and returns them unchanged.
     func testLookalikePathIsNotTreatedAsBlavatar() {
         // Given
-        let path = "https://attacker.example.com/gravatar.com/blavatar/123.png"
+        let url = URL(string: "https://attacker.example.com/gravatar.com/blavatar/123.png")!
 
         // When
-        let optimizedURL = SiteIconViewModel.optimizedURL(for: path)
+        let optimizedURL = SiteIconViewModel.optimizedURL(for: url)
 
         // Then
         XCTAssertEqual(optimizedURL?.host, "i0.wp.com")
@@ -124,22 +124,36 @@ final class SiteIconViewModelTests: XCTestCase {
     /// Tests that a WordPress.com subdomain is sized directly rather than wrapped in Photon.
     func testWPComSubdomainIsTreatedAsDotcom() {
         // Given
-        let path = "https://example.wordpress.com/icon.png"
+        let url = URL(string: "https://example.wordpress.com/icon.png")!
 
         // When
-        let optimizedURL = SiteIconViewModel.optimizedURL(for: path)
+        let optimizedURL = SiteIconViewModel.optimizedURL(for: url)
 
         // Then
         let size = 40 * Int(UIScreen.main.scale)
-        XCTAssertEqual(optimizedURL, URL(string: "\(path)?w=\(size)&h=\(size)"))
+        XCTAssertEqual(optimizedURL, URL(string: "\(url.absoluteString)?w=\(size)&h=\(size)"))
+    }
+
+    /// Tests that a URL relative to a base URL is resolved before its query is replaced.
+    func testURLRelativeToBaseURLIsResolvedBeforeOptimization() {
+        // Given
+        let baseURL = URL(string: "https://example.wordpress.com")!
+        let url = URL(string: "icon.png?existing=value", relativeTo: baseURL)!
+
+        // When
+        let optimizedURL = SiteIconViewModel.optimizedURL(for: url)
+
+        // Then
+        let size = 40 * Int(UIScreen.main.scale)
+        XCTAssertEqual(optimizedURL, URL(string: "https://example.wordpress.com/icon.png?w=\(size)&h=\(size)"))
     }
 
     // MARK: - Constants
 
     private struct Constants {
         static let customImageSize = CGSize(width: 60, height: 60)
-        static let dotcomPath = "https://fake.files.wordpress.com/fake.png"
-        static let gravatarPath = "https://secure.gravatar.com/blavatar/123"
-        static let photonPath = "https://fake.wp.com/fake.png"
+        static let dotcomURL = URL(string: "https://fake.files.wordpress.com/fake.png")!
+        static let gravatarURL = URL(string: "https://secure.gravatar.com/blavatar/123")!
+        static let photonURL = URL(string: "https://fake.wp.com/fake.png")!
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/Site Picker/BlogList/SiteIconViewModel+Extensions.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Picker/BlogList/SiteIconViewModel+Extensions.swift
@@ -13,7 +13,7 @@ extension SiteIconViewModel {
         self.firstLetter = blog.title?.first
 
         if let icon = blog.iconURL {
-            self.imageURL = SiteIconViewModel.optimizedURL(for: icon.absoluteString, imageSize: size.size, isP2: blog.isAutomatticP2)
+            self.imageURL = SiteIconViewModel.optimizedURL(for: icon, imageSize: size.size, isP2: blog.isAutomatticP2)
             self.host = MediaHost(blog)
         }
     }
@@ -33,35 +33,35 @@ extension SiteIconViewModel {
 // MARK: - SiteIconViewModel (Optimized URL)
 
 extension SiteIconViewModel {
-    /// Returns the Size Optimized URL for a given Path.
-    static func optimizedURL(for path: String, imageSize: CGSize = SiteIconViewModel.Size.regular.size, isP2: Bool = false) -> URL? {
-        guard let url = URL(string: path) else {
-            return nil
-        }
+    /// Returns the size-optimized URL for a given URL.
+    static func optimizedURL(
+        for url: URL,
+        imageSize: CGSize = SiteIconViewModel.Size.regular.size,
+        isP2: Bool = false
+    ) -> URL? {
         if url.isWordPressComHost || isP2 {
-            return optimizedDotcomURL(from: path, imageSize: imageSize)
+            return optimizedDotcomURL(from: url, imageSize: imageSize)
         }
         if isBlavatarURL(url) {
-            return optimizedBlavatarURL(from: path, imageSize: imageSize)
+            return optimizedBlavatarURL(from: url, imageSize: imageSize)
         }
-        return optimizedPhotonURL(from: path, imageSize: imageSize)
+        return optimizedPhotonURL(from: url, imageSize: imageSize)
     }
 
-    private static func optimizedDotcomURL(from path: String, imageSize: CGSize) -> URL? {
+    private static func optimizedDotcomURL(from url: URL, imageSize: CGSize) -> URL? {
         let size = imageSize.scaled(by: UITraitCollection.current.displayScale)
         let query = String(format: "w=%d&h=%d", Int(size.width), Int(size.height))
-        return parseURL(path: path, query: query)
+        return parseURL(url: url, query: query)
     }
 
-    static func optimizedBlavatarURL(from path: String, imageSize: CGSize) -> URL? {
+    static func optimizedBlavatarURL(from url: URL, imageSize: CGSize) -> URL? {
         let size = imageSize.scaled(by: UITraitCollection.current.displayScale)
         let query = String(format: "d=404&s=%d", Int(max(size.width, size.height)))
-        return parseURL(path: path, query: query)
+        return parseURL(url: url, query: query)
     }
 
-    private static func optimizedPhotonURL(from path: String, imageSize: CGSize) -> URL? {
-        guard let url = URL(string: path) else { return nil }
-        return PhotonImageURLHelper.photonURL(with: imageSize, forImageURL: url)
+    private static func optimizedPhotonURL(from url: URL, imageSize: CGSize) -> URL? {
+        PhotonImageURLHelper.photonURL(with: imageSize, forImageURL: url)
     }
 
     /// Indicates if the received URL is a Gravatar blavatar. Matches the host exactly or as
@@ -74,9 +74,9 @@ extension SiteIconViewModel {
         return (host == "gravatar.com" || host.hasSuffix(".gravatar.com")) && url.path.hasPrefix("/blavatar")
     }
 
-    /// Attempts to parse the URL contained within a Path, with a given query. Returns nil on failure.
-    private static func parseURL(path: String, query: String) -> URL? {
-        guard var components = URLComponents(string: path) else {
+    /// Attempts to update a URL with a given query. Returns nil on failure.
+    private static func parseURL(url: URL, query: String) -> URL? {
+        guard var components = URLComponents(url: url, resolvingAgainstBaseURL: true) else {
             return nil
         }
         components.query = query
@@ -101,10 +101,13 @@ extension SiteIconViewModel {
             }
             return nil
         }
-        if let url = URL(string: iconURL), isBlavatarURL(url) {
-            return optimizedBlavatarURL(from: iconURL, imageSize: size)
+        guard let url = URL(string: iconURL) else {
+            return nil
         }
-        return URL(string: iconURL)
+        if isBlavatarURL(url) {
+            return optimizedBlavatarURL(from: url, imageSize: size)
+        }
+        return url
     }
 
     private static func getHardcodedSiteIconURL(siteID: Int) -> URL? {

--- a/WordPress/Classes/ViewRelated/Reader/Controllers/ReaderFeedCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Controllers/ReaderFeedCell.swift
@@ -60,7 +60,7 @@ extension SiteIconViewModel {
     init(feed: ReaderFeed, faviconURL: URL? = nil, size: Size = .regular) {
         self.init(size: size)
         if let iconURL = feed.iconURL {
-            self.imageURL = SiteIconViewModel.optimizedURL(for: iconURL.absoluteString, imageSize: size.size)
+            self.imageURL = SiteIconViewModel.optimizedURL(for: iconURL, imageSize: size.size)
         } else if let faviconURL {
             self.imageURL = faviconURL
         }
@@ -75,7 +75,8 @@ private extension ReaderFeed {
             return nil
         }
         guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
-            let host = components.host else {
+            let host = components.host
+        else {
             return url.absoluteString
         }
 


### PR DESCRIPTION
## Description

Change `path: String` to `url: URL`, to avoid any potential URL parsing issues. This will save use some URL -> String -> URL conversions, since the current callers pass `URL.absoluteString` as the `path`.

It'll prevent a potential issue where a scheme-less URL string is passed as `path`, because `URL(string: "i.wp.com/icon.png").host` is nil.