### PR TITLE
Analytics: Attach the selected site to My Site dashboard card impressions

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Blaze/DashboardBlazeCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Blaze/DashboardBlazeCardCell.swift
@@ -31,25 +31,29 @@ final class DashboardBlazeCardCell: DashboardCollectionViewCell {
         switch viewModel.state {
         case .promo:
             let cardView = DashboardBlazePromoCardView(.make(with: blog, viewController: viewController))
-            self.setCardView(cardView, subtype: .promo)
+            self.setCardView(cardView, subtype: .promo, blog: blog)
         case .campaign(let campaign):
             let cardView = DashboardBlazeCampaignsCardView()
             cardView.configure(blog: blog, viewController: viewController, campaign: campaign)
-            self.setCardView(cardView, subtype: .campaigns)
+            self.setCardView(cardView, subtype: .campaigns, blog: blog)
         }
     }
 
-    private func setCardView(_ cardView: UIView, subtype: DashboardBlazeCardSubtype) {
+    private func setCardView(_ cardView: UIView, subtype: DashboardBlazeCardSubtype, blog: Blog) {
         contentView.subviews.forEach { $0.removeFromSuperview() }
 
         cardView.translatesAutoresizingMaskIntoConstraints = false
         contentView.addSubview(cardView)
         contentView.pinSubviewToAllEdges(cardView, priority: UILayoutPriority(999))
 
-        BlogDashboardAnalytics.shared.track(.dashboardCardShown, properties: [
-            "type": DashboardCard.blaze.rawValue,
-            "sub_type": subtype.rawValue
-        ])
+        BlogDashboardAnalytics.shared.track(
+            .dashboardCardShown,
+            properties: [
+                "type": DashboardCard.blaze.rawValue,
+                "sub_type": subtype.rawValue
+            ],
+            blog: blog
+        )
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/DashboardPostsListCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/DashboardPostsListCardCell.swift
@@ -74,10 +74,6 @@ class DashboardPostsListCardCell: UICollectionViewCell, Reusable {
         contentView.addSubview(frameView)
         contentView.pinSubviewToAllEdges(frameView, priority: UILayoutPriority(999))
     }
-
-    func trackPostsDisplayed() {
-        BlogDashboardAnalytics.shared.track(.dashboardCardShown, properties: ["type": "post", "sub_type": status.rawValue])
-    }
 }
 
 // MARK: BlogDashboardCardConfigurable

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/PostsCardViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/PostsCardViewModel.swift
@@ -262,9 +262,9 @@ private extension PostsCardViewModel {
     func trackCardDisplayedIfNeeded() {
         switch currentState {
         case .posts:
-            BlogDashboardAnalytics.shared.track(.dashboardCardShown, properties: ["type": "post", "sub_type": status.rawValue])
+            BlogDashboardAnalytics.shared.track(.dashboardCardShown, properties: ["type": "post", "sub_type": status.rawValue], blog: blog)
         case .error:
-            BlogDashboardAnalytics.shared.track(.dashboardCardShown, properties: ["type": "post", "sub_type": "error"])
+            BlogDashboardAnalytics.shared.track(.dashboardCardShown, properties: ["type": "post", "sub_type": "error"], blog: blog)
         case .loading:
             return
         }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Helpers/BlogDashboardAnalytics.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Helpers/BlogDashboardAnalytics.swift
@@ -17,19 +17,18 @@ class BlogDashboardAnalytics {
     /// This will track the given event and properties given they haven't been
     /// triggered before.
     ///
+    /// The My Site dashboard always shows exactly one site, so every card-shown
+    /// event carries that site. `blog` is required so the site identifier is
+    /// always attached and no future card can regress by omitting it.
+    ///
     /// - Parameters:
     ///   - event: a `String` that represents the event name
     ///   - properties: a `Hash` that represents the properties
-    ///   - blog: a `Blog` asssociated with the event
-    func track(_ event: WPAnalyticsEvent, properties: [AnyHashable: String] = [:], blog: Blog? = nil) {
+    ///   - blog: the `Blog` whose dashboard is being shown
+    func track(_ event: WPAnalyticsEvent, properties: [AnyHashable: String] = [:], blog: Blog) {
         if !fired.contains(where: { $0 == (event, properties) }) {
             fired.append((event, properties))
-
-            if let blog {
-                WPAnalytics.track(event, properties: properties, blog: blog)
-            } else {
-                WPAnalytics.track(event, properties: properties)
-            }
+            WPAnalytics.track(event, properties: properties, blog: blog)
         }
     }
 


### PR DESCRIPTION
The My Site dashboard shows exactly one site, but `my_site_dashboard_card_shown` fired without a `blog_id` for two of its cards — posts and Blaze — so Data Science measured the site present on only **56.1%** of `jpios_my_site_dashboard_card_shown` rows over a 14-day window (6,510,007 fires). This attaches the site to every card's impression.

## Root cause

`BlogDashboardAnalytics.track(_:properties:blog:)` took `blog` as an optional defaulting to `nil`, and only routed through the site-attaching path when a blog was supplied:

```swift
if let blog {
    WPAnalytics.track(event, properties: properties, blog: blog)  // sets blog_id
} else {
    WPAnalytics.track(event, properties: properties)              // no blog_id
}
```

Of the six cards that fire the event, three passed `blog` (`activity_log`, `todays_stats`, `pages`) and three did not: `post` — whose two sub-types are the highest-volume rows — and `blaze`. The optional made it possible to add a card and ship it without a site, which is how coverage drifted to ~56%.

## Changes

- **Require `blog`.** `BlogDashboardAnalytics.track` now takes a non-optional `Blog` and always calls `WPAnalytics.track(_:properties:blog:)`, which sets `blog_id` to the site's `dotComID`. The dashboard always has one site, so the type system now guarantees every impression carries it and no future card can drop it. This mirrors Android's `trackWithSiteDetails(...)`.
- **`PostsCardViewModel`** — pass the view model's `blog` for the `.posts` and `.error` sub-types.
- **`DashboardBlazeCardCell`** — thread the already-unwrapped `blog` from `update(with:)` into the card-shown call.
- **`DashboardPostsListCardCell`** — delete `trackPostsDisplayed()`. It fired the same event without a site but had no callers; the live posts impression is `PostsCardViewModel.trackCardDisplayedIfNeeded()`. Removing it closes a path that would double-count if it were ever wired up.

The three cards that already passed `blog` are unchanged.

## Not in this PR

- **Self-hosted sites.** `blog_id` comes from `blog.dotComID`, which is `nil` for self-hosted sites, so those impressions still carry no site — the same behavior as the three already-correct cards, and the reason the target is ~95% rather than 100%.
- **Event registration** (Part 2 of CMM-2213) is a Tracks-side task, not an app change.
- `dynamic_dashboard_card_shown` and `free_to_paid_plan_dashboard_card_shown` are separate events.

## Test plan

- [x] WordPress scheme compiles clean — cold build, 0 errors.
- [ ] Sign in to a WordPress.com or Jetpack site and open the My Site tab. In the Xcode console, each card logs `🔵 Tracked: my_site_dashboard_card_shown <blog_id: <site id>, sub_type: …, type: …>` — confirm the `post` and `blaze` lines now include `blog_id` (they previously had none).
- [ ] After deploy, re-run the CMM-2213 verification query and confirm `blog_id_pct` for `jpios_my_site_dashboard_card_shown` and `wpios_my_site_dashboard_card_shown` is at or above 95.

## Related

- Android fix: wordpress-mobile/WordPress-Android#23186
- CMM-2213
