### PR TITLE
Set up a8c-secrets identities

### DIFF
--- a/.a8c-secrets/keys.pub
+++ b/.a8c-secrets/keys.pub
@@ -1,0 +1,4 @@
+# dev
+age1srcq3hl92ym9jk3ezj5prwhche3w8szc0cssy8t7afrkjmtkxu2qkjsdfn
+# ci
+age1a7xcr6qzwnzgcxq95sq33p58xdzsmful8w7mp2zktvuy5434yuss9rmv8f

--- a/.a8c-secrets/repo-id
+++ b/.a8c-secrets/repo-id
@@ -1,0 +1,1 @@
+wordpress-ios@github.com@wordpress-mobile


### PR DESCRIPTION
## Description

Groundwork extracted from #25772 ([AINFRA-1538](https://linear.app/a8c/issue/AINFRA-1538)) so the a8c-secrets migration lands as small, independently reviewable pieces.

Adds the repository's `a8c-secrets` identity: the repo id and the public keys authorised to encrypt for it. Nothing reads these files yet — no encrypted blob is committed, no build phase or CI job consults them — so this is inert until the store swap lands.

## Testing instructions

Nothing to run. The review is a check that the two values are right:

- `repo-id` must match the repository this checkout came from.
- `keys.pub` lists the age recipients. Each line can be validated against its private half with `age-keygen -y`; @AliSoftware already did this for the CI key in https://github.com/wordpress-mobile/WordPress-iOS/pull/25772#discussion_r3573827005.
