### PR TITLE
ReaderPostHeaderView changes follow-up

### DIFF
--- a/Modules/Sources/WordPressReader/Detail/ReaderPostHeaderView.swift
+++ b/Modules/Sources/WordPressReader/Detail/ReaderPostHeaderView.swift
@@ -266,7 +266,7 @@ public final class ReaderPostHeaderView: UIView {
         separator.backgroundColor = colors.border
 
         lastExcerptLayoutWidth = 0
-        updateExcerptTruncation()
+        updateExcerptText()
     }
 
     // MARK: - Private
@@ -344,11 +344,19 @@ public final class ReaderPostHeaderView: UIView {
     }
 
     @objc private func excerptTapped() {
-        guard !isExcerptExpanded, let text = fullExcerptText else { return }
+        guard !isExcerptExpanded, fullExcerptText != nil else { return }
         isExcerptExpanded = true
-        let font = displaySettings.font(with: .callout)
-        let textColor = displaySettings.color.secondaryForeground
-        excerptLabel.attributedText = NSAttributedString(string: text, attributes: [.font: font, .foregroundColor: textColor])
+        updateExcerptText()
+    }
+
+    private func updateExcerptText() {
+        if isExcerptExpanded, let text = fullExcerptText {
+            let font = displaySettings.font(with: .callout)
+            let textColor = displaySettings.color.secondaryForeground
+            excerptLabel.attributedText = NSAttributedString(string: text, attributes: [.font: font, .foregroundColor: textColor])
+        } else {
+            updateExcerptTruncation()
+        }
     }
 
     @objc private func featuredImageTapped() {
@@ -400,12 +408,16 @@ public final class ReaderPostHeaderView: UIView {
 
     private func configureExcerpt(with excerpt: String?) {
         if let excerpt, !excerpt.isEmpty {
+            if excerpt != fullExcerptText {
+                isExcerptExpanded = false
+            }
             fullExcerptText = excerpt
             excerptLabel.isHidden = false
             lastExcerptLayoutWidth = 0
-            updateExcerptTruncation()
+            updateExcerptText()
         } else {
             fullExcerptText = nil
+            isExcerptExpanded = false
             excerptLabel.isHidden = true
         }
     }

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -526,7 +526,7 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
 
         // Tags collection view
         tagsCollectionView.coordinator?.displaySetting = displaySetting
-        tagsCollectionView.reloadData()
+        tagsCollectionView.coordinator?.reloadData()
     }
 
     /// Configure the webview

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -523,6 +523,10 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
 
         // Related posts table view
         relatedPostsTableView.reloadData()
+
+        // Tags collection view
+        tagsCollectionView.coordinator?.displaySetting = displaySetting
+        tagsCollectionView.reloadData()
     }
 
     /// Configure the webview
@@ -636,6 +640,7 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
             configureTagsCollectionView()
         }
 
+        tagsCollectionView.coordinator?.displaySetting = displaySetting
         tagsCollectionView.topics = tags
         scrollView.layoutIfNeeded()
     }


### PR DESCRIPTION
## Description

Two appearance regressions from the `ReaderPostHeaderView` integration (#25465), in Reader post detail:

1. Tag chips ignored the Reader display settings.
2. An expanded excerpt kept stale colors after a theme change.