### PR TITLE
Convert <br> tags to spaces in API-provided excerpts

### DIFF
--- a/Modules/Sources/WordPressKitModels/NSString+Summary.swift
+++ b/Modules/Sources/WordPressKitModels/NSString+Summary.swift
@@ -18,4 +18,11 @@ extension NSString {
     public func wpkit_makePlainText() -> String {
         makePlainText()
     }
+
+    /// Converts an HTML excerpt into single-line plain text, turning `<br>`
+    /// tags into spaces so adjacent words don't run together.
+    @objc
+    public func wpkit_makeSingleLinePlainText() -> String {
+        GutenbergExcerptGenerator.singleLinePlainText(from: (self as String))
+    }
 }

--- a/Modules/Sources/WordPressKitObjC/RemoteReaderPost.m
+++ b/Modules/Sources/WordPressKitObjC/RemoteReaderPost.m
@@ -627,7 +627,7 @@ static const NSUInteger ReaderPostTitleLength = 30;
 - (NSString *)postSummaryFromPostDictionary:(NSDictionary *)dict orPostContent:(NSString *)content {
     NSString *summary = [self stringOrEmptyString:[dict stringForKey:PostRESTKeyExcerpt]];
     summary = [self formatSummary:summary];
-    if (!summary) {
+    if (summary.length == 0) {
         summary = [self createSummaryFromContent:content];
     }
     return summary;

--- a/Modules/Sources/WordPressKitObjC/RemoteReaderPost.m
+++ b/Modules/Sources/WordPressKitObjC/RemoteReaderPost.m
@@ -670,14 +670,14 @@ static const NSUInteger ReaderPostTitleLength = 30;
 
 /**
  Formats a post's summary.  The excerpts provided by the REST API contain HTML and have some extra content appened to the end.
- HTML is stripped and the extra bit is removed.
+ HTML is stripped and the extra bit is removed. `<br>` tags become spaces so adjacent words don't run together.
 
  @param summary The summary to format.
  @return The formatted summary.
  */
 - (NSString *)formatSummary:(NSString *)summary
 {
-    summary = [self makePlainText:summary];
+    summary = [summary wpkit_makeSingleLinePlainText];
 
     NSString *continueReading = NSLocalizedString(@"Continue reading", @"Part of a prompt suggesting that there is more content for the user to read.");
     continueReading = [NSString stringWithFormat:@"%@ →", continueReading];

--- a/Modules/Sources/WordPressShared/Utility/GutenbergExcerptGenerator.swift
+++ b/Modules/Sources/WordPressShared/Utility/GutenbergExcerptGenerator.swift
@@ -27,19 +27,7 @@ public struct GutenbergExcerptGenerator {
         }
 
         let paragraph = String(content[paragraphTag.upperBound..<pEnd.lowerBound])
-
-        // Convert `<br>` runs to spaces so words don't run together, then remove
-        // any remaining tags and shortcodes.
-        let withoutBreaks = replacingMatches(of: lineBreakRegex, in: paragraph, withTemplate: " ")
-        let stripped = replacingMatches(of: tagOrShortcodeRegex, in: withoutBreaks, withTemplate: "")
-
-        // Decode entities and collapse every whitespace run into a single space,
-        // yielding single-line plain text.
-        let text = stripped
-            .stringByDecodingXMLCharacters()
-            .components(separatedBy: collapsibleWhitespace)
-            .filter { !$0.isEmpty }
-            .joined(separator: " ")
+        let text = singleLinePlainText(from: paragraph)
 
         // Truncate if needed.
         if text.count <= maxLength {
@@ -51,6 +39,25 @@ public struct GutenbergExcerptGenerator {
             return String(truncated[..<lastSpace]) + "…"
         }
         return truncated + "…"
+    }
+
+    /// Converts HTML into single-line plain text. Unlike a plain tag stripper,
+    /// `<br>` runs become spaces so adjacent words don't run together.
+    /// Remaining tags and shortcodes are removed, entities are decoded, and
+    /// whitespace runs collapse into single spaces.
+    public static func singleLinePlainText(from html: String) -> String {
+        // Convert `<br>` runs to spaces so words don't run together, then remove
+        // any remaining tags and shortcodes.
+        let withoutBreaks = replacingMatches(of: lineBreakRegex, in: html, withTemplate: " ")
+        let stripped = replacingMatches(of: tagOrShortcodeRegex, in: withoutBreaks, withTemplate: "")
+
+        // Decode entities and collapse every whitespace run into a single space,
+        // yielding single-line plain text.
+        return stripped
+            .stringByDecodingXMLCharacters()
+            .components(separatedBy: collapsibleWhitespace)
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
     }
 
     /// Returns the range of the first match of `regex` in `string`, or `nil`.

--- a/Tests/WordPressKitTests/WordPressKitTests/Tests/RemoteReaderPostTests.m
+++ b/Tests/WordPressKitTests/WordPressKitTests/Tests/RemoteReaderPostTests.m
@@ -112,6 +112,14 @@
     XCTAssertEqualObjects(summary, @"Yes, look behind", @"A <br> in the API excerpt should become a space instead of running words together.");
 }
 
+- (void)testSummaryFallsBackToContentWhenExcerptIsEmpty {
+    RemoteReaderPost *remoteReaderPost = [RemoteReaderPost alloc];
+    NSDictionary *dict = @{@"excerpt": @""};
+    NSString *content = @"<p>Generated from the post content.</p>";
+    NSString *summary = [remoteReaderPost postSummaryFromPostDictionary:dict orPostContent:content];
+    XCTAssertEqualObjects(summary, @"Generated from the post content.", @"An empty API excerpt should fall back to a summary generated from the post content.");
+}
+
 - (void)testSiteIsAtomic {
     NSString *key = @"site_is_atomic";
 

--- a/Tests/WordPressKitTests/WordPressKitTests/Tests/RemoteReaderPostTests.m
+++ b/Tests/WordPressKitTests/WordPressKitTests/Tests/RemoteReaderPostTests.m
@@ -105,6 +105,13 @@
     XCTAssertTrue([str isEqualToString:sanatizedStr], @"The post summary was not plain text.");
 }
 
+- (void)testSummaryConvertsLineBreaksToSpaces {
+    RemoteReaderPost *remoteReaderPost = [RemoteReaderPost alloc];
+    NSDictionary *dict = @{@"excerpt": @"<p>Yes,<br>look behind</p>"};
+    NSString *summary = [remoteReaderPost postSummaryFromPostDictionary:dict orPostContent:@""];
+    XCTAssertEqualObjects(summary, @"Yes, look behind", @"A <br> in the API excerpt should become a space instead of running words together.");
+}
+
 - (void)testSiteIsAtomic {
     NSString *key = @"site_is_atomic";
 


### PR DESCRIPTION
## Description

Relates to https://github.com/wordpress-mobile/WordPress-iOS/pull/25392. Reader posts almost always carry an API-provided excerpt, and `formatSummary` stripped its HTML with a plain tag stripper, so `<br>`-separated words still ran together in the feed.

To reproduce the issue: publish a post with an author-set excerpt containing a `<br>` tag (e.g. `Yes,<br>look behind`), then view it in the Reader feed. The cell shows "Yes,look behind". This only reproduces with author-set excerpts; WordPress.com strips `<br>` server-side when it auto-generates an excerpt from post content, which a client-side fix can't repair.

| Before | After |
|---|---|
| <img width="400" src="https://github.com/user-attachments/assets/725f946d-b454-43a1-80e7-e18da45a4b45" /> | <img width="400" src="https://github.com/user-attachments/assets/2f8159fc-38ee-47e8-813e-d521c0f1ca59" /> |