### PR TITLE
feat: align iOS third-party blocks setting with Android's Site Settings toggle

### DIFF
--- a/Modules/Sources/WordPressCore/WordPressClient.swift
+++ b/Modules/Sources/WordPressCore/WordPressClient.swift
@@ -56,6 +56,11 @@ public actor WordPressClient {
         /// WordPress.com sites don't all support plugins.
         case plugins
 
+        /// The editor assets API serves the scripts and styles for blocks provided by
+        /// plugins installed on the site. This is distinct from ``plugins``, which reports
+        /// whether the site exposes the plugin *management* API.
+        case editorAssets
+
         /// A string representation of the feature for use in API queries or logging.
         public var stringValue: String {
             switch self {
@@ -63,6 +68,7 @@ public actor WordPressClient {
             case .blockEditorSettings: "block-editor-settings"
             case .applicationPasswordExtras: "application-password-extras"
             case .plugins: "plugins"
+            case .editorAssets: "editor-assets"
             }
         }
     }
@@ -180,6 +186,9 @@ public actor WordPressClient {
             case .blockEditorSettings: apiRoot.hasRoute(route: "/wp-block-editor/v1/sites/\(siteId)/settings")
             case .blockTheme: isBlockTheme
             case .plugins: apiRoot.hasRoute(route: "/wp/v2/plugins")
+            case .editorAssets:
+                apiRoot.hasRoute(route: "/wpcom/v2/sites/\(siteId)/editor-assets")
+                    || apiRoot.hasRoute(route: "/wpcom/v2/editor-assets")
             case .applicationPasswordExtras: apiRoot.hasRoute(route: "/application-password-extras/v1/admin-ajax")
             }
         }
@@ -188,6 +197,7 @@ public actor WordPressClient {
         case .blockEditorSettings: apiRoot.hasRoute(route: "/wp-block-editor/v1/settings")
         case .blockTheme: isBlockTheme
         case .plugins: apiRoot.hasRoute(route: "/wp/v2/plugins")
+        case .editorAssets: apiRoot.hasRoute(route: "/wpcom/v2/editor-assets")
         case .applicationPasswordExtras: apiRoot.hasRoute(route: "/application-password-extras/v1/admin-ajax")
         }
     }

--- a/Modules/Sources/WordPressCore/WordPressClient.swift
+++ b/Modules/Sources/WordPressCore/WordPressClient.swift
@@ -59,6 +59,12 @@ public actor WordPressClient {
         /// The editor assets API serves the scripts and styles for blocks provided by
         /// plugins installed on the site. This is distinct from ``plugins``, which reports
         /// whether the site exposes the plugin *management* API.
+        ///
+        /// A site serves this route under exactly one of two paths, decided by how the app
+        /// reaches it: proxied through WP.com it is namespaced under `/sites/{id}/`, and
+        /// addressed directly it is bare. Probing for the form the site does not serve is the
+        /// correct answer, because that is the form the editor would fetch — so `siteId` must
+        /// reflect the transport the editor will actually use.
         case editorAssets
 
         /// A string representation of the feature for use in API queries or logging.
@@ -186,9 +192,7 @@ public actor WordPressClient {
             case .blockEditorSettings: apiRoot.hasRoute(route: "/wp-block-editor/v1/sites/\(siteId)/settings")
             case .blockTheme: isBlockTheme
             case .plugins: apiRoot.hasRoute(route: "/wp/v2/plugins")
-            case .editorAssets:
-                apiRoot.hasRoute(route: "/wpcom/v2/sites/\(siteId)/editor-assets")
-                    || apiRoot.hasRoute(route: "/wpcom/v2/editor-assets")
+            case .editorAssets: apiRoot.hasRoute(route: "/wpcom/v2/sites/\(siteId)/editor-assets")
             case .applicationPasswordExtras: apiRoot.hasRoute(route: "/application-password-extras/v1/admin-ajax")
             }
         }

--- a/Modules/Sources/WordPressData/Swift/Blog+SelfHosted.swift
+++ b/Modules/Sources/WordPressData/Swift/Blog+SelfHosted.swift
@@ -343,7 +343,7 @@ extension WordPressSite {
     /// access. The two don't always line up: a WordPress.com Atomic site
     /// presents as `.dotCom` but is accessed directly when application
     /// password credentials are available.
-    public enum Transport {
+    public enum Transport: Hashable {
         /// Requests go to the site's own REST API root, authenticated with
         /// an application password.
         case direct(ApplicationPasswordCredentials)

--- a/Modules/Tests/WordPressCoreTests/WordPressClientFeatureTests.swift
+++ b/Modules/Tests/WordPressCoreTests/WordPressClientFeatureTests.swift
@@ -91,9 +91,9 @@ struct WordPressClientCachingTests {
 
         let results = try await [result1, result2, result3, result4]
 
-        #expect(results[0] == true)  // blockEditorSettings
-        #expect(results[1] == true)  // blockTheme
-        #expect(results[2] == true)  // plugins
+        #expect(results[0] == true) // blockEditorSettings
+        #expect(results[1] == true) // blockTheme
+        #expect(results[2] == true) // plugins
         #expect(results[3] == false) // applicationPasswordExtras (not in routes)
 
         // Despite 4 concurrent calls, API should only be called once

--- a/Modules/Tests/WordPressCoreTests/WordPressClientFeatureTests.swift
+++ b/Modules/Tests/WordPressCoreTests/WordPressClientFeatureTests.swift
@@ -14,6 +14,33 @@ struct WordPressClientFeatureTests {
         #expect(WordPressClient.Feature.blockEditorSettings.stringValue == "block-editor-settings")
         #expect(WordPressClient.Feature.applicationPasswordExtras.stringValue == "application-password-extras")
         #expect(WordPressClient.Feature.plugins.stringValue == "plugins")
+        #expect(WordPressClient.Feature.editorAssets.stringValue == "editor-assets")
+    }
+
+    /// `editorAssets` reports whether the site can serve blocks provided by plugins, which is
+    /// the `editor-assets` route. `plugins` reports whether the plugin *management* API is
+    /// exposed — a different route that WP.com Simple sites don't have. Conflating the two
+    /// makes third-party blocks look unsupported on sites that support them perfectly well.
+    @Test
+    func editorAssetsIsDistinctFromPluginManagement() async throws {
+        let mockAPI = MockWordPressClientAPI()
+        mockAPI.mockRoutes = ["/wpcom/v2/editor-assets"]
+
+        let client = WordPressClient(api: mockAPI, siteURL: URL(string: "https://example.com")!)
+
+        #expect(try await client.supports(.editorAssets) == true)
+        #expect(try await client.supports(.plugins) == false)
+    }
+
+    /// WP.com sites expose the route under a site-namespaced path.
+    @Test
+    func editorAssetsAcceptsSiteNamespacedRoute() async throws {
+        let mockAPI = MockWordPressClientAPI()
+        mockAPI.mockRoutes = ["/wpcom/v2/sites/12345/editor-assets"]
+
+        let client = WordPressClient(api: mockAPI, siteURL: URL(string: "https://example.com")!)
+
+        #expect(try await client.supports(.editorAssets, forSiteId: 12345) == true)
     }
 }
 

--- a/Modules/Tests/WordPressCoreTests/WordPressClientFeatureTests.swift
+++ b/Modules/Tests/WordPressCoreTests/WordPressClientFeatureTests.swift
@@ -32,15 +32,49 @@ struct WordPressClientFeatureTests {
         #expect(try await client.supports(.plugins) == false)
     }
 
-    /// WP.com sites expose the route under a site-namespaced path.
+    /// A site proxied through WP.com — a Simple site, or a Jetpack site with no application
+    /// password — serves the route namespaced under its site id.
     @Test
-    func editorAssetsAcceptsSiteNamespacedRoute() async throws {
+    func editorAssetsUsesTheNamespacedRouteWhenProxied() async throws {
         let mockAPI = MockWordPressClientAPI()
         mockAPI.mockRoutes = ["/wpcom/v2/sites/12345/editor-assets"]
 
         let client = WordPressClient(api: mockAPI, siteURL: URL(string: "https://example.com")!)
 
         #expect(try await client.supports(.editorAssets, forSiteId: 12345) == true)
+    }
+
+    /// The two forms are alternatives, not aliases: the editor fetches whichever one matches the
+    /// transport it is configured for, so a route the site serves under the *other* form is not
+    /// support. Accepting either here reported support for sites the editor would then fail to
+    /// load assets from.
+    @Test
+    func editorAssetsRejectsTheFormTheEditorWouldNotFetch() async throws {
+        let bareOnly = MockWordPressClientAPI()
+        bareOnly.mockRoutes = ["/wpcom/v2/editor-assets"]
+        let proxiedClient = WordPressClient(api: bareOnly, siteURL: URL(string: "https://example.com")!)
+
+        // Proxied: the editor fetches the namespaced path, which this site does not serve.
+        #expect(try await proxiedClient.supports(.editorAssets, forSiteId: 12345) == false)
+
+        let namespacedOnly = MockWordPressClientAPI()
+        namespacedOnly.mockRoutes = ["/wpcom/v2/sites/12345/editor-assets"]
+        let directClient = WordPressClient(api: namespacedOnly, siteURL: URL(string: "https://example.com")!)
+
+        // Direct: the editor fetches the bare path, which this site does not serve.
+        #expect(try await directClient.supports(.editorAssets) == false)
+    }
+
+    /// An Atomic, Jetpack, or self-hosted site addressed with an application password serves the
+    /// route bare, and is probed without a site id.
+    @Test
+    func editorAssetsUsesTheBareRouteWhenDirect() async throws {
+        let mockAPI = MockWordPressClientAPI()
+        mockAPI.mockRoutes = ["/wpcom/v2/editor-assets"]
+
+        let client = WordPressClient(api: mockAPI, siteURL: URL(string: "https://example.com")!)
+
+        #expect(try await client.supports(.editorAssets) == true)
     }
 }
 

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 * [*] Custom Post Types: Make custom post types with REST API and editor support available in My Site [#25849]
 * [*] Stop the media picker from removing gallery images when you cancel it in the experimental editor [#25866]
 * [*] Stats: Fix the screen getting stuck on a loading indicator for self-hosted sites that are not connected to Jetpack [#25858]
+* [*] [internal] Experimental Gutenberg editor: add a per-site "Use Third-Party Blocks (Beta)" toggle to Site Settings, matching Android [#25889]
 
 27.1
 -----

--- a/Tests/KeystoneTests/Tests/Features/Gutenberg/EditorConfigurationPluginsTests.swift
+++ b/Tests/KeystoneTests/Tests/Features/Gutenberg/EditorConfigurationPluginsTests.swift
@@ -21,7 +21,10 @@ final class EditorConfigurationPluginsTests {
     }
 
     func tearDown() {
-        featureFlags.override(RemoteFeatureFlag.newGutenbergPlugins, withValue: RemoteFeatureFlag.newGutenbergPlugins.originalValue)
+        featureFlags.override(
+            RemoteFeatureFlag.newGutenbergPlugins,
+            withValue: RemoteFeatureFlag.newGutenbergPlugins.originalValue
+        )
     }
 
     @Test("Should disable plugins for non-Jetpack-connected sites without app password")
@@ -125,11 +128,12 @@ final class EditorConfigurationPluginsTests {
 
         let result = EditorConfiguration.shouldEnablePlugins(for: blog)
 
-        let expectedResult = RemoteFeatureFlag.newGutenbergPlugins.enabled() &&
-                           blog.isAccessibleThroughWPCom &&
-                           blog.isHostedAtWPcom
+        let expectedResult =
+            RemoteFeatureFlag.newGutenbergPlugins.enabled() && blog.isAccessibleThroughWPCom && blog.isHostedAtWPcom
 
-        #expect(result == expectedResult,
-                "Should use RemoteFeatureFlag.newGutenbergPlugins.enabled() when not provided")
+        #expect(
+            result == expectedResult,
+            "Should use RemoteFeatureFlag.newGutenbergPlugins.enabled() when not provided"
+        )
     }
 }

--- a/Tests/KeystoneTests/Tests/Features/Gutenberg/EditorConfigurationPluginsTests.swift
+++ b/Tests/KeystoneTests/Tests/Features/Gutenberg/EditorConfigurationPluginsTests.swift
@@ -257,6 +257,33 @@ final class EditorConfigurationPluginsTests {
         )
     }
 
+    @Test("shouldEnablePlugins resolves the application password with the injected keychain")
+    func shouldEnablePluginsUsesInjectedKeychain() throws {
+        let blog = makeSelfHostedBlog()
+        let settings = settings
+        settings.setSupports(.editorAssets, true, for: blog)
+        settings.setThirdPartyBlocksEnabled(true, for: blog)
+
+        // The site is eligible only by way of an application password, and that password exists
+        // solely in the injected keychain. Without it the lookup falls back to the device
+        // keychain, finds nothing, and the site resolves as unsupported.
+        let keychain = TestKeychain()
+        try keychain.setPassword(
+            for: try blog.getUsername(),
+            to: "app-password",
+            serviceName: try blog.getUrlString()
+        )
+
+        #expect(
+            EditorConfiguration.shouldEnablePlugins(
+                for: blog,
+                settings: settings,
+                keychain: keychain,
+                isFeatureFlagEnabled: true
+            ) == true
+        )
+    }
+
     @Test("Preference survives the remote flag being turned off and back on")
     func preferenceSurvivesFlagCycle() throws {
         let blog = makeSimpleBlog()

--- a/Tests/KeystoneTests/Tests/Features/Gutenberg/EditorConfigurationPluginsTests.swift
+++ b/Tests/KeystoneTests/Tests/Features/Gutenberg/EditorConfigurationPluginsTests.swift
@@ -1,92 +1,77 @@
-import Testing
-import Foundation
 import CoreData
-import WordPressData
+import Foundation
 import GutenbergKit
+import Testing
+import WordPressCore
+import WordPressData
+import WordPressShared
 
 @testable import WordPress
 
-@Suite("EditorConfiguration.shouldEnablePlugins Tests")
+// Serialized because capability support is keyed on `Blog.locallyUniqueId`, which hashes the
+// Core Data object ID. Newly inserted blogs have temporary IDs that can repeat across parallel
+// tests, letting one test's `setSupports` write land on another test's blog.
+@Suite("Third-party blocks capability resolution", .serialized)
 final class EditorConfigurationPluginsTests {
     private let contextManager = ContextManager.forTesting()
-    private let keychain = TestKeychain()
-    private let featureFlags = FeatureFlagOverrideStore()
+    private let database = EphemeralKeyValueDatabase()
 
     private var context: NSManagedObjectContext {
         contextManager.mainContext
     }
 
-    init() {
-        featureFlags.override(RemoteFeatureFlag.newGutenbergPlugins, withValue: true)
+    private var settings: GutenbergSettings {
+        GutenbergSettings(database: database)
     }
 
-    func tearDown() {
-        featureFlags.override(
-            RemoteFeatureFlag.newGutenbergPlugins,
-            withValue: RemoteFeatureFlag.newGutenbergPlugins.originalValue
+    /// Resolves with the remote feature flag pinned on, which is the interesting case for most
+    /// of these tests. The flag is passed explicitly rather than overridden globally so the
+    /// suite can run in parallel without tests clobbering each other's flag state.
+    private func resolve(
+        for blog: Blog,
+        appPassword: String? = nil,
+        isFeatureFlagEnabled: Bool = true
+    ) -> ThirdPartyBlocksCapability {
+        settings.resolveThirdPartyBlocks(
+            for: blog,
+            appPassword: appPassword,
+            isFeatureFlagEnabled: isFeatureFlagEnabled
         )
     }
 
-    @Test("Should disable plugins for non-Jetpack-connected sites without app password")
-    func disablesPluginsForNonJetpackSitesWithoutAppPassword() async throws {
-        let blog = BlogBuilder(context)
-            .with(atomic: false)
-            .isNotHostedAtWPcom()
-            .with(username: "selfhosted")
-            .with(url: "https://self-hosted.org")
-            .build()
-
-        let result = EditorConfiguration.shouldEnablePlugins(for: blog, appPassword: nil)
-
-        #expect(result == false, "Should return false for non-Jetpack sites without app password")
-    }
-
-    @Test("Should enable plugins for Simple WP.com sites")
-    func enablesPluginsForSimpleSites() async throws {
+    /// A Simple WP.com site, which needs no application password.
+    private func makeSimpleBlog() -> Blog {
         let blog = BlogBuilder(context)
             .with(atomic: false)
             .isHostedAtWPcom()
             .withAnAccount(username: "simpleuser", authToken: "token")
             .with(dotComID: 12345)
             .build()
-
-        let result = EditorConfiguration.shouldEnablePlugins(for: blog, appPassword: nil)
-
-        #expect(result == true, "Should return true for Simple WP.com sites")
+        return withPermanentID(blog)
     }
 
-    @Test("Should enable plugins for Atomic sites with app password")
-    func enablesPluginsForAtomicSitesWithAppPassword() async throws {
+    /// Capability support is keyed on `Blog.locallyUniqueId`, which hashes the Core Data object
+    /// ID. Newly inserted objects start with a temporary ID that Core Data replaces on save, so
+    /// a write made before the save would be read back under a different key. Saving up front
+    /// keeps the key stable for the life of the test.
+    private func withPermanentID(_ blog: Blog) -> Blog {
+        try? context.obtainPermanentIDs(for: [blog])
+        return blog
+    }
+
+    /// A self-hosted site signed in directly, with no WordPress.com account.
+    private func makeSelfHostedBlog() -> Blog {
         let blog = BlogBuilder(context)
-            .with(atomic: true)
+            .with(atomic: false)
             .isNotHostedAtWPcom()
-            .withAnAccount(username: "atomicuser", authToken: "token")
-            .with(dotComID: 67890)
-            .with(url: "https://atomic.com")
+            .with(username: "selfhosted")
+            .with(url: "https://self-hosted.org")
             .build()
-
-        let result = EditorConfiguration.shouldEnablePlugins(for: blog, appPassword: "app-password-123")
-
-        #expect(result == true, "Should return true for Atomic sites with app password")
+        return withPermanentID(blog)
     }
 
-    @Test("Should disable plugins for Atomic sites without app password")
-    func disablesPluginsForAtomicSitesWithoutAppPassword() async throws {
-        let blog = BlogBuilder(context)
-            .with(atomic: true)
-            .isNotHostedAtWPcom()
-            .withAnAccount(username: "atomicuser", authToken: "token")
-            .with(dotComID: 67890)
-            .with(url: "https://atomic.com")
-            .build()
-
-        let result = EditorConfiguration.shouldEnablePlugins(for: blog, appPassword: nil)
-
-        #expect(result == false, "Should return false for Atomic sites without app password")
-    }
-
-    @Test("Should enable plugins for Jetpack-connected sites with app password")
-    func enablesPluginsForJetpackSitesWithAppPassword() async throws {
+    /// A Jetpack-connected site, which authenticates with an application password.
+    private func makeJetpackBlog() -> Blog {
         let blog = BlogBuilder(context)
             .with(atomic: false)
             .isNotHostedAtWPcom()
@@ -95,45 +80,191 @@ final class EditorConfigurationPluginsTests {
             .with(dotComID: 99999)
             .with(url: "https://jetpack-site.org")
             .build()
-
-        let result = EditorConfiguration.shouldEnablePlugins(for: blog, appPassword: "jetpack-app-password")
-
-        #expect(result == true, "Should return true for Jetpack sites with app password")
+        return withPermanentID(blog)
     }
 
-    @Test("Should disable plugins for Jetpack-connected sites without app password")
-    func disablesPluginsForJetpackSitesWithoutAppPassword() async throws {
-        let blog = BlogBuilder(context)
-            .with(atomic: false)
-            .isNotHostedAtWPcom()
-            .withAnAccount(username: "jetpackuser", authToken: "token")
-            .withJetpack(version: "13.0")
-            .with(dotComID: 99999)
-            .with(url: "https://jetpack-site.org")
-            .build()
+    // MARK: - Flag gating
 
-        let result = EditorConfiguration.shouldEnablePlugins(for: blog, appPassword: nil)
+    @Test("Hidden when the remote feature flag is off, even if the user opted in")
+    func hiddenWhenFlagOff() throws {
+        let blog = makeSimpleBlog()
+        let settings = settings
+        settings.setThirdPartyBlocksEnabled(true, for: blog)
+        settings.setSupports(.editorAssets, true, for: blog)
 
-        #expect(result == false, "Should return false for Jetpack sites without app password")
+        let capability = resolve(for: blog, isFeatureFlagEnabled: false)
+
+        #expect(capability == .hidden)
+        #expect(capability.shouldApplyInEditor == false)
+        #expect(capability.isVisibleInSiteSettings == false)
     }
 
-    @Test("Should use default remote flag implementation when not provided")
-    func usesDefaultRemoteFlagImplementation() async throws {
-        let blog = BlogBuilder(context)
-            .with(atomic: false)
-            .isHostedAtWPcom()
-            .withAnAccount(username: "user", authToken: "token")
-            .with(dotComID: 12345)
-            .build()
+    // MARK: - Site eligibility
 
-        let result = EditorConfiguration.shouldEnablePlugins(for: blog)
+    /// A self-hosted site signed in with an application password has no WordPress.com account, so
+    /// it isn't `isAccessibleThroughWPCom` — but a site running Jetpack still serves
+    /// `/wpcom/v2/editor-assets` from its own API root. Eligibility is the probe's call, not a
+    /// judgement about how the site is hosted.
+    @Test("Available for a self-hosted site whose probe found the editor-assets route")
+    func availableForSelfHostedSiteWithCapability() throws {
+        let blog = makeSelfHostedBlog()
+        let settings = settings
+        settings.setSupports(.editorAssets, true, for: blog)
+        settings.setThirdPartyBlocksEnabled(true, for: blog)
 
-        let expectedResult =
-            RemoteFeatureFlag.newGutenbergPlugins.enabled() && blog.isAccessibleThroughWPCom && blog.isHostedAtWPcom
+        let capability = resolve(for: blog, appPassword: "app-password")
+
+        #expect(capability == .available(true))
+        #expect(capability.shouldApplyInEditor == true)
+    }
+
+    @Test("Unsupported for a self-hosted site whose probe found no editor-assets route")
+    func unsupportedForSelfHostedSiteWithoutCapability() throws {
+        let blog = makeSelfHostedBlog()
+        settings.setSupports(.editorAssets, false, for: blog)
+
+        let capability = resolve(for: blog, appPassword: "app-password")
+
+        #expect(capability == .unsupported)
+        #expect(capability.shouldApplyInEditor == false)
+        // Android shows the row disabled rather than hiding it.
+        #expect(capability.isVisibleInSiteSettings == true)
+        #expect(capability.isInteractive == false)
+    }
+
+    @Test("Unsupported for a Jetpack site with no application password")
+    func unsupportedWithoutApplicationPassword() throws {
+        let blog = makeJetpackBlog()
+
+        let capability = resolve(for: blog, appPassword: nil)
+
+        #expect(capability == .unsupported)
+        #expect(capability.shouldApplyInEditor == false)
+    }
+
+    @Test("Unsupported when the site was probed and lacks the editor-assets route")
+    func unsupportedWhenProbedWithoutCapability() throws {
+        let blog = makeSimpleBlog()
+        let settings = settings
+        settings.setSupports(.editorAssets, false, for: blog)
+        // Even an explicit opt-in can't override a site that can't serve the blocks.
+        settings.setThirdPartyBlocksEnabled(true, for: blog)
+
+        let capability = resolve(for: blog)
+
+        #expect(capability == .unsupported)
+        #expect(capability.shouldApplyInEditor == false)
+    }
+
+    @Test("Available when the site has not been probed yet, so the setting stays reachable")
+    func availableWhenNotYetProbed() throws {
+        let blog = makeSimpleBlog()
+
+        #expect(settings.hasProbedSupport(for: .editorAssets, blog: blog) == false)
+
+        let capability = resolve(for: blog)
+
+        #expect(capability == .available(false))
+        #expect(capability.isInteractive == true)
+    }
+
+    // MARK: - User preference
+
+    @Test("Defaults to off, so a capable site does not load plugins until the user opts in")
+    func defaultsToDisabled() throws {
+        let blog = makeSimpleBlog()
+        let settings = settings
+        settings.setSupports(.editorAssets, true, for: blog)
+
+        let capability = resolve(for: blog)
+
+        #expect(capability == .available(false))
+        #expect(capability.shouldApplyInEditor == false)
+    }
+
+    @Test("Applies in the editor once flag, capability, and preference all agree")
+    func appliesWhenAllConditionsMet() throws {
+        let blog = makeSimpleBlog()
+        let settings = settings
+        settings.setSupports(.editorAssets, true, for: blog)
+        settings.setThirdPartyBlocksEnabled(true, for: blog)
+
+        let capability = resolve(for: blog)
+
+        #expect(capability == .available(true))
+        #expect(capability.shouldApplyInEditor == true)
+    }
+
+    @Test("Applies for a Jetpack site with an application password")
+    func appliesForJetpackSiteWithApplicationPassword() throws {
+        let blog = makeJetpackBlog()
+        let settings = settings
+        settings.setSupports(.editorAssets, true, for: blog)
+        settings.setThirdPartyBlocksEnabled(true, for: blog)
+
+        let capability = resolve(for: blog, appPassword: "jetpack-app-password")
+
+        #expect(capability == .available(true))
+        #expect(capability.shouldApplyInEditor == true)
+    }
+
+    @Test("Preference is stored per site")
+    func preferenceIsPerSite() throws {
+        let enabledBlog = makeSimpleBlog()
+        let otherBlog = withPermanentID(
+            BlogBuilder(context)
+                .with(atomic: false)
+                .isHostedAtWPcom()
+                .withAnAccount(username: "otheruser", authToken: "token")
+                .with(dotComID: 54321)
+                .with(url: "https://other-site.com")
+                .build()
+        )
+
+        let settings = settings
+        settings.setSupports(.editorAssets, true, for: enabledBlog)
+        settings.setSupports(.editorAssets, true, for: otherBlog)
+        settings.setThirdPartyBlocksEnabled(true, for: enabledBlog)
+
+        #expect(resolve(for: enabledBlog) == .available(true))
+        #expect(resolve(for: otherBlog) == .available(false))
+    }
+
+    // MARK: - Editor entry point
+
+    @Test("shouldEnablePlugins follows the resolved capability")
+    func shouldEnablePluginsFollowsCapability() throws {
+        let blog = makeSimpleBlog()
+        let settings = settings
+        settings.setSupports(.editorAssets, true, for: blog)
 
         #expect(
-            result == expectedResult,
-            "Should use RemoteFeatureFlag.newGutenbergPlugins.enabled() when not provided"
+            EditorConfiguration.shouldEnablePlugins(
+                for: blog,
+                settings: settings,
+                isFeatureFlagEnabled: true
+            ) == false
         )
+
+        settings.setThirdPartyBlocksEnabled(true, for: blog)
+
+        #expect(
+            EditorConfiguration.shouldEnablePlugins(
+                for: blog,
+                settings: settings,
+                isFeatureFlagEnabled: true
+            ) == true
+        )
+    }
+
+    @Test("Preference survives the remote flag being turned off and back on")
+    func preferenceSurvivesFlagCycle() throws {
+        let blog = makeSimpleBlog()
+        let settings = settings
+        settings.setSupports(.editorAssets, true, for: blog)
+        settings.setThirdPartyBlocksEnabled(true, for: blog)
+
+        #expect(resolve(for: blog, isFeatureFlagEnabled: false) == .hidden)
+        #expect(resolve(for: blog, isFeatureFlagEnabled: true) == .available(true))
     }
 }

--- a/WordPress/Classes/Networking/WordPressClient.swift
+++ b/WordPress/Classes/Networking/WordPressClient.swift
@@ -25,23 +25,11 @@ public final class WordPressClientFactory: Sendable {
     /// credentials would keep being served.
     private struct CacheKey: Hashable {
         let blogId: TaggedManagedObjectID<Blog>
-        let transport: Transport
-
-        /// The identity of a `WordPressSite.Transport`, which is not itself `Hashable`.
-        enum Transport: Hashable {
-            case direct(WordPressSite.ApplicationPasswordCredentials)
-            case dotComProxy(siteId: Int, oAuthToken: String)
-        }
+        let transport: WordPressSite.Transport
 
         init(site: WordPressSite) {
             self.blogId = site.blogId
-            self.transport =
-                switch site.transport {
-                case let .direct(credentials):
-                    .direct(credentials)
-                case let .dotComProxy(siteId, oAuthToken):
-                    .dotComProxy(siteId: siteId, oAuthToken: oAuthToken)
-                }
+            self.transport = site.transport
         }
     }
 

--- a/WordPress/Classes/Networking/WordPressClient.swift
+++ b/WordPress/Classes/Networking/WordPressClient.swift
@@ -10,18 +10,40 @@ import WordPressShared
 public final class WordPressClientFactory: Sendable {
     public static let shared = WordPressClientFactory()
 
-    private let instances = OSAllocatedUnfairLock<[TaggedManagedObjectID<Blog>: WordPressClient]>(initialState: [:])
+    /// Identifies a cached client by both the site and the transport it was built for.
+    ///
+    /// A site's transport changes underneath us: a WordPress.com site starts out proxied through
+    /// the WP.com REST API and switches to addressing its own API root once an application
+    /// password is created. The two speak to different API roots, whose discovery documents key
+    /// routes differently — the proxy namespaces everything under `/sites/{id}/`. Caching on the
+    /// blog alone kept serving a client whose cached API root no longer matched the transport its
+    /// callers were reasoning about, so route lookups silently missed.
+    private struct CacheKey: Hashable {
+        let blogId: TaggedManagedObjectID<Blog>
+        let isProxied: Bool
+
+        init(site: WordPressSite) {
+            self.blogId = site.blogId
+            self.isProxied = if case .dotComProxy = site.transport { true } else { false }
+        }
+    }
+
+    private let instances = OSAllocatedUnfairLock<[CacheKey: WordPressClient]>(initialState: [:])
     private init() {}
 
     public func instance(for site: WordPressSite) -> WordPressClient {
-        instances.withLock { dict in
-            if let client = dict[site.blogId] {
-                return client
-            } else {
-                let client = WordPressClient(site: site)
-                dict[site.blogId] = client
+        let key = CacheKey(site: site)
+        return instances.withLock { dict in
+            if let client = dict[key] {
                 return client
             }
+
+            let client = WordPressClient(site: site)
+            // Drop any client built for this site's previous transport; its cached API root
+            // describes a different root than the one this site now uses.
+            dict = dict.filter { $0.key.blogId != key.blogId }
+            dict[key] = client
+            return client
         }
     }
 

--- a/WordPress/Classes/Networking/WordPressClient.swift
+++ b/WordPress/Classes/Networking/WordPressClient.swift
@@ -18,13 +18,30 @@ public final class WordPressClientFactory: Sendable {
     /// routes differently — the proxy namespaces everything under `/sites/{id}/`. Caching on the
     /// blog alone kept serving a client whose cached API root no longer matched the transport its
     /// callers were reasoning about, so route lookups silently missed.
+    ///
+    /// The transport's credentials are part of the identity, not just which case it is: rotating
+    /// an application password or refreshing the site's REST API root changes where requests go
+    /// and how they authenticate while staying `.direct`, and a client built for the superseded
+    /// credentials would keep being served.
     private struct CacheKey: Hashable {
         let blogId: TaggedManagedObjectID<Blog>
-        let isProxied: Bool
+        let transport: Transport
+
+        /// The identity of a `WordPressSite.Transport`, which is not itself `Hashable`.
+        enum Transport: Hashable {
+            case direct(WordPressSite.ApplicationPasswordCredentials)
+            case dotComProxy(siteId: Int, oAuthToken: String)
+        }
 
         init(site: WordPressSite) {
             self.blogId = site.blogId
-            self.isProxied = if case .dotComProxy = site.transport { true } else { false }
+            self.transport =
+                switch site.transport {
+                case let .direct(credentials):
+                    .direct(credentials)
+                case let .dotComProxy(siteId, oAuthToken):
+                    .dotComProxy(siteId: siteId, oAuthToken: oAuthToken)
+                }
         }
     }
 

--- a/WordPress/Classes/Utility/Editor/EditorConfiguration+Blog.swift
+++ b/WordPress/Classes/Utility/Editor/EditorConfiguration+Blog.swift
@@ -53,7 +53,9 @@ extension EditorConfiguration {
         .setNamespaceExcludedPaths(["/wpcom/v2/following/recommendations", "/wpcom/v2/following/mine"])
         .setAuthHeader(authHeader)
         .setShouldUseThemeStyles(GutenbergSettings().isThemeStylesEnabled(for: blog))
-        .setShouldUsePlugins(Self.shouldEnablePlugins(for: blog, appPassword: applicationPassword))
+        .setShouldUsePlugins(
+            Self.shouldEnablePlugins(for: blog, appPassword: applicationPassword, keychain: keychain)
+        )
         .setLocale(WordPressComLanguageDatabase.shared.deviceLanguage.slug)
         .setEnableNetworkLogging(ExtensiveLogging.enabled)
         .setNetworkFallbackMode(.automatic)
@@ -80,12 +82,14 @@ extension EditorConfiguration {
         for blog: Blog,
         appPassword: String? = nil,
         settings: GutenbergSettings = GutenbergSettings(),
+        keychain: KeychainAccessible = AppKeychain(),
         isFeatureFlagEnabled: Bool = RemoteFeatureFlag.newGutenbergPlugins.enabled()
     ) -> Bool {
         settings
             .resolveThirdPartyBlocks(
                 for: blog,
                 appPassword: appPassword,
+                keychain: keychain,
                 isFeatureFlagEnabled: isFeatureFlagEnabled
             )
             .shouldApplyInEditor

--- a/WordPress/Classes/Utility/Editor/EditorConfiguration+Blog.swift
+++ b/WordPress/Classes/Utility/Editor/EditorConfiguration+Blog.swift
@@ -53,7 +53,6 @@ extension EditorConfiguration {
         .setNamespaceExcludedPaths(["/wpcom/v2/following/recommendations", "/wpcom/v2/following/mine"])
         .setAuthHeader(authHeader)
         .setShouldUseThemeStyles(GutenbergSettings().isThemeStylesEnabled(for: blog))
-        // Limited to Jetpack-connected sites until editor assets endpoint is available in WordPress core
         .setShouldUsePlugins(Self.shouldEnablePlugins(for: blog, appPassword: applicationPassword))
         .setLocale(WordPressComLanguageDatabase.shared.deviceLanguage.slug)
         .setEnableNetworkLogging(ExtensiveLogging.enabled)
@@ -74,11 +73,21 @@ extension EditorConfiguration {
     /// Returns true if the plugins should be enabled for the given blog.
     /// This is used to determine if the editor should load third-party
     /// plugins providing blocks.
-    static func shouldEnablePlugins(for blog: Blog, appPassword: String? = nil) -> Bool {
-        // Requires a Jetpack until editor assets endpoint is available in WordPress core.
-        // Requires a WP.com Simple site or an application password to authenticate all REST
-        // API requests, including those originating from non-core blocks.
-        RemoteFeatureFlag.newGutenbergPlugins.enabled() && blog.isAccessibleThroughWPCom
-            && (blog.isHostedAtWPcom || appPassword != nil)
+    ///
+    /// Requires the remote feature flag, a site that can support the feature, and the user's
+    /// per-site opt-in. See `GutenbergSettings.resolveThirdPartyBlocks(for:)`.
+    static func shouldEnablePlugins(
+        for blog: Blog,
+        appPassword: String? = nil,
+        settings: GutenbergSettings = GutenbergSettings(),
+        isFeatureFlagEnabled: Bool = RemoteFeatureFlag.newGutenbergPlugins.enabled()
+    ) -> Bool {
+        settings
+            .resolveThirdPartyBlocks(
+                for: blog,
+                appPassword: appPassword,
+                isFeatureFlagEnabled: isFeatureFlagEnabled
+            )
+            .shouldApplyInEditor
     }
 }

--- a/WordPress/Classes/Utility/Editor/EditorDependencyManager.swift
+++ b/WordPress/Classes/Utility/Editor/EditorDependencyManager.swift
@@ -277,8 +277,18 @@ final class EditorDependencyManager: Sendable {
 
     /// Query the server for its editor capabilities, and update the local editor settings store with the result.
     ///
+    /// Joins the probe already in flight for this site, if there is one, rather than starting a
+    /// second. Errors from a joined probe are logged by it rather than rethrown here.
+    ///
     @MainActor
     public func fetchEditorCapabilities(for blog: Blog) async throws {
+        await capabilityTask(for: blog).value
+    }
+
+    /// Query the server for its editor capabilities, and update the local editor settings store with the result.
+    ///
+    @MainActor
+    private func performFetchEditorCapabilities(for blog: Blog) async throws {
         let site = try WordPressSite(blog: blog)
         let client = WordPressClientFactory.shared.instance(for: site)
 
@@ -305,30 +315,35 @@ final class EditorDependencyManager: Sendable {
     /// Returns immediately and ignores errors – prefer the `async` version of this method.
     ///
     public func fetchEditorCapabilities(for blog: Blog) {
+        _ = capabilityTask(for: blog)
+    }
+
+    /// Returns the capability probe in flight for the site, starting one if there is none.
+    ///
+    /// Deduplication lives here rather than in one of the entry points so that every caller shares
+    /// a single probe per site, however it was reached.
+    private func capabilityTask(for blog: Blog) -> Task<Void, Never> {
         let blogID = TaggedManagedObjectID(blog)
 
-        let isAlreadyRunning = state.withLock { state in
-            state.capabilityTasks[blogID] != nil
-        }
-
-        guard !isAlreadyRunning else {
-            return
-        }
-
-        let task = Task {
-            do {
-                try await self.fetchEditorCapabilities(for: blog)
-            } catch {
-                DDLogError("EditorDependencyManager: Failed to fetch editor capabilities: \(error)")
+        return state.withLock { state in
+            if let existing = state.capabilityTasks[blogID] {
+                return existing
             }
 
-            self.state.withLock { state in
-                _ = state.capabilityTasks.removeValue(forKey: blogID)
-            }
-        }
+            let task = Task {
+                do {
+                    try await self.performFetchEditorCapabilities(for: blog)
+                } catch {
+                    DDLogError("EditorDependencyManager: Failed to fetch editor capabilities: \(error)")
+                }
 
-        state.withLock { state in
+                self.state.withLock { state in
+                    _ = state.capabilityTasks.removeValue(forKey: blogID)
+                }
+            }
+
             state.capabilityTasks[blogID] = task
+            return task
         }
     }
 }

--- a/WordPress/Classes/Utility/Editor/EditorDependencyManager.swift
+++ b/WordPress/Classes/Utility/Editor/EditorDependencyManager.swift
@@ -292,12 +292,12 @@ final class EditorDependencyManager: Sendable {
 
         let hasBlockTheme = try await client.supports(.blockTheme, forSiteId: siteId)
         let hasBlockSettings = try await client.supports(.blockEditorSettings, forSiteId: siteId)
-        let supportsPlugins = try await client.supports(.plugins, forSiteId: siteId)
+        let supportsEditorAssets = try await client.supports(.editorAssets, forSiteId: siteId)
 
         GutenbergSettings()
             .setSupports(.blockEditorSettings, hasBlockSettings, for: blog)
             .setSupports(.blockTheme, hasBlockTheme, for: blog)
-            .setSupports(.plugins, supportsPlugins, for: blog)
+            .setSupports(.editorAssets, supportsEditorAssets, for: blog)
     }
 
     /// Query the server for its editor capabilities, and update the local editor settings store with the result.

--- a/WordPress/Classes/Utility/Editor/GutenbergSettings+ThirdPartyBlocks.swift
+++ b/WordPress/Classes/Utility/Editor/GutenbergSettings+ThirdPartyBlocks.swift
@@ -86,8 +86,14 @@ extension GutenbergSettings {
 
         // Requires a WP.com Simple site, or an application password to authenticate all REST API
         // requests — including those originating from non-core blocks.
-        let applicationPassword = appPassword ?? (try? blog.getApplicationToken(using: keychain))
-        guard blog.isHostedAtWPcom || applicationPassword != nil else {
+        //
+        // The keychain lookup is a synchronous Security-framework call and this runs on the main
+        // thread while cells and footers are built, so it is deferred behind the WP.com check
+        // rather than resolved up front.
+        let hasApplicationPassword = {
+            (appPassword ?? (try? blog.getApplicationToken(using: keychain))) != nil
+        }
+        guard blog.isHostedAtWPcom || hasApplicationPassword() else {
             return .unsupported
         }
 
@@ -125,16 +131,37 @@ extension GutenbergSettingsBridge {
         }
     }
 
-    /// Whether the Site Settings row should be shown for the given blog.
-    @objc(isThirdPartyBlocksVisibleForBlog:)
-    public static func isThirdPartyBlocksVisible(for blog: Blog) -> Bool {
-        GutenbergSettings().resolveThirdPartyBlocks(for: blog).isVisibleInSiteSettings
+    /// The resolved third-party blocks capability, in a form Objective-C can hold onto.
+    ///
+    /// Resolving reads the keychain, so callers that ask more than once per pass — Site Settings
+    /// builds its sections, cell, and footer from it — should resolve once and pass the result to
+    /// the `...ForCapability:` accessors below.
+    @objc(ThirdPartyBlocksCapabilityValue)
+    public enum CapabilityValue: Int {
+        case hidden
+        case unsupported
+        case available
     }
 
-    /// Whether the Site Settings row should be interactive for the given blog. A visible but
-    /// non-interactive row means the site can't support the feature.
-    @objc(isThirdPartyBlocksSupportedForBlog:)
-    public static func isThirdPartyBlocksSupported(for blog: Blog) -> Bool {
-        GutenbergSettings().resolveThirdPartyBlocks(for: blog).isInteractive
+    @objc(thirdPartyBlocksCapabilityForBlog:)
+    public static func thirdPartyBlocksCapability(for blog: Blog) -> CapabilityValue {
+        switch GutenbergSettings().resolveThirdPartyBlocks(for: blog) {
+        case .hidden: return .hidden
+        case .unsupported: return .unsupported
+        case .available: return .available
+        }
+    }
+
+    /// Whether the Site Settings row should be shown.
+    @objc(isThirdPartyBlocksVisibleForCapability:)
+    public static func isThirdPartyBlocksVisible(for capability: CapabilityValue) -> Bool {
+        capability != .hidden
+    }
+
+    /// Whether the Site Settings row should be interactive. A visible but non-interactive row
+    /// means the site can't support the feature.
+    @objc(isThirdPartyBlocksSupportedForCapability:)
+    public static func isThirdPartyBlocksSupported(for capability: CapabilityValue) -> Bool {
+        capability == .available
     }
 }

--- a/WordPress/Classes/Utility/Editor/GutenbergSettings+ThirdPartyBlocks.swift
+++ b/WordPress/Classes/Utility/Editor/GutenbergSettings+ThirdPartyBlocks.swift
@@ -1,0 +1,140 @@
+import Foundation
+import WordPressCore
+import WordPressData
+import WordPressShared
+
+/// The resolved state of the third-party blocks ("plugins") capability for a site.
+///
+/// Mirrors Android's `EditorCapabilityResolver` so both platforms surface the feature
+/// identically. The remote feature flag, the site's advertised capability, and the user's
+/// per-site preference compose as AND: the editor loads third-party blocks only when all
+/// three agree.
+enum ThirdPartyBlocksCapability: Equatable {
+    /// The feature is not being offered. The Site Settings row is hidden.
+    case hidden
+
+    /// The site cannot support third-party blocks. The row is shown but disabled, with an
+    /// explanation, matching Android's treatment.
+    case unsupported
+
+    /// The site supports third-party blocks. The associated value is the user's preference.
+    case available(Bool)
+
+    /// Whether the editor should load third-party blocks.
+    ///
+    /// True only for `.available(true)` — the collapsed form of the precedence table.
+    var shouldApplyInEditor: Bool {
+        switch self {
+        case .hidden, .unsupported:
+            return false
+        case .available(let isEnabled):
+            return isEnabled
+        }
+    }
+
+    /// Whether the Site Settings row should be shown at all.
+    var isVisibleInSiteSettings: Bool {
+        switch self {
+        case .hidden:
+            return false
+        case .unsupported, .available:
+            return true
+        }
+    }
+
+    /// Whether the Site Settings row should be interactive.
+    var isInteractive: Bool {
+        switch self {
+        case .hidden, .unsupported:
+            return false
+        case .available:
+            return true
+        }
+    }
+}
+
+extension GutenbergSettings {
+    /// Resolves whether third-party blocks are offered, supported, and enabled for the given blog.
+    ///
+    /// Precedence:
+    /// 1. Remote flag off → `.hidden`
+    /// 2. Site can't authenticate non-core block requests → `.unsupported`
+    /// 3. Site doesn't advertise the `editor-assets` route → `.unsupported`
+    /// 4. Otherwise → `.available(userPreference)`
+    ///
+    /// A site whose capability has not been probed yet is treated as supported rather than
+    /// unsupported. The probe is fire-and-forget (see `EditorDependencyManager`), so it may not
+    /// have completed — or, on a fresh install, run at all — by the time this is called. Assuming
+    /// support keeps the setting reachable; the editor still degrades gracefully if the route is
+    /// genuinely absent, whereas assuming the opposite would disable the row on capable sites.
+    ///
+    /// - Parameters:
+    ///   - blog: The blog to resolve the capability for
+    ///   - appPassword: The blog's application password, if one has already been loaded. Pass this
+    ///     to avoid a redundant keychain read; omit it to have the value looked up.
+    ///   - isFeatureFlagEnabled: Whether the remote feature flag is on. Defaults to the live value.
+    /// - Returns: The resolved capability
+    func resolveThirdPartyBlocks(
+        for blog: Blog,
+        appPassword: String? = nil,
+        keychain: KeychainAccessible = AppKeychain(),
+        isFeatureFlagEnabled: Bool = RemoteFeatureFlag.newGutenbergPlugins.enabled()
+    ) -> ThirdPartyBlocksCapability {
+        guard isFeatureFlagEnabled else {
+            return .hidden
+        }
+
+        // Requires a WP.com Simple site, or an application password to authenticate all REST API
+        // requests — including those originating from non-core blocks.
+        let applicationPassword = appPassword ?? (try? blog.getApplicationToken(using: keychain))
+        guard blog.isHostedAtWPcom || applicationPassword != nil else {
+            return .unsupported
+        }
+
+        // Treat "not probed yet" as supported — see the note above.
+        let hasProbed = hasProbedSupport(for: .editorAssets, blog: blog)
+        guard !hasProbed || getSupports(.editorAssets, for: blog) else {
+            return .unsupported
+        }
+
+        return .available(isThirdPartyBlocksEnabled(for: blog))
+    }
+}
+
+extension GutenbergSettingsBridge {
+    @objc(isThirdPartyBlocksEnabledForBlog:)
+    public static func isThirdPartyBlocksEnabled(for blog: Blog) -> Bool {
+        GutenbergSettings().isThirdPartyBlocksEnabled(for: blog)
+    }
+
+    @objc(setThirdPartyBlocksEnabled:forBlog:)
+    public static func setThirdPartyBlocksEnabled(_ isEnabled: Bool, for blog: Blog) {
+        GutenbergSettings().setThirdPartyBlocksEnabled(isEnabled, for: blog)
+        invalidatePrefetchedEditor(for: blog)
+    }
+
+    /// Discards the editor dependencies prefetched for this site.
+    ///
+    /// The editor is warmed up ahead of time using an `EditorConfiguration` built from these
+    /// preferences, so a cached editor would keep the setting the user just changed until the
+    /// cache happened to be evicted.
+    static func invalidatePrefetchedEditor(for blog: Blog) {
+        let blogID = TaggedManagedObjectID(blog)
+        Task {
+            await EditorDependencyManager.shared.invalidate(for: blogID)
+        }
+    }
+
+    /// Whether the Site Settings row should be shown for the given blog.
+    @objc(isThirdPartyBlocksVisibleForBlog:)
+    public static func isThirdPartyBlocksVisible(for blog: Blog) -> Bool {
+        GutenbergSettings().resolveThirdPartyBlocks(for: blog).isVisibleInSiteSettings
+    }
+
+    /// Whether the Site Settings row should be interactive for the given blog. A visible but
+    /// non-interactive row means the site can't support the feature.
+    @objc(isThirdPartyBlocksSupportedForBlog:)
+    public static func isThirdPartyBlocksSupported(for blog: Blog) -> Bool {
+        GutenbergSettings().resolveThirdPartyBlocks(for: blog).isInteractive
+    }
+}

--- a/WordPress/Classes/Utility/Editor/GutenbergSettings.swift
+++ b/WordPress/Classes/Utility/Editor/GutenbergSettings.swift
@@ -22,6 +22,10 @@ class GutenbergSettings {
             let url = urlString(fromBlogURL: url)
             return "com.wordpress.gutenberg-theme-styles-" + url
         }
+        static func thirdPartyBlocksEnabled(forBlogURL url: String?) -> String {
+            let url = urlString(fromBlogURL: url)
+            return "com.wordpress.gutenberg-third-party-blocks-" + url
+        }
         static let focalPointPickerTooltipShown = "kGutenbergFocalPointPickerTooltipShown"
         static let blockTypeImpressions = "kBlockTypeImpressions"
 
@@ -258,6 +262,29 @@ class GutenbergSettings {
         database.set(isEnabled, forKey: Key.themeStylesEnabled(forBlogURL: blog.url))
     }
 
+    // MARK: - Third-Party Blocks
+
+    /// Returns whether third-party blocks are enabled for the given blog.
+    ///
+    /// This is the user's per-site preference only. It is stored locally and is never
+    /// posted to the server. Whether the preference is honored also depends on the
+    /// remote feature flag and on the site advertising the capability.
+    ///
+    /// - Parameter blog: The blog to check the third-party blocks setting for
+    /// - Returns: true if the user opted in, false otherwise (default: false)
+    func isThirdPartyBlocksEnabled(for blog: Blog) -> Bool {
+        database.bool(forKey: Key.thirdPartyBlocksEnabled(forBlogURL: blog.url))
+    }
+
+    /// Sets whether third-party blocks are enabled for the given blog.
+    ///
+    /// - Parameters:
+    ///   - isEnabled: Whether to enable third-party blocks
+    ///   - blog: The blog to set the third-party blocks setting for
+    func setThirdPartyBlocksEnabled(_ isEnabled: Bool, for blog: Blog) {
+        database.set(isEnabled, forKey: Key.thirdPartyBlocksEnabled(forBlogURL: blog.url))
+    }
+
     /// Sets whether the given API feature is available for the given blog. This is unrelated to whether it's *enabled* for that blog.
     ///
     /// - Parameters:
@@ -282,6 +309,21 @@ class GutenbergSettings {
         }
 
         return false
+    }
+
+    /// Returns whether the server has been queried for support of the given API feature on the given blog.
+    ///
+    /// `getSupports(_:for:)` reports `false` both for "the server said no" and for "we never
+    /// asked". Callers that need to tell those apart — to avoid presenting an unprobed site as
+    /// unsupported — should check this first.
+    ///
+    /// - Parameters:
+    ///   - feature: The API feature to check
+    ///   - blog: The blog to check the given API feature for
+    /// - Returns: true if a capability probe has recorded a result for this feature and blog
+    func hasProbedSupport(for feature: WordPressClient.Feature, blog: Blog) -> Bool {
+        let key = "org.wordpress.gutenberg-supports-" + feature.stringValue + "-" + blog.locallyUniqueId
+        return database.object(forKey: key) != nil
     }
 }
 
@@ -310,6 +352,7 @@ public class GutenbergSettingsBridge: NSObject {
     @objc(setThemeStylesEnabled:forBlog:)
     public static func setThemeStylesEnabled(_ isEnabled: Bool, for blog: Blog) {
         GutenbergSettings().setThemeStylesEnabled(isEnabled, for: blog)
+        invalidatePrefetchedEditor(for: blog)
     }
 
     @objc(isThemeStylesSupportedForBlog:)

--- a/WordPress/Classes/Utility/Editor/GutenbergSettings.swift
+++ b/WordPress/Classes/Utility/Editor/GutenbergSettings.swift
@@ -26,6 +26,13 @@ class GutenbergSettings {
             let url = urlString(fromBlogURL: url)
             return "com.wordpress.gutenberg-third-party-blocks-" + url
         }
+        /// Keyed on the blog rather than its URL, so the record survives a site changing address.
+        ///
+        /// Reading and writing must agree exactly: `hasProbedSupport(for:blog:)` tells "the server
+        /// said no" from "we never asked" purely by whether this key is present.
+        static func supports(_ feature: WordPressClient.Feature, forBlog blog: Blog) -> String {
+            "org.wordpress.gutenberg-supports-" + feature.stringValue + "-" + blog.locallyUniqueId
+        }
         static let focalPointPickerTooltipShown = "kGutenbergFocalPointPickerTooltipShown"
         static let blockTypeImpressions = "kBlockTypeImpressions"
 
@@ -292,8 +299,7 @@ class GutenbergSettings {
     ///   - blog: The blog to set theme styles setting for
     @discardableResult
     func setSupports(_ feature: WordPressClient.Feature, _ newValue: Bool, for blog: Blog) -> Self {
-        let key = "org.wordpress.gutenberg-supports-" + feature.stringValue + "-" + blog.locallyUniqueId
-        database.set(newValue, forKey: key)
+        database.set(newValue, forKey: Key.supports(feature, forBlog: blog))
         return self
     }
 
@@ -302,7 +308,7 @@ class GutenbergSettings {
     /// - Parameter blog: The blog to check the given API feature for
     /// - Returns: true if the feature is available, false if the server hasn't been queried for support yet, or if the server doesn't support it.
     func getSupports(_ feature: WordPressClient.Feature, for blog: Blog) -> Bool {
-        let key = "org.wordpress.gutenberg-supports-" + feature.stringValue + "-" + blog.locallyUniqueId
+        let key = Key.supports(feature, forBlog: blog)
 
         if database.object(forKey: key) != nil {
             return database.bool(forKey: key)
@@ -322,8 +328,7 @@ class GutenbergSettings {
     ///   - blog: The blog to check the given API feature for
     /// - Returns: true if a capability probe has recorded a result for this feature and blog
     func hasProbedSupport(for feature: WordPressClient.Feature, blog: Blog) -> Bool {
-        let key = "org.wordpress.gutenberg-supports-" + feature.stringValue + "-" + blog.locallyUniqueId
-        return database.object(forKey: key) != nil
+        database.object(forKey: Key.supports(feature, forBlog: blog)) != nil
     }
 }
 

--- a/WordPress/Classes/Utility/Editor/GutenbergSettings.swift
+++ b/WordPress/Classes/Utility/Editor/GutenbergSettings.swift
@@ -26,11 +26,11 @@ class GutenbergSettings {
         static let blockTypeImpressions = "kBlockTypeImpressions"
 
         private static func urlString(fromBlogURL url: String?) -> String {
-            return (url ?? "")
-            // New sites will add a slash at the end of URL.
-            // This is removed when the URL is refreshed from remote.
-            // Removing trailing '/' in case there is one for consistency.
-            .removingTrailingCharacterIfExists("/")
+            (url ?? "")
+                // New sites will add a slash at the end of URL.
+                // This is removed when the URL is refreshed from remote.
+                // Removing trailing '/' in case there is one for consistency.
+                .removingTrailingCharacterIfExists("/")
         }
     }
 
@@ -91,7 +91,8 @@ class GutenbergSettings {
         let blogURLs: [String?] = coreDataStack.performQuery { context in
             guard let blogs = try? BlogQuery().blogs(in: context) else { return [] }
 
-            return blogs
+            return
+                blogs
                 .filter { $0.editor == .aztec }
                 .map { $0.url }
         }
@@ -100,13 +101,17 @@ class GutenbergSettings {
             database.set(true, forKey: Key.enabledOnce(forBlogURL: blogURL))
         }
         let editorSettingsService = EditorSettingsService(coreDataStack: coreDataStack)
-        editorSettingsService.migrateGlobalSettingToRemote(isGutenbergEnabled: true, overrideRemote: true, onSuccess: {
-            WPAnalytics.refreshMetadata()
-        })
+        editorSettingsService.migrateGlobalSettingToRemote(
+            isGutenbergEnabled: true,
+            overrideRemote: true,
+            onSuccess: {
+                WPAnalytics.refreshMetadata()
+            }
+        )
     }
 
     func shouldPresentInformativeDialog(for blog: Blog) -> Bool {
-        return database.bool(forKey: Key.showPhase2Dialog(forBlogURL: blog.url))
+        database.bool(forKey: Key.showPhase2Dialog(forBlogURL: blog.url))
     }
 
     func setShowPhase2Dialog(_ showDialog: Bool, forBlogURL url: String?) {
@@ -129,12 +134,16 @@ class GutenbergSettings {
         let mobileEditor: MobileEditor = isEnabled ? .gutenberg : .aztec
         blog.mobileEditor = mobileEditor
 
-        coreDataStack.performAndSave({ context in
-            let blogInContext = try? context.existingObject(with: blog.objectID) as? Blog
-            blogInContext?.mobileEditor = mobileEditor
-        }, completion: {
-            WPAnalytics.refreshMetadata()
-        }, on: .main)
+        coreDataStack.performAndSave(
+            { context in
+                let blogInContext = try? context.existingObject(with: blog.objectID) as? Blog
+                blogInContext?.mobileEditor = mobileEditor
+            },
+            completion: {
+                WPAnalytics.refreshMetadata()
+            },
+            on: .main
+        )
     }
 
     private func shouldUpdateSettings(enabling isEnablingGutenberg: Bool, for blog: Blog) -> Bool {
@@ -162,12 +171,12 @@ class GutenbergSettings {
 
     /// True if gutenberg editor has been enabled at least once on the given blog
     func wasGutenbergEnabledOnce(for blog: Blog) -> Bool {
-        return database.object(forKey: Key.enabledOnce(forBlogURL: blog.url)) != nil
+        database.object(forKey: Key.enabledOnce(forBlogURL: blog.url)) != nil
     }
 
     /// True if gutenberg should be autoenabled for the blog hosting the given post.
     func shouldAutoenableGutenberg(for post: AbstractPost) -> Bool {
-        return !wasGutenbergEnabledOnce(for: post.blog)
+        !wasGutenbergEnabledOnce(for: post.blog)
     }
 
     func willShowDialog(for blog: Blog) {
@@ -196,7 +205,7 @@ class GutenbergSettings {
     // MARK: - Gutenberg Choice Logic
 
     func isSimpleWPComSite(_ blog: Blog) -> Bool {
-        return !blog.isAtomic && blog.isHostedAtWPcom
+        !blog.isAtomic && blog.isHostedAtWPcom
     }
 
     /// Call this method to know if Gutenberg must be used for the specified post.
@@ -290,12 +299,12 @@ public class GutenbergSettingsBridge: NSObject {
 
     @objc(isSimpleWPComSite:)
     public static func isSimpleWPComSite(_ blog: Blog) -> Bool {
-        return GutenbergSettings().isSimpleWPComSite(blog)
+        GutenbergSettings().isSimpleWPComSite(blog)
     }
 
     @objc(isThemeStylesEnabledForBlog:)
     public static func isThemeStylesEnabled(for blog: Blog) -> Bool {
-        return GutenbergSettings().isThemeStylesEnabled(for: blog)
+        GutenbergSettings().isThemeStylesEnabled(for: blog)
     }
 
     @objc(setThemeStylesEnabled:forBlog:)

--- a/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteSettingsViewController+Swift.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteSettingsViewController+Swift.swift
@@ -267,7 +267,7 @@ extension SiteSettingsViewController {
         let footer = makeFooterView()
 
         var text = Strings.thirdPartyBlocksFooterEnabled
-        if case .unsupported = GutenbergSettings().resolveThirdPartyBlocks(for: self.blog) {
+        if GutenbergSettingsBridge.CapabilityValue(rawValue: self.thirdPartyBlocksCapabilityValue()) == .unsupported {
             text += "\n\n" + Strings.thirdPartyBlocksFooterUnsupported
         }
         footer.textLabel?.text = text

--- a/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteSettingsViewController+Swift.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteSettingsViewController+Swift.swift
@@ -252,10 +252,14 @@ extension SiteSettingsViewController {
         let settings = GutenbergSettings()
 
         var text = Strings.themeStylesFooterEnabled
-        if !settings.getSupports(.blockTheme, for: self.blog) {
-            text += "\n\n" + Strings.themeStylesFooterBlockThemeSuggested
-        } else if !settings.getSupports(.blockEditorSettings, for: self.blog) {
+        // Ordered to match what gates the row: missing block editor settings is what disables the
+        // toggle, so it has to be the reason shown. A non-block theme only means the styles may
+        // not match, which is advice for a site whose toggle still works — a site failing both
+        // would otherwise be told to check its theme while the switch sat greyed out.
+        if !settings.getSupports(.blockEditorSettings, for: self.blog) {
             text += "\n\n" + Strings.themeStylesFooterGutenbergRequired
+        } else if !settings.getSupports(.blockTheme, for: self.blog) {
+            text += "\n\n" + Strings.themeStylesFooterBlockThemeSuggested
         }
         footer.textLabel?.text = text
 
@@ -564,7 +568,7 @@ private extension SiteSettingsViewController {
             value:
                 "Your site isn't using a Block Theme, so the editor might not match your content correctly. If things aren't looking right, you can disable editor styles.",
             comment:
-                "Explanation for why the 'Use theme styles' toggle is disabled when the site doesn't have a block theme"
+                "Caveat shown under the 'Use theme styles' toggle when the site doesn't have a block theme. The toggle still works; the styles may just not match the content."
         )
 
         static let themeStylesFooterGutenbergRequired = NSLocalizedString(

--- a/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteSettingsViewController+Swift.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteSettingsViewController+Swift.swift
@@ -92,7 +92,16 @@ extension SiteSettingsViewController {
             return
         }
 
-        EditorDependencyManager.shared.fetchEditorCapabilities(for: self.blog)
+        // The probe is asynchronous, and the editor rows are built from its results. Without
+        // reloading when it lands, the rows keep whatever state they were built with — which,
+        // on first load, is before any capability is known.
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+
+            try? await EditorDependencyManager.shared.fetchEditorCapabilities(for: self.blog)
+
+            self.reloadSections()
+        }
     }
 
     // MARK: - Timezone
@@ -241,13 +250,27 @@ extension SiteSettingsViewController {
     public func themeStylesSectionFooterView() -> UIView {
         let footer = makeFooterView()
         let settings = GutenbergSettings()
+
+        var text = Strings.themeStylesFooterEnabled
         if !settings.getSupports(.blockTheme, for: self.blog) {
-            footer.textLabel?.text = Strings.themeStylesFooterBlockThemeSuggested
+            text += "\n\n" + Strings.themeStylesFooterBlockThemeSuggested
         } else if !settings.getSupports(.blockEditorSettings, for: self.blog) {
-            footer.textLabel?.text = Strings.themeStylesFooterGutenbergRequired
-        } else {
-            footer.textLabel?.text = Strings.themeStylesFooterEnabled
+            text += "\n\n" + Strings.themeStylesFooterGutenbergRequired
         }
+        footer.textLabel?.text = text
+
+        return footer
+    }
+
+    @objc(getThirdPartyBlocksSectionFooterView)
+    public func thirdPartyBlocksSectionFooterView() -> UIView {
+        let footer = makeFooterView()
+
+        var text = Strings.thirdPartyBlocksFooterEnabled
+        if case .unsupported = GutenbergSettings().resolveThirdPartyBlocks(for: self.blog) {
+            text += "\n\n" + Strings.thirdPartyBlocksFooterUnsupported
+        }
+        footer.textLabel?.text = text
 
         return footer
     }
@@ -555,6 +578,19 @@ private extension SiteSettingsViewController {
             "siteSettings.themeStyles.footer.enabled",
             value: "Make the block editor look like your theme.",
             comment: "Explanation for the option to enable theme styles when the feature is available"
+        )
+
+        static let thirdPartyBlocksFooterEnabled = NSLocalizedString(
+            "siteSettings.thirdPartyBlocks.footer.enabled",
+            value: "Load third-party blocks from plugins installed on your site.",
+            comment: "Explanation for the option to load blocks provided by plugins installed on the site"
+        )
+
+        static let thirdPartyBlocksFooterUnsupported = NSLocalizedString(
+            "siteSettings.thirdPartyBlocks.footer.unsupported",
+            value: "Install the Jetpack plugin on your site to activate third-party block support.",
+            comment:
+                "Explanation appended to the 'Use third-party blocks' footer when the site can't support the feature"
         )
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteSettingsViewController+Swift.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteSettingsViewController+Swift.swift
@@ -569,7 +569,7 @@ private extension SiteSettingsViewController {
 
         static let themeStylesFooterGutenbergRequired = NSLocalizedString(
             "siteSettings.themeStyles.footer.gutenbergRequired",
-            value: "Install the Gutenberg Plugin on your site to activate theme style support.",
+            value: "Install the Gutenberg plugin on your site to activate theme style support.",
             comment:
                 "Explanation for why the 'Use theme styles' toggle is disabled when the site doesn't have the Gutenberg plugin"
         )

--- a/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteSettingsViewController.h
+++ b/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteSettingsViewController.h
@@ -11,6 +11,7 @@ typedef NS_ENUM(NSInteger, SiteSettingsSection) {
     SiteSettingsSectionAccount,
     SiteSettingsSectionBlockEditor,
     SiteSettingsSectionThemeStyles,
+    SiteSettingsSectionThirdPartyBlocks,
     SiteSettingsSectionWriting,
     SiteSettingsSectionMedia,
     SiteSettingsSectionDiscussion,
@@ -26,6 +27,12 @@ typedef NS_ENUM(NSInteger, SiteSettingsSection) {
 - (instancetype)initWithBlog:(Blog *)blog;
 
 - (void)saveSettingsWithChanges:(BlogSettingsChanges *)changes;
+
+/// Rebuilds the section list and reloads the table.
+///
+/// Editor capabilities are fetched asynchronously and decide which editor rows are shown and
+/// whether they're interactive, so the table has to be rebuilt once they arrive.
+- (void)reloadSections;
 
 // General Settings: These were made available here to help with the transition to Swift.
 

--- a/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteSettingsViewController.h
+++ b/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteSettingsViewController.h
@@ -34,6 +34,14 @@ typedef NS_ENUM(NSInteger, SiteSettingsSection) {
 /// whether they're interactive, so the table has to be rebuilt once they arrive.
 - (void)reloadSections;
 
+/// The resolved third-party blocks capability, cached for the current reload pass.
+///
+/// Resolving reads the keychain, and the section list, cell, and footer each need the value while
+/// the table is being built, so it is resolved once and reused. Returns a raw
+/// `ThirdPartyBlocksCapabilityValue`; the caller in `SiteSettingsViewController+Swift` wraps it
+/// back into the enum.
+- (NSInteger)thirdPartyBlocksCapabilityValue;
+
 // General Settings: These were made available here to help with the transition to Swift.
 
 - (void)showLanguageSelectorForBlog:(Blog *)blog;

--- a/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteSettingsViewController.m
@@ -87,6 +87,10 @@ NS_ENUM(NSInteger, SiteSettingsJetpack) {
 
 @property (nonatomic, strong) NSArray<NSNumber *> *tableSections;
 @property (nonatomic, strong) NSArray<NSNumber *> *writingSectionRows;
+/// Caches the resolved third-party blocks capability for one reload pass. Resolving it reads the
+/// keychain, and the sections, cells, and footers each ask for it while the table is being built.
+/// Cleared by `reloadSections` so the next pass picks up newly probed capabilities.
+@property (nonatomic, strong) NSNumber *cachedThirdPartyBlocksCapability;
 @end
 
 @implementation SiteSettingsViewController
@@ -143,6 +147,7 @@ NS_ENUM(NSInteger, SiteSettingsJetpack) {
 {
     [super viewDidAppear:animated];
 
+    self.cachedThirdPartyBlocksCapability = nil; // re-resolve against newly probed capabilities.
     [self.tableView reloadData];
 }
 
@@ -177,7 +182,7 @@ NS_ENUM(NSInteger, SiteSettingsJetpack) {
 
         // Third-party blocks are gated behind their own remote flag, and the row is hidden
         // outright for sites that aren't offered the feature.
-        if ([GutenbergSettings isThirdPartyBlocksVisibleForBlog:self.blog]) {
+        if ([GutenbergSettings isThirdPartyBlocksVisibleForCapability:[self thirdPartyBlocksCapabilityValue]]) {
             [sections addObject:@(SiteSettingsSectionThirdPartyBlocks)];
         }
     }
@@ -559,7 +564,7 @@ NS_ENUM(NSInteger, SiteSettingsJetpack) {
     // Use the property, not the ivar: the cell is created lazily, so on the first pass the ivar
     // is still nil and assigning to it is silently dropped — leaving the row with the disabled
     // state its factory applies.
-    BOOL isSupported = [GutenbergSettings isThirdPartyBlocksSupportedForBlog:self.blog];
+    BOOL isSupported = [GutenbergSettings isThirdPartyBlocksSupportedForCapability:[self thirdPartyBlocksCapabilityValue]];
     self.thirdPartyBlocksSelectorCell.isEnabled = isSupported;
     [self.thirdPartyBlocksSelectorCell setOn:isSupported && [GutenbergSettings isThirdPartyBlocksEnabledForBlog:self.blog]];
 }
@@ -1057,9 +1062,18 @@ NS_ENUM(NSInteger, SiteSettingsJetpack) {
     [self refreshData];
 }
 
+- (NSInteger)thirdPartyBlocksCapabilityValue
+{
+    if (!self.cachedThirdPartyBlocksCapability) {
+        self.cachedThirdPartyBlocksCapability = @([GutenbergSettings thirdPartyBlocksCapabilityForBlog:self.blog]);
+    }
+    return self.cachedThirdPartyBlocksCapability.integerValue;
+}
+
 - (void)reloadSections
 {
     self.tableSections = nil; // force the tableSections to be repopulated.
+    self.cachedThirdPartyBlocksCapability = nil; // re-resolve against newly probed capabilities.
     [self.tableView reloadData];
 }
 
@@ -1071,6 +1085,7 @@ NS_ENUM(NSInteger, SiteSettingsJetpack) {
     [service syncSettingsForBlog:self.blog success:^{
         [weakSelf.refreshControl endRefreshing];
         self.tableSections = nil; // force the tableSections to be repopulated.
+        self.cachedThirdPartyBlocksCapability = nil; // re-resolve against newly probed capabilities.
         [weakSelf.tableView reloadData];
     } failure:^(NSError * __unused error) {
         [weakSelf.refreshControl endRefreshing];

--- a/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteSettingsViewController.m
@@ -57,6 +57,7 @@ NS_ENUM(NSInteger, SiteSettingsJetpack) {
 #pragma mark - Writing Section
 @property (nonatomic, strong) SwitchTableViewCell  *editorSelectorCell;
 @property (nonatomic, strong) SwitchTableViewCell  *themeStylesSelectorCell;
+@property (nonatomic, strong) SwitchTableViewCell  *thirdPartyBlocksSelectorCell;
 @property (nonatomic, strong) SettingTableViewCell *defaultCategoryCell;
 @property (nonatomic, strong) SettingTableViewCell *tagsCell;
 @property (nonatomic, strong) SettingTableViewCell *customTaxonomiesCell;
@@ -173,6 +174,12 @@ NS_ENUM(NSInteger, SiteSettingsJetpack) {
     // Only show theme styles toggle when GutenbergKit is enabled
     if ([RemoteFeature enabled:RemoteFeatureFlagNewGutenberg]) {
         [sections addObject:@(SiteSettingsSectionThemeStyles)];
+
+        // Third-party blocks are gated behind their own remote flag, and the row is hidden
+        // outright for sites that aren't offered the feature.
+        if ([GutenbergSettings isThirdPartyBlocksVisibleForBlog:self.blog]) {
+            [sections addObject:@(SiteSettingsSectionThirdPartyBlocks)];
+        }
     }
 
     if ([self.blog supports:BlogFeatureWpComRESTAPI] && self.blog.isAdmin) {
@@ -256,6 +263,10 @@ NS_ENUM(NSInteger, SiteSettingsJetpack) {
             return 1;
         }
         case SiteSettingsSectionThemeStyles:
+        {
+            return 1;
+        }
+        case SiteSettingsSectionThirdPartyBlocks:
         {
             return 1;
         }
@@ -359,12 +370,29 @@ NS_ENUM(NSInteger, SiteSettingsJetpack) {
             [GutenbergSettings setThemeStylesEnabled:value forBlog:blog];
         };
 
-        // Default to greyed-out, only make the control interactive if theme styles are supported
-        _themeStylesSelectorCell.flipSwitch.enabled = false;
-        _themeStylesSelectorCell.textLabel.textColor = UIColor.lightGrayColor;
+        // Default to disabled, only make the control interactive if theme styles are supported
+        _themeStylesSelectorCell.isEnabled = false;
         [self.themeStylesSelectorCell setOn:false];
     }
     return _themeStylesSelectorCell;
+}
+
+- (SwitchTableViewCell *)thirdPartyBlocksSelectorCell
+{
+    if (!_thirdPartyBlocksSelectorCell) {
+        _thirdPartyBlocksSelectorCell = [SwitchTableViewCell new];
+        _thirdPartyBlocksSelectorCell.name = NSLocalizedString(@"Use third-party blocks (beta)", @"Option to load blocks provided by plugins installed on the site");
+        _thirdPartyBlocksSelectorCell.flipSwitch.accessibilityIdentifier = @"useThirdPartyBlocksSwitch";
+        __weak Blog *blog = self.blog;
+        _thirdPartyBlocksSelectorCell.onChange = ^(BOOL value){
+            [GutenbergSettings setThirdPartyBlocksEnabled:value forBlog:blog];
+        };
+
+        // Default to disabled, only make the control interactive if the site supports the feature
+        _thirdPartyBlocksSelectorCell.isEnabled = false;
+        [self.thirdPartyBlocksSelectorCell setOn:false];
+    }
+    return _thirdPartyBlocksSelectorCell;
 }
 
 - (SettingTableViewCell *)defaultCategoryCell
@@ -521,11 +549,19 @@ NS_ENUM(NSInteger, SiteSettingsJetpack) {
 
 - (void)configureThemeStylesSelectorCell
 {
-    if ([GutenbergSettings isThemeStylesSupportedForBlog: self.blog]){
-        _themeStylesSelectorCell.flipSwitch.enabled = true;
-        _themeStylesSelectorCell.textLabel.textColor = UIColor.labelColor;
-        [self.themeStylesSelectorCell setOn:[GutenbergSettings isThemeStylesEnabledForBlog:self.blog]];
-    }
+    BOOL isSupported = [GutenbergSettings isThemeStylesSupportedForBlog:self.blog];
+    self.themeStylesSelectorCell.isEnabled = isSupported;
+    [self.themeStylesSelectorCell setOn:isSupported && [GutenbergSettings isThemeStylesEnabledForBlog:self.blog]];
+}
+
+- (void)configureThirdPartyBlocksSelectorCell
+{
+    // Use the property, not the ivar: the cell is created lazily, so on the first pass the ivar
+    // is still nil and assigning to it is silently dropped — leaving the row with the disabled
+    // state its factory applies.
+    BOOL isSupported = [GutenbergSettings isThirdPartyBlocksSupportedForBlog:self.blog];
+    self.thirdPartyBlocksSelectorCell.isEnabled = isSupported;
+    [self.thirdPartyBlocksSelectorCell setOn:isSupported && [GutenbergSettings isThirdPartyBlocksEnabledForBlog:self.blog]];
 }
 
 - (void)configureDefaultCategoryCell
@@ -680,6 +716,10 @@ NS_ENUM(NSInteger, SiteSettingsJetpack) {
             [self configureThemeStylesSelectorCell];
             return self.themeStylesSelectorCell;
 
+        case SiteSettingsSectionThirdPartyBlocks:
+            [self configureThirdPartyBlocksSelectorCell];
+            return self.thirdPartyBlocksSelectorCell;
+
         case SiteSettingsSectionWriting:
             return [self tableView:tableView cellForWritingSettingsAtRow:indexPath.row];
 
@@ -753,6 +793,14 @@ NS_ENUM(NSInteger, SiteSettingsJetpack) {
             }
             break;
 
+        case SiteSettingsSectionThirdPartyBlocks:
+            // Only show "Editor" header if no earlier editor section already carries it
+            if (![self.tableSections containsObject:@(SiteSettingsSectionBlockEditor)]
+                && ![self.tableSections containsObject:@(SiteSettingsSectionThemeStyles)]) {
+                headingTitle = NSLocalizedString(@"Editor", @"Title for the editor section in site settings screen");
+            }
+            break;
+
         case SiteSettingsSectionWriting:
             headingTitle = NSLocalizedString(@"Writing", @"Title for the writing section in site settings screen");
             break;
@@ -787,6 +835,10 @@ NS_ENUM(NSInteger, SiteSettingsJetpack) {
 
         case SiteSettingsSectionThemeStyles:
             footerView = [self getThemeStylesSectionFooterView];
+            break;
+
+        case SiteSettingsSectionThirdPartyBlocks:
+            footerView = [self getThirdPartyBlocksSectionFooterView];
             break;
 
         case SiteSettingsSectionTraffic:
@@ -1003,6 +1055,12 @@ NS_ENUM(NSInteger, SiteSettingsJetpack) {
 - (IBAction)refreshTriggered:(id)sender
 {
     [self refreshData];
+}
+
+- (void)reloadSections
+{
+    self.tableSections = nil; // force the tableSections to be repopulated.
+    [self.tableView reloadData];
 }
 
 - (void)refreshData

--- a/WordPress/Classes/ViewRelated/Cells/SwitchTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Cells/SwitchTableViewCell.swift
@@ -26,6 +26,29 @@ open class SwitchTableViewCell: WPTableViewCell {
         }
     }
 
+    /// Whether the row can be toggled.
+    ///
+    /// Disabling the `flipSwitch` alone isn't enough: the whole row carries a tap gesture that
+    /// toggles the value, so the switch would still change when the row is tapped. This also
+    /// dims the label, and re-applies that dimming on layout — `WPStyleGuide.configureTableViewCell`
+    /// calls `sizeToFit()`, which restores the label's default color.
+    @objc open var isEnabled: Bool = true {
+        didSet {
+            flipSwitch.isEnabled = isEnabled
+            tapGestureRecognizer.isEnabled = isEnabled
+            applyLabelColor()
+        }
+    }
+
+    private func applyLabelColor() {
+        textLabel?.textColor = isEnabled ? .label : .secondaryLabel
+    }
+
+    open override func layoutSubviews() {
+        super.layoutSubviews()
+        applyLabelColor()
+    }
+
     // MARK: - Initializers
     public required init(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)!

--- a/WordPress/Classes/ViewRelated/Cells/SwitchTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Cells/SwitchTableViewCell.swift
@@ -29,9 +29,8 @@ open class SwitchTableViewCell: WPTableViewCell {
     /// Whether the row can be toggled.
     ///
     /// Disabling the `flipSwitch` alone isn't enough: the whole row carries a tap gesture that
-    /// toggles the value, so the switch would still change when the row is tapped. This also
-    /// dims the label, and re-applies that dimming on layout — `WPStyleGuide.configureTableViewCell`
-    /// calls `sizeToFit()`, which restores the label's default color.
+    /// toggles the value, so the switch would still change when the row is tapped. A disabled row
+    /// also dims its label, to match how the switch reads.
     @objc open var isEnabled: Bool = true {
         didSet {
             flipSwitch.isEnabled = isEnabled
@@ -44,9 +43,13 @@ open class SwitchTableViewCell: WPTableViewCell {
         textLabel?.textColor = isEnabled ? .label : .secondaryLabel
     }
 
-    open override func layoutSubviews() {
-        super.layoutSubviews()
-        applyLabelColor()
+    open override func prepareForReuse() {
+        super.prepareForReuse()
+
+        // Callers that never touch `isEnabled` — most of them — would otherwise inherit both the
+        // flag and the dimmed label from whichever row last used this cell, with no `didSet` to
+        // put either back.
+        isEnabled = true
     }
 
     // MARK: - Initializers

--- a/WordPress/Classes/ViewRelated/Cells/SwitchTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Cells/SwitchTableViewCell.swift
@@ -10,7 +10,7 @@ open class SwitchTableViewCell: WPTableViewCell {
 
     @objc open var name: String {
         get {
-            return textLabel?.text ?? String()
+            textLabel?.text ?? String()
         }
         set {
             textLabel?.text = newValue
@@ -19,7 +19,7 @@ open class SwitchTableViewCell: WPTableViewCell {
 
     @objc open var on: Bool {
         get {
-            return flipSwitch.isOn
+            flipSwitch.isOn
         }
         set {
             flipSwitch.isOn = newValue


### PR DESCRIPTION
## Description

Fixes [CMM-2265](https://linear.app/a8c/issue/CMM-2265/align-ios-third-party-blocks-setting-with-androids-user-facing-site).

The GutenbergKit third-party blocks ("plugins") feature is surfaced differently on each platform. Android gives users a per-site toggle in Site Settings; on iOS the only toggle lived in the internal-only Debug Menu, so no end user could enable it. This adopts Android's user-facing model.

Three things compose as AND — the editor receives `plugins = true` only when all agree:

| Order | Condition | State | Setting row | Editor |
| -- | -- | -- | -- | -- |
| 1 | `gutenberg_kit_plugins` off | `hidden` | Not shown | Off |
| 2 | Site can't authenticate, or lacks the `editor-assets` route | `unsupported` | Shown, disabled | Off |
| 3 | All pass | `available(userEnabled)` | Shown, interactive | Follows user |

The remote flag remains the outer kill switch and rollout control; the new setting is a per-site opt-in *within* an enabled rollout. Because the preference persists independently, toggling the flag off and on restores each site's prior choice.

**Eligibility is measured, not assumed.** The `editor-assets` route is provided by plugins, so it appears and disappears as those are activated — there's no site-shape heuristic that predicts it. The capability probe decides; the only other requirement is that the site can authenticate non-core block requests (a WP.com Simple site, or an application password).

Available | Unavailable
-- | -- 
<img width="750" height="1334" alt="available" src="https://github.com/user-attachments/assets/2f45678b-9311-473e-b865-4a45cdc516be" /> | <img width="750" height="1334" alt="unavailable" src="https://github.com/user-attachments/assets/1717ac62-5ef8-4de6-bb4b-baffce4c107a" />

## Pre-existing bugs this also fixes

Adding a second capability-gated row to Site Settings made several latent bugs reachable. Each was found during device testing; all affect the existing **Use theme styles** row identically, and several live in shared code beyond this feature's scope.

**The API client wasn't rebuilt when a site's credentials or transport changed.** A WordPress.com site starts proxied through the WP.com REST API and switches to addressing its own API root once an application password is created. The two roots key their discovery documents differently: the proxy namespaces every route under `/sites/{id}/`. `WordPressClientFactory` cached clients by blog alone and `WordPressClient` fetches its API root once in `init`, so after the transport flipped, non-namespaced route lookups were run against a still-cached proxy document. Every lookup missed, which read as "this site supports nothing" and disabled both editor rows until reinstall. Clients are now keyed on the transport's full identity, so rotating an application password or refreshing the site's REST API root — both of which change where requests go while the site stays direct — also retires the superseded client.

**The capability probe checked the plugin management route, not `editor-assets`.** The probe checked `Feature.plugins`, which resolves to `/wp/v2/plugins` (the plugin *management* API). Third-party blocks are served by `/wpcom/v2/editor-assets`. Adds `Feature.editorAssets`. A site serves that route under exactly one of two paths, decided by how the app reaches it: proxied through WP.com it is namespaced under `/sites/{id}/`, and addressed directly it is bare. The probe checks the form the editor will actually fetch, so a site advertising only the other form correctly resolves as unsupported rather than reporting support the editor can't deliver. `Feature.plugins` is left in place with its `stringValue` unchanged, so no stored settings are invalidated.

**One capability probe now runs per site.** Deduplication lived in the fire-and-forget wrapper rather than in the work itself, so callers that awaited results always started a second probe alongside the one My Site had already launched. Both entry points now join a single in-flight probe per site.

**Editor cells were configured through the backing ivar instead of the property.** The configure methods assigned `isEnabled` to the backing ivar, but the cells are created lazily by their getters. On first pass the ivar is `nil`, so the assignment was dropped; the next line called the getter, which created the cell with its factory default of disabled. A supported site rendered its row disabled until something forced a reconfigure — which is why cancelling a back swipe appeared to "fix" it.

**Editor rows weren't reloaded when capabilities arrived.** The probe is asynchronous but Site Settings built its rows once and never rebuilt them, so `viewDidLoad` ran before results landed. Also invalidates the prefetched editor when either preference is toggled — the editor is warmed up from an `EditorConfiguration` built with these values, so opening it after a toggle reused a cached editor with the old setting.

## Notes for reviewers

**The capability probe previously had no effect.** `EditorDependencyManager` wrote `.setSupports(.plugins, …)` but nothing outside tests ever read it. This PR makes it load-bearing — which is how the bugs above surfaced.

**Un-probed sites resolve as supported, deliberately.** `fetchEditorCapabilities` is fire-and-forget and gated behind `newGutenberg`, so on a fresh install it may not have run when the setting is first read. `getSupports` returns `false` for both "server said no" and "never asked", so `hasProbedSupport(for:blog:)` separates them. Treating un-probed as *unsupported* would disable the row on capable sites; treating it as supported degrades to an editor without plugin blocks, which is today's behavior anyway.

**The capability is resolved once per reload.** Resolving reads the keychain, and the section list, the cell, and the footer each need the value while the table is being built. Site Settings resolves it once per pass and caches it, invalidated wherever the table is rebuilt.

**`SwitchTableViewCell` gained a real `isEnabled`.** Disabling `flipSwitch` alone left the row's tap gesture active, so the value still toggled when the label was tapped. A disabled row also dims its label. Because most callers never assign `isEnabled` — `SwitchRow.configureCell` among them — the flag resets in `prepareForReuse`, so a dequeued cell doesn't inherit the previous row's state. Both editor rows adopt it.

**Tests:** the previous suite asserted site-type behavior throughout and was rewritten. It now covers flag-off, unsupported, un-probed, default-off, opted-in, per-site isolation, the flag off→on cycle, self-hosted sites with and without the capability, keychain injection, and the `shouldEnablePlugins` entry point. The route probe is covered in both directions: each site shape resolves its own form, and rejects the form the editor would not fetch. Two test-infrastructure fixes were needed: the flag value is injected rather than overriding the shared `FeatureFlagOverrideStore` (which parallel tests clobber), and builder-made blogs get `obtainPermanentIDs` — capability support is keyed on `Blog.locallyUniqueId`, which hashes the Core Data object ID, so a write made before Core Data promotes a temporary ID is read back under a different key.

## Testing instructions

> [!note]
> WordPress servers may send cached results when the app probes for capabilities, so there can be delays between disabling a plugin and seeing the result in the app.

Behind the `gutenberg_kit_plugins` remote flag, off by default. Enable it in **Me → App Settings → Debug → Feature Flags → "Experimental Block Editor Plugins"** (also requires "Experimental Block Editor").

1. **Flag off** → no "Use third-party blocks (beta)" row.
2. **WP.com Simple site** → row appears in the Editor section, off by default. Toggle on, open the editor, confirm plugin-provided blocks appear in the inserter. Toggle off → they're gone. This is the proxied case, where the route is namespaced under the site id.
3. **Atomic site** → same. Worth opening the editor first (which creates an application password and flips the site's transport), then returning to Site Settings — that sequence previously stranded both editor rows as disabled. Once an application password exists the site is addressed directly, so it exercises the bare form of the route.
4. **Self-hosted site with Gutenberg + Jetpack** → row enabled. Deactivate those plugins and refresh → row disabled, since the `editor-assets` route goes away with them.
5. **Per-site persistence** → enable on one site, confirm another is unaffected.
6. **Flag cycle** → with the toggle on, turn the remote flag off (row disappears), then on again; the previous choice is restored.
7. **Header check** → the "Editor" section header should appear exactly once.

Both editor rows are worth a pass in dark mode and at larger dynamic type sizes, since the disabled state now uses `.secondaryLabel`. The other `SwitchTableViewCell` screens — Sharing Buttons, Discussion Settings, Notification Settings — are worth a scroll to confirm rows still render enabled, since that cell is shared.
