### PR TITLE
Authenticate Reader featured images for private Atomic sites

### DIFF
--- a/Modules/Sources/WordPressReader/Detail/ReaderPostHeaderView.swift
+++ b/Modules/Sources/WordPressReader/Detail/ReaderPostHeaderView.swift
@@ -30,6 +30,7 @@ public final class ReaderPostHeaderView: UIView {
         public let authorAvatarURL: URL?
         public let dateString: String?
         public let featuredImageURL: URL?
+        public let featuredImageHost: MediaHostProtocol?
         public let excerpt: String?
 
         public init(
@@ -39,6 +40,7 @@ public final class ReaderPostHeaderView: UIView {
             authorAvatarURL: URL? = nil,
             dateString: String?,
             featuredImageURL: URL? = nil,
+            featuredImageHost: MediaHostProtocol? = nil,
             excerpt: String? = nil
         ) {
             self.siteName = siteName
@@ -47,6 +49,7 @@ public final class ReaderPostHeaderView: UIView {
             self.authorAvatarURL = authorAvatarURL
             self.dateString = dateString
             self.featuredImageURL = featuredImageURL
+            self.featuredImageHost = featuredImageHost
             self.excerpt = excerpt
         }
     }
@@ -233,7 +236,7 @@ public final class ReaderPostHeaderView: UIView {
 
         mainStack.setCustomSpacing(viewModel.featuredImageURL != nil ? 18 : 12, after: authorRow)
 
-        configureFeaturedImage(with: viewModel.featuredImageURL)
+        configureFeaturedImage(with: viewModel.featuredImageURL, host: viewModel.featuredImageHost)
         configureExcerpt(with: viewModel.excerpt)
     }
 
@@ -374,7 +377,7 @@ public final class ReaderPostHeaderView: UIView {
         headerRow.isHidden = siteNameLabel.isHidden
     }
 
-    private func configureFeaturedImage(with url: URL?) {
+    private func configureFeaturedImage(with url: URL?, host: MediaHostProtocol?) {
         guard let url else {
             featuredImageView.isHidden = true
             return
@@ -383,7 +386,7 @@ public final class ReaderPostHeaderView: UIView {
         featuredImageView.isHidden = false
         updateFeaturedImageAspectRatio(Constants.defaultFeaturedImageAspectRatio)
 
-        featuredImageView.setImage(with: ImageRequest(url: url)) { [weak self] result in
+        featuredImageView.setImage(with: ImageRequest(url: url, host: host)) { [weak self] result in
             guard let self, case .success(let image) = result else { return }
             guard image.size.width > 0 else { return }
             let ratio = min(image.size.height / image.size.width, Constants.maxFeaturedImageAspectRatio)

--- a/Tests/KeystoneTests/Tests/Networking/MediaHostTests.swift
+++ b/Tests/KeystoneTests/Tests/Networking/MediaHostTests.swift
@@ -64,6 +64,26 @@ struct MediaHostTests {
         let siteID = 16557
         let username = "demouser"
         let authToken = "letMeIn!"
+        let siteHost = "example.com"
+
+        let host = MediaHost(
+            isAccessibleThroughWPCom: true,
+            isPrivate: true,
+            isAtomic: true,
+            siteID: siteID,
+            username: username,
+            siteHost: siteHost,
+            authToken: authToken,
+            failure: { _ in Issue.record("Should not fail") }
+        )
+
+        #expect(host == .privateAtomicWPComSite(siteID: siteID, username: username, authToken: authToken, siteHost: siteHost))
+    }
+
+    @Test func initializationWithPrivateAtomicWPComSiteWithoutSiteHost() {
+        let siteID = 16557
+        let username = "demouser"
+        let authToken = "letMeIn!"
 
         let host = MediaHost(
             isAccessibleThroughWPCom: true,
@@ -75,7 +95,7 @@ struct MediaHostTests {
             failure: { _ in Issue.record("Should not fail") }
         )
 
-        #expect(host == .privateAtomicWPComSite(siteID: siteID, username: username, authToken: authToken))
+        #expect(host == .privateAtomicWPComSite(siteID: siteID, username: username, authToken: authToken, siteHost: nil))
     }
 
     @Test func initializationWithPrivateAtomicWPComSiteWithoutAuthTokenFails() async {

--- a/Tests/KeystoneTests/Tests/Networking/MediaRequestAuthenticatorTests.swift
+++ b/Tests/KeystoneTests/Tests/Networking/MediaRequestAuthenticatorTests.swift
@@ -128,7 +128,7 @@ class MediaRequestAuthenticatorTests: CoreDataTestCase {
 
         authenticator.authenticatedRequest(
             for: url,
-            from: .privateAtomicWPComSite(siteID: siteID, username: username, authToken: authToken),
+            from: .privateAtomicWPComSite(siteID: siteID, username: username, authToken: authToken, siteHost: nil),
             onComplete: { request in
                 expectation.fulfill()
 

--- a/Tests/KeystoneTests/Tests/Networking/MediaRequestAuthenticatorTests.swift
+++ b/Tests/KeystoneTests/Tests/Networking/MediaRequestAuthenticatorTests.swift
@@ -247,4 +247,145 @@ class MediaRequestAuthenticatorTests: CoreDataTestCase {
 
         waitForExpectations(timeout: 0.5)
     }
+
+    func testPrivateAtomicSiteCustomDomainMediaIsRoutedThroughAtomicProxy() {
+        let authToken = "letMeIn!"
+        let siteID = 246482522
+        let url = URL(string: "https://example.com/wp-content/uploads/2026/08/photo.jpg")!
+        let authenticator = MediaRequestAuthenticator()
+        let expectation = self.expectation(description: "Completion closure called")
+
+        authenticator.authenticatedRequest(
+            for: url,
+            from: .privateAtomicWPComSite(siteID: siteID, username: "demouser", authToken: authToken, siteHost: "example.com"),
+            onComplete: { request in
+                expectation.fulfill()
+
+                let components = request.url.flatMap { URLComponents(url: $0, resolvingAgainstBaseURL: true) }
+                XCTAssertEqual(components?.scheme, "https")
+                XCTAssertEqual(components?.host, "public-api.wordpress.com")
+                XCTAssertEqual(components?.path, "/wpcom/v2/sites/\(siteID)/atomic-auth-proxy/file")
+                XCTAssertEqual(components?.queryItems, [URLQueryItem(name: "path", value: "/wp-content/uploads/2026/08/photo.jpg")])
+                XCTAssertEqual(request.allHTTPHeaderFields?["Authorization"], "Bearer \(authToken)")
+        }) { _ in
+            XCTFail("This should not be called")
+        }
+
+        waitForExpectations(timeout: 0.5)
+    }
+
+    func testPrivateAtomicSiteCustomDomainHostMatchIsCaseInsensitive() {
+        let authToken = "letMeIn!"
+        let url = URL(string: "https://Example.com/wp-content/uploads/photo.jpg")!
+        let authenticator = MediaRequestAuthenticator()
+        let expectation = self.expectation(description: "Completion closure called")
+
+        authenticator.authenticatedRequest(
+            for: url,
+            from: .privateAtomicWPComSite(siteID: 246482522, username: "demouser", authToken: authToken, siteHost: "example.com"),
+            onComplete: { request in
+                expectation.fulfill()
+
+                XCTAssertEqual(request.url?.host, "public-api.wordpress.com")
+                XCTAssertEqual(request.allHTTPHeaderFields?["Authorization"], "Bearer \(authToken)")
+        }) { _ in
+            XCTFail("This should not be called")
+        }
+
+        waitForExpectations(timeout: 0.5)
+    }
+
+    func testPrivateAtomicSiteCustomDomainProxyDropsSourceAuthorityFields() {
+        // A crafted source URL must not carry userinfo, a nonstandard port, or a
+        // fragment onto the token-bearing proxy request.
+        let authToken = "letMeIn!"
+        let siteID = 246482522
+        let url = URL(string: "https://user:pass@example.com:8443/wp-content/uploads/photo.jpg#frag")!
+        let authenticator = MediaRequestAuthenticator()
+        let expectation = self.expectation(description: "Completion closure called")
+
+        authenticator.authenticatedRequest(
+            for: url,
+            from: .privateAtomicWPComSite(siteID: siteID, username: "demouser", authToken: authToken, siteHost: "example.com"),
+            onComplete: { request in
+                expectation.fulfill()
+
+                let components = request.url.flatMap { URLComponents(url: $0, resolvingAgainstBaseURL: true) }
+                XCTAssertEqual(components?.scheme, "https")
+                XCTAssertEqual(components?.host, "public-api.wordpress.com")
+                XCTAssertNil(components?.port)
+                XCTAssertNil(components?.user)
+                XCTAssertNil(components?.password)
+                XCTAssertNil(components?.fragment)
+                XCTAssertEqual(components?.path, "/wpcom/v2/sites/\(siteID)/atomic-auth-proxy/file")
+                XCTAssertEqual(components?.queryItems, [URLQueryItem(name: "path", value: "/wp-content/uploads/photo.jpg")])
+                XCTAssertEqual(request.allHTTPHeaderFields?["Authorization"], "Bearer \(authToken)")
+        }) { _ in
+            XCTFail("This should not be called")
+        }
+
+        waitForExpectations(timeout: 0.5)
+    }
+
+    func testPrivateAtomicSiteCustomDomainWithoutWPContentGetsPlainRequest() {
+        let url = URL(string: "https://example.com/files/photo.jpg")!
+        let authenticator = MediaRequestAuthenticator()
+        let expectation = self.expectation(description: "Completion closure called")
+
+        authenticator.authenticatedRequest(
+            for: url,
+            from: .privateAtomicWPComSite(siteID: 246482522, username: "demouser", authToken: "letMeIn!", siteHost: "example.com"),
+            onComplete: { request in
+                expectation.fulfill()
+
+                XCTAssertEqual(request.url, url)
+                XCTAssertNil(request.allHTTPHeaderFields?["Authorization"])
+        }) { _ in
+            XCTFail("This should not be called")
+        }
+
+        waitForExpectations(timeout: 0.5)
+    }
+
+    func testPrivateAtomicSiteDoesNotAuthenticateMismatchedHost() {
+        // The #25863 threat model: a crafted post claiming to be private Atomic must not
+        // get the account token attached to, or its media proxied from, a foreign host.
+        let url = URL(string: "https://attacker.example.com/wp-content/uploads/photo.jpg")!
+        let authenticator = MediaRequestAuthenticator()
+        let expectation = self.expectation(description: "Completion closure called")
+
+        authenticator.authenticatedRequest(
+            for: url,
+            from: .privateAtomicWPComSite(siteID: 246482522, username: "demouser", authToken: "letMeIn!", siteHost: "example.com"),
+            onComplete: { request in
+                expectation.fulfill()
+
+                XCTAssertEqual(request.url, url)
+                XCTAssertNil(request.allHTTPHeaderFields?["Authorization"])
+        }) { _ in
+            XCTFail("This should not be called")
+        }
+
+        waitForExpectations(timeout: 0.5)
+    }
+
+    func testPrivateAtomicSiteWithoutSiteHostGetsPlainRequestForCustomDomain() {
+        let url = URL(string: "https://example.com/wp-content/uploads/photo.jpg")!
+        let authenticator = MediaRequestAuthenticator()
+        let expectation = self.expectation(description: "Completion closure called")
+
+        authenticator.authenticatedRequest(
+            for: url,
+            from: .privateAtomicWPComSite(siteID: 246482522, username: "demouser", authToken: "letMeIn!", siteHost: nil),
+            onComplete: { request in
+                expectation.fulfill()
+
+                XCTAssertEqual(request.url, url)
+                XCTAssertNil(request.allHTTPHeaderFields?["Authorization"])
+        }) { _ in
+            XCTFail("This should not be called")
+        }
+
+        waitForExpectations(timeout: 0.5)
+    }
 }

--- a/Tests/KeystoneTests/Tests/Networking/MediaRequestAuthenticatorTests.swift
+++ b/Tests/KeystoneTests/Tests/Networking/MediaRequestAuthenticatorTests.swift
@@ -221,4 +221,30 @@ class MediaRequestAuthenticatorTests: CoreDataTestCase {
 
         XCTAssertEqual(asset.url, URL(string: "https://example.files.wordpress.com/video.mp4")!)
     }
+
+    func testPrivateAtomicSitePhotonURLIsRoutedThroughAtomicProxy() {
+        let authToken = "letMeIn!"
+        let siteID = 246482522
+        let url = URL(string: "https://i0.wp.com/example.com/wp-content/uploads/2026/08/photo.jpg?ssl=1")!
+        let authenticator = MediaRequestAuthenticator()
+        let expectation = self.expectation(description: "Completion closure called")
+
+        authenticator.authenticatedRequest(
+            for: url,
+            from: .privateAtomicWPComSite(siteID: siteID, username: "demouser", authToken: authToken, siteHost: "example.com"),
+            onComplete: { request in
+                expectation.fulfill()
+
+                let components = request.url.flatMap { URLComponents(url: $0, resolvingAgainstBaseURL: true) }
+                XCTAssertEqual(components?.scheme, "https")
+                XCTAssertEqual(components?.host, "public-api.wordpress.com")
+                XCTAssertEqual(components?.path, "/wpcom/v2/sites/\(siteID)/atomic-auth-proxy/file")
+                XCTAssertEqual(components?.queryItems, [URLQueryItem(name: "path", value: "/wp-content/uploads/2026/08/photo.jpg")])
+                XCTAssertEqual(request.allHTTPHeaderFields?["Authorization"], "Bearer \(authToken)")
+        }) { _ in
+            XCTFail("This should not be called")
+        }
+
+        waitForExpectations(timeout: 0.5)
+    }
 }

--- a/WordPress/Classes/Networking/MediaHost+Extensions.swift
+++ b/WordPress/Classes/Networking/MediaHost+Extensions.swift
@@ -18,6 +18,7 @@ extension MediaHost {
             isAtomic: blog.isAtomic,
             siteID: blog.dotComID?.intValue,
             username: blog.effectiveUsername,
+            siteHost: URL(string: blog.url ?? "")?.host,
             authToken: blog.account?.authToken,
             failure: { error in
                 WordPressAppDelegate.crashLogging?.logError(error)
@@ -45,6 +46,7 @@ extension MediaHost {
             isAtomic: post.isBlogAtomic,
             siteID: post.siteID?.intValue,
             username: username,
+            siteHost: URL(string: post.blogURL ?? "")?.host,
             authToken: authToken,
             failure: { error in
                 WordPressAppDelegate.crashLogging?.logError(error)

--- a/WordPress/Classes/Networking/MediaHost.swift
+++ b/WordPress/Classes/Networking/MediaHost.swift
@@ -9,7 +9,7 @@ public enum MediaHost: Equatable, Sendable, MediaHostProtocol {
     case publicWPComSite
     case privateSelfHostedSite
     case privateWPComSite(authToken: String)
-    case privateAtomicWPComSite(siteID: Int, username: String, authToken: String)
+    case privateAtomicWPComSite(siteID: Int, username: String, authToken: String, siteHost: String?)
 
     public enum Error: Swift.Error {
         case wpComWithoutSiteID
@@ -23,6 +23,7 @@ public enum MediaHost: Equatable, Sendable, MediaHostProtocol {
         isAtomic: Bool,
         siteID: Int?,
         username: String?,
+        siteHost: String? = nil,
         authToken: @autoclosure () -> String?,
         failure: (Error) -> Void) {
 
@@ -90,7 +91,7 @@ public enum MediaHost: Equatable, Sendable, MediaHostProtocol {
             return
         }
 
-        self = .privateAtomicWPComSite(siteID: siteID, username: username, authToken: authToken)
+        self = .privateAtomicWPComSite(siteID: siteID, username: username, authToken: authToken, siteHost: siteHost)
     }
 
     // MARK: - MediaHostProtocol

--- a/WordPress/Classes/Networking/MediaRequestAuthenticator.swift
+++ b/WordPress/Classes/Networking/MediaRequestAuthenticator.swift
@@ -247,30 +247,47 @@ struct MediaRequestAuthenticator {
         onComplete provide: @escaping (URLRequest) -> (),
         onFailure fail: @escaping (Error) -> ()) {
 
-        guard var components = URLComponents(url: url, resolvingAgainstBaseURL: true) else {
-            fail(Error.cannotBreakDownURLIntoComponents(url: url))
+        guard let request = atomicProxyRequest(for: url, siteID: siteID, authToken: authToken) else {
+            if let components = URLComponents(url: url, resolvingAgainstBaseURL: true) {
+                fail(Error.cannotFindWPContentInPhotonPath(components: components))
+            } else {
+                fail(Error.cannotBreakDownURLIntoComponents(url: url))
+            }
             return
         }
 
-        guard let wpContentRange = components.path.range(of: "/wp-content") else {
-            fail(Error.cannotFindWPContentInPhotonPath(components: components))
-            return
+        provide(request)
+    }
+
+    /// Builds a token-authenticated atomic-auth-proxy request for a media file under the
+    /// site's wp-content directory. The token is attached to public-api.wordpress.com only,
+    /// never to the original host, so this is safe for URLs on hosts outside the WP.com
+    /// allowlist. Returns nil when the URL cannot be proxied (no /wp-content path segment,
+    /// or the URL cannot be decomposed).
+    private func atomicProxyRequest(for url: URL, siteID: Int, authToken: String) -> URLRequest? {
+        guard let sourceComponents = URLComponents(url: url, resolvingAgainstBaseURL: true),
+              let wpContentRange = sourceComponents.path.range(of: "/wp-content") else {
+            return nil
         }
 
-        let contentPath = String(components.path[wpContentRange.lowerBound ..< components.path.endIndex])
+        let contentPath = String(sourceComponents.path[wpContentRange.lowerBound...])
 
+        // Build the proxy URL from scratch rather than mutating the source URL's
+        // components. The source URL is server-supplied and potentially
+        // attacker-influenced; reusing its components would carry over authority
+        // fields (userinfo, port, fragment) onto the request that attaches the
+        // Bearer token. Only the wp-content path is taken from the source.
+        var components = URLComponents()
         components.scheme = secureHttpScheme
         components.host = wpComApiHost
         components.path = "/wpcom/v2/sites/\(siteID)/atomic-auth-proxy/file"
         components.queryItems = [URLQueryItem(name: "path", value: contentPath)]
 
         guard let finalURL = components.url else {
-            fail(Error.cannotCreateAtomicProxyURL(components: components))
-            return
+            return nil
         }
 
-        let request = tokenAuthenticatedWPComRequest(for: finalURL, authToken: authToken)
-        provide(request)
+        return tokenAuthenticatedWPComRequest(for: finalURL, authToken: authToken)
     }
 
     // MARK: - Adding the Auth Token

--- a/WordPress/Classes/Networking/MediaRequestAuthenticator.swift
+++ b/WordPress/Classes/Networking/MediaRequestAuthenticator.swift
@@ -63,6 +63,20 @@ struct MediaRequestAuthenticator {
         onComplete provide: @escaping (URLRequest) -> (),
         onFailure fail: @escaping (Error) -> ()) {
 
+        // A private Atomic site serves its media from its own mapped domain, which the
+        // WP.com allowlist below rightly refuses to send the account token to. Route those
+        // requests through the atomic-auth-proxy instead: the token is only ever attached
+        // to public-api.wordpress.com, and WP.com decides whether the viewer can access
+        // the file.
+        if case .privateAtomicWPComSite(let siteID, _, let authToken, let siteHost) = host,
+           let siteHost,
+           !url.isWordPressComHost,
+           url.host?.lowercased() == siteHost.lowercased(),
+           let request = atomicProxyRequest(for: url, siteID: siteID, authToken: authToken) {
+            provide(request)
+            return
+        }
+
         // We want to make sure we're never sending credentials
         // to a URL that's not safe.
         guard url.isWordPressComHost else {

--- a/WordPress/Classes/Networking/MediaRequestAuthenticator.swift
+++ b/WordPress/Classes/Networking/MediaRequestAuthenticator.swift
@@ -86,7 +86,7 @@ struct MediaRequestAuthenticator {
                 authToken: authToken,
                 onComplete: provide,
                 onFailure: fail)
-        case .privateAtomicWPComSite(let siteID, let username, let authToken):
+        case .privateAtomicWPComSite(let siteID, let username, let authToken, _):
             if url.isPhoton() {
                 authenticatedRequestForPrivateAtomicSiteThroughPhoton(
                     for: url,
@@ -112,7 +112,7 @@ struct MediaRequestAuthenticator {
         case .publicWPComSite: AVURLAsset(url: url)
         case .privateSelfHostedSite: AVURLAsset(url: url)
         case .privateWPComSite(let authToken): authenticatedAsset(for: url, authToken: authToken)
-        case .privateAtomicWPComSite(_, _, let authToken): authenticatedAsset(for: url, authToken: authToken)
+        case .privateAtomicWPComSite(_, _, let authToken, _): authenticatedAsset(for: url, authToken: authToken)
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/Cards/ReaderPostCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Cards/ReaderPostCell.swift
@@ -321,7 +321,7 @@ private final class ReaderPostCellView: UIView {
         imageView.isHidden = viewModel.imageURL == nil
 
         if let imageURL = viewModel.imageURL {
-            imageView.setImage(with: imageURL, size: coverSize)
+            imageView.setImage(with: imageURL, host: viewModel.imageHost, size: coverSize)
         }
 
         if viewModel.isSeen == true {

--- a/WordPress/Classes/ViewRelated/Reader/Cards/ReaderPostCellViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Cards/ReaderPostCellViewModel.swift
@@ -13,6 +13,7 @@ final class ReaderPostCellViewModel {
     let details: String
     let isSeen: Bool?
     let imageURL: URL?
+    let imageHost: MediaHostProtocol?
 
     // Footer (Buttons)
     private(set) var isToolbarHidden = false
@@ -41,6 +42,7 @@ final class ReaderPostCellViewModel {
         self.details = post.contentPreviewForDisplay() ?? ""
         self.isSeen = post.isSeenSupported ? post.isSeen : nil
         self.imageURL = post.featuredImageURLForDisplay() ?? post.pathForDisplayImage.flatMap(URL.init)
+        self.imageHost = MediaHost(post)
 
         self.toolbar = ReaderPostToolbarViewModel.make(post: post)
         if isP2 && post.primaryTag == "afk" {
@@ -68,6 +70,7 @@ final class ReaderPostCellViewModel {
         self.author = "WordPress Mobile Apps"
         self.time = "9d ago"
         self.isSeen = nil
+        self.imageHost = nil
         self.title = "Discovering the Wonders of the Wild"
         self.details = "Lorem ipsum dolor sit amet. Non omnis quia et natus voluptatum et eligendi voluptate vel iusto fuga sit repellendus molestiae aut voluptatem blanditiis ad neque sapiente. Id galisum distinctio quo enim aperiam non veritatis vitae et ducimus rerum."
         self.imageURL = URL(string: "https://picsum.photos/1260/630.jpg")

--- a/WordPress/Classes/ViewRelated/Reader/Controllers/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Controllers/ReaderStreamViewController.swift
@@ -1711,10 +1711,10 @@ extension ReaderStreamViewController: UITableViewDataSourcePrefetching {
     private func makeImageRequests(for indexPaths: [IndexPath]) -> [ImageRequest] {
         let targetSize = coverSize
         return indexPaths.compactMap {
-            guard let imageURL = getPost(at: $0)?.featuredImageURLForDisplay() else {
+            guard let post = getPost(at: $0), let imageURL = post.featuredImageURLForDisplay() else {
                 return nil
             }
-            return ImageRequest(url: imageURL, options: ImageRequestOptions(size: targetSize))
+            return ImageRequest(url: imageURL, host: MediaHost(post), options: ImageRequestOptions(size: targetSize))
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -577,6 +577,7 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
             authorAvatarURL: post.avatarURLForDisplay(),
             dateString: post.dateForDisplay()?.mediumStringWithTime(),
             featuredImageURL: featuredImageURL,
+            featuredImageHost: MediaHost(post),
             excerpt: cachedExcerpt
         ))
         updateHeader()


### PR DESCRIPTION
## Description

A private Atomic site's featured image failed to load in the Reader detail header and lightbox when the media is served from the site's own mapped custom domain rather than a `*.wordpress.com` host. #25863 restricts WP.com media authentication to WP.com hosts, so `MediaRequestAuthenticator` sent a plain, unauthenticated request for the custom-domain URL and the image came back empty.

This PR:
1. Passes the post's `MediaHost` through every Reader image producer (detail header, feed cover, and prefetch), so they authenticate identically to the lightbox.
2. Adds a branch in `MediaRequestAuthenticator` that routes a private Atomic site's own-domain `/wp-content` media through the WP.com atomic-auth-proxy (`public-api.wordpress.com/wpcom/v2/sites/<id>/atomic-auth-proxy/file`).

## Testing instructions

Prepare an atomic site with a custom domain. Create a post with featured image. Open the post on a fresh install. The featured image should load in the detail header, and tapping it should load the full image in the lightbox.