### PR TITLE
Delete unused feature flags

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -11,7 +11,6 @@ public enum FeatureFlag: Int, CaseIterable {
     case whatsNew
     case qrCodeLogin
     case bloggingPrompts
-    case jetpackDisconnect
     case siteIconCreator
     case betaSiteDesigns
     case compliancePopover
@@ -50,8 +49,6 @@ public enum FeatureFlag: Int, CaseIterable {
             return app == .jetpack
         case .bloggingPrompts:
             return app == .jetpack || app == .reader
-        case .jetpackDisconnect:
-            return BuildConfiguration.current == .debug
         case .siteIconCreator:
             return BuildConfiguration.current.isInternal
         case .betaSiteDesigns:
@@ -110,7 +107,6 @@ extension FeatureFlag {
         case .whatsNew: "What's New"
         case .qrCodeLogin: "QR Code Login"
         case .bloggingPrompts: "Blogging Prompts"
-        case .jetpackDisconnect: "Jetpack disconnect"
         case .siteIconCreator: "Site Icon Creator"
         case .betaSiteDesigns: "Fetch Beta Site Designs"
         case .compliancePopover: "Compliance Popover"

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -14,7 +14,6 @@ public enum FeatureFlag: Int, CaseIterable {
     case jetpackDisconnect
     case siteIconCreator
     case betaSiteDesigns
-    case commentModerationUpdate
     case compliancePopover
     case googleDomainsCard
     case voiceToContent
@@ -56,8 +55,6 @@ public enum FeatureFlag: Int, CaseIterable {
         case .siteIconCreator:
             return BuildConfiguration.current.isInternal
         case .betaSiteDesigns:
-            return false
-        case .commentModerationUpdate:
             return false
         case .compliancePopover:
             return true
@@ -116,7 +113,6 @@ extension FeatureFlag {
         case .jetpackDisconnect: "Jetpack disconnect"
         case .siteIconCreator: "Site Icon Creator"
         case .betaSiteDesigns: "Fetch Beta Site Designs"
-        case .commentModerationUpdate: "Comments Moderation Update"
         case .compliancePopover: "Compliance Popover"
         case .googleDomainsCard: "Google Domains Promotional Card"
         case .voiceToContent: "Voice to Content"

--- a/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteSettingsViewController.m
@@ -47,10 +47,9 @@ NS_ENUM(NSInteger, SiteSettingsAdvanced) {
 
 NS_ENUM(NSInteger, SiteSettingsJetpack) {
     SiteSettingsJetpackSecurity = 0,
-    SiteSettingsJetpackConnection,
 };
 
-@interface SiteSettingsViewController () <UITableViewDelegate, UITextFieldDelegate, JetpackConnectionDelegate, PostCategoriesViewControllerDelegate>
+@interface SiteSettingsViewController () <UITableViewDelegate, UITextFieldDelegate, PostCategoriesViewControllerDelegate>
 
 #pragma mark - Account Section
 @property (nonatomic, strong) SettingTableViewCell *usernameTextCell;
@@ -74,7 +73,6 @@ NS_ENUM(NSInteger, SiteSettingsJetpack) {
 @property (nonatomic, strong) SwitchTableViewCell *ampSettingCell;
 #pragma mark - Jetpack Settings Section
 @property (nonatomic, strong) SettingTableViewCell *jetpackSecurityCell;
-@property (nonatomic, strong) SettingTableViewCell *jetpackConnectionCell;
 #pragma mark - Device Section
 @property (nonatomic, strong) SwitchTableViewCell *geotaggingCell;
 #pragma mark - Advanced Section
@@ -514,17 +512,6 @@ NS_ENUM(NSInteger, SiteSettingsJetpack) {
     return _jetpackSecurityCell;
 }
 
-- (SettingTableViewCell *)jetpackConnectionCell
-{
-    if (_jetpackConnectionCell) {
-        return _jetpackConnectionCell;
-    }
-    _jetpackConnectionCell = [[SettingTableViewCell alloc] initWithLabel:NSLocalizedString(@"Manage Connection", @"Label for managing the Blog Jetpack Connection section")
-                                                                editable:YES
-                                                         reuseIdentifier:nil];
-    return _jetpackConnectionCell;
-}
-
 - (void)configureEditorSelectorCell
 {
     [self.editorSelectorCell setOn:self.blog.isGutenbergEnabled];
@@ -608,9 +595,6 @@ NS_ENUM(NSInteger, SiteSettingsJetpack) {
     switch (row) {
         case (SiteSettingsJetpackSecurity):
             return self.jetpackSecurityCell;
-
-        case (SiteSettingsJetpackConnection):
-            return self.jetpackConnectionCell;
     }
     return nil;
 }
@@ -945,10 +929,6 @@ NS_ENUM(NSInteger, SiteSettingsJetpack) {
         case SiteSettingsJetpackSecurity:
             [self showJetpackSettingsForBlog:self.blog];
             break;
-
-        case SiteSettingsJetpackConnection:
-            [self showJetpackConnectionForBlog:self.blog];
-            break;
     }
 }
 
@@ -1180,25 +1160,6 @@ NS_ENUM(NSInteger, SiteSettingsJetpack) {
 
     JetpackSettingsViewController *settings = [[JetpackSettingsViewController alloc] initWithBlog:blog];
     [self.navigationController pushViewController:settings animated:YES];
-}
-
-- (void)showJetpackConnectionForBlog:(Blog *)blog
-{
-
-    NSParameterAssert(blog);
-
-    JetpackConnectionViewController *jetpackConnectionVC = [[JetpackConnectionViewController alloc] initWithBlog:blog];
-    jetpackConnectionVC.delegate = self;
-    [self.navigationController pushViewController:jetpackConnectionVC animated:YES];
-}
-
-#pragma mark - JetpackConnectionViewControllerDelegate
-
-- (void)jetpackDisconnectedForBlog:(Blog *)blog
-{
-    if (blog == self.blog) {
-        [self.navigationController popToRootViewControllerAnimated:YES];
-    }
 }
 
 #pragma mark - PostCategoriesViewControllerDelegate

--- a/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteSettingsViewController.m
@@ -48,7 +48,6 @@ NS_ENUM(NSInteger, SiteSettingsAdvanced) {
 NS_ENUM(NSInteger, SiteSettingsJetpack) {
     SiteSettingsJetpackSecurity = 0,
     SiteSettingsJetpackConnection,
-    SiteSettingsJetpackCount,
 };
 
 @interface SiteSettingsViewController () <UITableViewDelegate, UITextFieldDelegate, JetpackConnectionDelegate, PostCategoriesViewControllerDelegate>
@@ -280,9 +279,6 @@ NS_ENUM(NSInteger, SiteSettingsJetpack) {
         }
         case SiteSettingsSectionJetpackSettings:
         {
-            if ([Feature enabled:FeatureFlagJetpackDisconnect]) {
-                return SiteSettingsJetpackCount;
-            }
             return 1;
         }
         case SiteSettingsSectionAdvanced:


### PR DESCRIPTION
## Description

The deleted "Manage Connection" entrance is debug build only. See https://github.com/wordpress-mobile/WordPress-iOS/issues/7473 and https://github.com/wordpress-mobile/WordPress-iOS/pull/7827.