### PR TITLE
Fix duplicate domain navigation in Jetpack

### DIFF
--- a/Tests/KeystoneTests/Tests/Features/Domains/DomainDetailsWebViewControllerTests.swift
+++ b/Tests/KeystoneTests/Tests/Features/Domains/DomainDetailsWebViewControllerTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import Testing
 
 @testable import WordPress
 
@@ -54,7 +55,56 @@ final class DomainDetailsWebViewControllerTests: XCTestCase {
         siteSlug: String = Constants.siteSlug,
         viewSlug: String = Constants.viewSlug
     ) throws -> String {
-        let url = "\(Constants.domainManagementBase)/\(domain)/\(viewSlug)/\(siteSlug)".addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)
+        let url = "\(Constants.domainManagementBase)/\(domain)/\(viewSlug)/\(siteSlug)"
+            .addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)
         return try XCTUnwrap(url)
+    }
+}
+
+@MainActor
+struct DomainDetailsNavigationTests {
+
+    @Test func navigationPolicyDistinguishesRedirectsFromLinks() throws {
+        let controller = DomainDetailsWebViewController(
+            domain: "example.com",
+            siteSlug: "example.wordpress.com",
+            type: .mapped
+        )
+        let redirectURL = try #require(
+            URL(string: "https://wordpress.com/domains/manage/all/example.com/edit/example.wordpress.com?redirected=1")
+        )
+        var redirectRequest = URLRequest(url: redirectURL)
+        redirectRequest.mainDocumentURL = redirectURL
+        let externalURLHandler = ExternalURLHandlerSpy()
+
+        let redirectPolicy = controller.linkBehavior.handle(
+            request: redirectRequest,
+            with: .other,
+            externalURLHandler: externalURLHandler
+        )
+
+        #expect(redirectPolicy == .allow)
+        #expect(externalURLHandler.openedURL == nil)
+
+        let linkURL = try #require(URL(string: "https://wordpress.com/support"))
+        var linkRequest = URLRequest(url: linkURL)
+        linkRequest.mainDocumentURL = linkURL
+
+        let linkPolicy = controller.linkBehavior.handle(
+            request: linkRequest,
+            with: .linkActivated,
+            externalURLHandler: externalURLHandler
+        )
+
+        #expect(linkPolicy == .cancel)
+        #expect(externalURLHandler.openedURL == linkURL)
+    }
+}
+
+private final class ExternalURLHandlerSpy: ExternalURLHandler {
+    private(set) var openedURL: URL?
+
+    func open(_ url: URL) {
+        openedURL = url
     }
 }

--- a/Tests/KeystoneTests/Tests/Features/Domains/DomainDetailsWebViewControllerTests.swift
+++ b/Tests/KeystoneTests/Tests/Features/Domains/DomainDetailsWebViewControllerTests.swift
@@ -70,12 +70,35 @@ struct DomainDetailsNavigationTests {
             siteSlug: "example.wordpress.com",
             type: .mapped
         )
+        let domainDetailsURL = try #require(controller.url)
         let redirectURL = try #require(
             URL(string: "https://wordpress.com/domains/manage/all/example.com/edit/example.wordpress.com?redirected=1")
         )
         var redirectRequest = URLRequest(url: redirectURL)
         redirectRequest.mainDocumentURL = redirectURL
         let externalURLHandler = ExternalURLHandlerSpy()
+
+        #expect(
+            DomainDetailsWebViewController.shouldAllowNavigation(
+                to: redirectURL,
+                domainDetailsURL: domainDetailsURL,
+                isLoading: true
+            )
+        )
+        #expect(
+            DomainDetailsWebViewController.shouldAllowNavigation(
+                to: domainDetailsURL,
+                domainDetailsURL: domainDetailsURL,
+                isLoading: false
+            )
+        )
+        #expect(
+            !DomainDetailsWebViewController.shouldAllowNavigation(
+                to: redirectURL,
+                domainDetailsURL: domainDetailsURL,
+                isLoading: false
+            )
+        )
 
         let redirectPolicy = controller.linkBehavior.handle(
             request: redirectRequest,

--- a/WordPress/Classes/ViewRelated/Me/Domain Details/DomainDetailsWebViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/Domain Details/DomainDetailsWebViewController.swift
@@ -13,21 +13,17 @@ final class DomainDetailsWebViewController: WebKitViewController {
         static let manageAllDomainsPath = "\(domainsPath)/manage/all"
     }
 
-    // MARK: - Properties
-
-    private let domain: String
-
-    private var observation: NSKeyValueObservation?
-
     // MARK: - Init
 
     init(domain: String, siteSlug: String, type: DomainType, analyticsSource: String? = nil) {
-        self.domain = domain
         let url = Self.wpcomDetailsURL(domain: domain, siteSlug: siteSlug, type: type)
         let configuration = WebViewControllerConfiguration(url: url)
         configuration.customTitle = domain
         configuration.analyticsSource = analyticsSource
         configuration.secureInteraction = true
+        if let url {
+            configuration.linkBehavior = .urlOnly(url)
+        }
         configuration.authenticateWithDefaultAccount()
         super.init(configuration: configuration)
     }
@@ -40,23 +36,7 @@ final class DomainDetailsWebViewController: WebKitViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        self.observeURL()
         self.trackWebViewShownEvent(url: url)
-    }
-
-    // MARK: - Handling URL Changes
-
-    private func observeURL() {
-        self.observation = webView.observe(\.url) { [weak self] webView, _ in
-            guard let self, let url = webView.url else {
-                return
-            }
-            if !self.shouldAllowNavigation(for: url) {
-                // Open URL in device browser then go back to Domain Management page.
-                self.open(url)
-                self.goBack()
-            }
-        }
     }
 
     // MARK: - Navigation
@@ -82,14 +62,6 @@ final class DomainDetailsWebViewController: WebKitViewController {
     private func trackWebViewShownEvent(url: URL?) {
         let properties = ["url": url?.absoluteString ?? ""]
         WPAnalytics.track(.allDomainsDomainDetailsWebViewShown, properties: properties)
-    }
-
-    private func shouldAllowNavigation(for url: URL) -> Bool {
-        return url.absoluteString == self.url?.absoluteString
-    }
-
-    private func open(_ url: URL) {
-        UIApplication.shared.open(url)
     }
 
     private static func wpcomDetailsURL(domain: String, siteSlug: String, type: DomainType) -> URL? {

--- a/WordPress/Classes/ViewRelated/Me/Domain Details/DomainDetailsWebViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/Domain Details/DomainDetailsWebViewController.swift
@@ -13,6 +13,10 @@ final class DomainDetailsWebViewController: WebKitViewController {
         static let manageAllDomainsPath = "\(domainsPath)/manage/all"
     }
 
+    // MARK: - Properties
+
+    private var observation: NSKeyValueObservation?
+
     // MARK: - Init
 
     init(domain: String, siteSlug: String, type: DomainType, analyticsSource: String? = nil) {
@@ -36,7 +40,27 @@ final class DomainDetailsWebViewController: WebKitViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        self.observeURL()
         self.trackWebViewShownEvent(url: url)
+    }
+
+    // MARK: - Handling URL Changes
+
+    private func observeURL() {
+        self.observation = webView.observe(\.url) { [weak self] webView, _ in
+            guard let self, let url = webView.url else {
+                return
+            }
+            if !Self.shouldAllowNavigation(
+                to: url,
+                domainDetailsURL: self.url,
+                isLoading: webView.isLoading
+            ) {
+                // Open URL in device browser then go back to Domain Management page.
+                UIApplication.shared.open(url)
+                self.goBack()
+            }
+        }
     }
 
     // MARK: - Navigation
@@ -62,6 +86,14 @@ final class DomainDetailsWebViewController: WebKitViewController {
     private func trackWebViewShownEvent(url: URL?) {
         let properties = ["url": url?.absoluteString ?? ""]
         WPAnalytics.track(.allDomainsDomainDetailsWebViewShown, properties: properties)
+    }
+
+    static func shouldAllowNavigation(
+        to url: URL,
+        domainDetailsURL: URL?,
+        isLoading: Bool
+    ) -> Bool {
+        isLoading || url == domainDetailsURL
     }
 
     private static func wpcomDetailsURL(domain: String, siteSlug: String, type: DomainType) -> URL? {


### PR DESCRIPTION
## Description

Fixes CMM-2221.

### Problem

Opening a domain from `My Site > Domains` presented `DomainDetailsWebViewController`, but one tap also opened Safari with the same management page.

The controller observes changes to `WKWebView.url` so JavaScript-driven actions such as Payment Details can open outside the app. During the initial page load, WordPress.com also changes the web view URL as part of its redirect flow. The observer treated that automatic transition like post-load navigation, opened it in Safari, and called `goBack()`, causing the duplicate navigation.

The first revision replaced URL observation with `LinkBehavior.urlOnly`. Review feedback identified that this fixed the initial redirect but regressed actions that change the URL through JavaScript without triggering a navigation delegate callback.

### Change

This revision keeps both navigation mechanisms and gives each one a specific job:

- `LinkBehavior.urlOnly` continues to open normal user-activated links externally.
- URL observation is restored for JavaScript-driven URL changes.
- URL changes are allowed while `webView.isLoading`, which covers the automatic WordPress.com bootstrap and redirect flow.
- Once loading has finished, a URL different from the original Domain Details URL opens in Safari and the embedded web view returns to Domain Management.

This preserves the intended external navigation behavior without reopening Safari during the initial Domain Details load.

### Regression coverage

`DomainDetailsNavigationTests.navigationPolicyDistinguishesRedirectsFromLinks` verifies that:

- A changed URL is allowed during an active page load.
- The original Domain Details URL remains allowed after loading.
- A changed URL after loading is rejected by the embedded-navigation policy.
- A non-link navigation remains available for URL observation to handle.
- A normal activated link still opens through the external URL handler.

Expected behavior:

| Action | Result |
| --- | --- |
| Tap a domain | Domain Details open once, inside Jetpack |
| Trigger a post-load JavaScript URL change | The destination opens in Safari |
| Tap the `Renews` link | The renewal page opens in Safari |

Domain expiry and renewal-date behavior are outside this change.

## Testing instructions

1. Build and sign in to Jetpack with a WordPress.com account that has a domain.
2. Open `My Site > Domains`.
3. Tap a domain once.
4. Confirm Domain Details open inside Jetpack and Safari does not open.
5. Tap an external action such as Payment Details or `Renews`.
6. Confirm the destination opens in Safari and Domain Details remain available in Jetpack.

Local verification completed:

- Six focused domain tests passed, including the updated navigation-policy regression test.
- Targeted SwiftLint passed for both changed files.
- The Jetpack simulator build passed.
- Manual verification confirmed Domain Details remained inside Jetpack without opening Safari.
- Manual verification confirmed the visible renewal link opened in Safari.
- Payment Details was not available on either local test domain, so that exact control could not be exercised manually; the post-load JavaScript URL-change path is covered by the focused policy test.