### PR TITLE
Fixes an isuse where back up logs show up in Personal plan sites

### DIFF
--- a/Modules/Sources/WordPressData/Swift/Blog+Capabilities.swift
+++ b/Modules/Sources/WordPressData/Swift/Blog+Capabilities.swift
@@ -24,6 +24,22 @@ extension Blog {
         case viewStats = "view_stats"
     }
 
+    /// Features included in the site's current plan and products, as reported
+    /// by the sites API (`plan.features.active`). The slugs mirror wpcom's
+    /// WPCOM_Features and are what the web client checks before showing
+    /// feature UI, so they are the source of truth for plan gating.
+    ///
+    public enum PlanFeature: String {
+        case backupsSelfServe = "backups-self-serve"
+        case scanSelfServe = "scan-self-serve"
+    }
+
+    /// Returns true if a given feature is included in the site's plan. False otherwise
+    ///
+    public func hasPlanFeature(_ feature: PlanFeature) -> Bool {
+        return planActiveFeatures?.contains(feature.rawValue) ?? false
+    }
+
     /// Returns true if a given capability is enabled. False otherwise
     ///
     public func isUserCapableOf(_ capability: Capability) -> Bool {
@@ -42,16 +58,24 @@ extension Blog {
         return isUserCapableOf(.uploadFiles)
     }
 
-    /// Returns true if the current user is allowed to see Jetpack's Backups
+    /// Returns true if the current user is allowed to see Jetpack's Backups.
     ///
+    /// The backup capability alone is not enough: WordPress.com grants it to
+    /// Personal and Premium Simple sites because it backs them up internally,
+    /// but those backups have no user-facing UI. The backups-self-serve plan
+    /// feature is what gates the Backup UI on the web.
     @objc public func isBackupsAllowed() -> Bool {
-        return isUserCapableOf("backup") || isUserCapableOf("backup-daily") || isUserCapableOf("backup-realtime")
+        return hasPlanFeature(.backupsSelfServe)
+            && (isUserCapableOf("backup") || isUserCapableOf("backup-daily") || isUserCapableOf("backup-realtime"))
     }
 
-    /// Returns true if the current user is allowed to see Jetpack's Scan
+    /// Returns true if the current user is allowed to see Jetpack's Scan.
     ///
+    /// Like backups, the scan capability is granted to Personal and Premium
+    /// Simple sites whose scans are managed internally with no user-facing UI.
+    /// The scan-self-serve plan feature is what gates the Scan UI on the web.
     @objc public func isScanAllowed() -> Bool {
-        return !hasBusinessPlan && isUserCapableOf("scan")
+        return !hasBusinessPlan && hasPlanFeature(.scanSelfServe) && isUserCapableOf("scan")
     }
 
     /// Returns true if the current user is allowed to view Stats

--- a/Modules/Sources/WordPressKit/ActivityServiceRemote.swift
+++ b/Modules/Sources/WordPressKit/ActivityServiceRemote.swift
@@ -51,8 +51,7 @@ open class ActivityServiceRemote: ServiceRemoteWordPressComREST {
         path?.queryItems?.append(URLQueryItem(name: "number", value: "\(count)"))
         path?.queryItems?.append(URLQueryItem(name: "page", value: "\(pageNumber)"))
 
-        if let after, let before,
-           let lastSecondOfBeforeDay = before.endOfDay() {
+        if let after, let before, let lastSecondOfBeforeDay = before.endOfDay() {
             path?.queryItems?.append(URLQueryItem(name: "after", value: formatter.string(from: after)))
             path?.queryItems?.append(URLQueryItem(name: "before", value: formatter.string(from: lastSecondOfBeforeDay)))
         } else if let on = after ?? before {
@@ -68,22 +67,25 @@ open class ActivityServiceRemote: ServiceRemoteWordPressComREST {
 
         let finalPath = self.path(forEndpoint: endpoint, withVersion: ._2_0)
 
-        wordPressComRESTAPI.get(finalPath,
-                                parameters: nil,
-                                success: { response, _ in
-                                    do {
-                                        let (activities, totalItems) = try self.mapActivitiesResponse(response)
-                                        let hasMore = totalItems > pageNumber * (count + 1)
-                                        success(activities, hasMore)
-                                    } catch {
-                                        WPKitLogError("Error parsing activity response for site \(siteID)")
-                                        WPKitLogError("\(error)")
-                                        WPKitLogDebug("Full response: \(response)")
-                                        failure(error)
-                                    }
-                                }, failure: { error, _ in
-                                    failure(error)
-                                })
+        wordPressComRESTAPI.get(
+            finalPath,
+            parameters: nil,
+            success: { response, _ in
+                do {
+                    let (activities, totalItems) = try self.mapActivitiesResponse(response)
+                    let hasMore = totalItems > pageNumber * (count + 1)
+                    success(activities, hasMore)
+                } catch {
+                    WPKitLogError("Error parsing activity response for site \(siteID)")
+                    WPKitLogError("\(error)")
+                    WPKitLogDebug("Full response: \(response)")
+                    failure(error)
+                }
+            },
+            failure: { error, _ in
+                failure(error)
+            }
+        )
     }
 
     /// Retrieves activity groups associated with a site.
@@ -97,38 +99,42 @@ open class ActivityServiceRemote: ServiceRemoteWordPressComREST {
     ///
     /// - Returns: An array of available activity groups for a site.
     ///
-    open func getActivityGroupsForSite(_ siteID: Int,
-                                       after: Date? = nil,
-                                       before: Date? = nil,
-                                       success: @escaping (_ groups: [ActivityGroup]) -> Void,
-                                       failure: @escaping (Error) -> Void) {
+    open func getActivityGroupsForSite(
+        _ siteID: Int,
+        after: Date? = nil,
+        before: Date? = nil,
+        success: @escaping (_ groups: [ActivityGroup]) -> Void,
+        failure: @escaping (Error) -> Void
+    ) {
         let endpoint = "sites/\(siteID)/activity/count/group"
         let path = self.path(forEndpoint: endpoint, withVersion: ._2_0)
         var parameters: [String: AnyObject] = [:]
 
-        if let after, let before,
-           let lastSecondOfBeforeDay = before.endOfDay() {
+        if let after, let before, let lastSecondOfBeforeDay = before.endOfDay() {
             parameters["after"] = formatter.string(from: after) as AnyObject
             parameters["before"] = formatter.string(from: lastSecondOfBeforeDay) as AnyObject
         } else if let on = after ?? before {
             parameters["on"] = formatter.string(from: on) as AnyObject
         }
 
-        wordPressComRESTAPI.get(path,
-                                parameters: parameters,
-                                success: { response, _ in
-                                    do {
-                                        let groups = try self.mapActivityGroupsResponse(response)
-                                        success(groups)
-                                    } catch {
-                                        WPKitLogError("Error parsing activity groups for site \(siteID)")
-                                        WPKitLogError("\(error)")
-                                        WPKitLogDebug("Full response: \(response)")
-                                        failure(error)
-                                    }
-                                }, failure: { error, _ in
-                                    failure(error)
-                                })
+        wordPressComRESTAPI.get(
+            path,
+            parameters: parameters,
+            success: { response, _ in
+                do {
+                    let groups = try self.mapActivityGroupsResponse(response)
+                    success(groups)
+                } catch {
+                    WPKitLogError("Error parsing activity groups for site \(siteID)")
+                    WPKitLogError("\(error)")
+                    WPKitLogDebug("Full response: \(response)")
+                    failure(error)
+                }
+            },
+            failure: { error, _ in
+                failure(error)
+            }
+        )
     }
 
     /// Retrieves the site current rewind state.
@@ -138,43 +144,49 @@ open class ActivityServiceRemote: ServiceRemoteWordPressComREST {
     ///
     /// - Returns: The current rewind status for the site.
     ///
-    open func getRewindStatus(_ siteID: Int,
-                              success: @escaping (RewindStatus) -> Void,
-                              failure: @escaping (Error) -> Void) {
+    open func getRewindStatus(
+        _ siteID: Int,
+        success: @escaping (RewindStatus) -> Void,
+        failure: @escaping (Error) -> Void
+    ) {
         let endpoint = "sites/\(siteID)/rewind"
         let path = self.path(forEndpoint: endpoint, withVersion: ._2_0)
 
-        wordPressComRESTAPI.get(path,
-                                parameters: nil,
-                                success: { response, _ in
-                                    guard let rewindStatus = response as? [String: AnyObject] else {
-                                        failure(ResponseError.decodingFailure)
-                                        return
-                                    }
-                                    do {
-                                        let status = try RewindStatus(dictionary: rewindStatus)
-                                        success(status)
-                                    } catch {
-                                        WPKitLogError("Error parsing rewind response for site \(siteID)")
-                                        WPKitLogError("\(error)")
-                                        WPKitLogDebug("Full response: \(response)")
-                                        failure(ResponseError.decodingFailure)
-                                    }
-                                }, failure: { error, _ in
-                                    // FIXME: A hack to support free WPCom sites and Rewind. Should be obsolote as soon as the backend
-                                    // stops returning 412's for those sites.
-                                    let nsError = error as NSError
+        wordPressComRESTAPI.get(
+            path,
+            parameters: nil,
+            success: { response, _ in
+                guard let rewindStatus = response as? [String: AnyObject] else {
+                    failure(ResponseError.decodingFailure)
+                    return
+                }
+                do {
+                    let status = try RewindStatus(dictionary: rewindStatus)
+                    success(status)
+                } catch {
+                    WPKitLogError("Error parsing rewind response for site \(siteID)")
+                    WPKitLogError("\(error)")
+                    WPKitLogDebug("Full response: \(response)")
+                    failure(ResponseError.decodingFailure)
+                }
+            },
+            failure: { error, _ in
+                // FIXME: A hack to support free WPCom sites and Rewind. Should be obsolote as soon as the backend
+                // stops returning 412's for those sites.
+                let nsError = error as NSError
 
-                                    guard nsError.domain == WordPressComRestApiEndpointError.errorDomain,
-                                       nsError.code == WordPressComRestApiErrorCode.preconditionFailure.rawValue else {
-                                        failure(error)
-                                        return
-                                    }
+                guard nsError.domain == WordPressComRestApiEndpointError.errorDomain,
+                    nsError.code == WordPressComRestApiErrorCode.preconditionFailure.rawValue
+                else {
+                    failure(error)
+                    return
+                }
 
-                                    let status = RewindStatus(state: .unavailable)
-                                    success(status)
-                                    return
-                                })
+                let status = RewindStatus(state: .unavailable)
+                success(status)
+                return
+            }
+        )
     }
 }
 
@@ -183,7 +195,8 @@ private extension ActivityServiceRemote {
     func mapActivitiesResponse(_ response: Any) throws -> ([Activity], Int) {
 
         guard let json = response as? [String: AnyObject],
-              let totalItems = json["totalItems"] as? Int else {
+            let totalItems = json["totalItems"] as? Int
+        else {
             throw ActivityServiceRemote.ResponseError.decodingFailure
         }
 
@@ -192,7 +205,8 @@ private extension ActivityServiceRemote {
         }
 
         guard let current = json["current"] as? [String: AnyObject],
-              let orderedItems = current["orderedItems"] as? [[String: AnyObject]] else {
+            let orderedItems = current["orderedItems"] as? [[String: AnyObject]]
+        else {
             throw ActivityServiceRemote.ResponseError.decodingFailure
         }
 
@@ -210,7 +224,8 @@ private extension ActivityServiceRemote {
 
     func mapActivityGroupsResponse(_ response: Any) throws -> ([ActivityGroup]) {
         guard let json = response as? [String: AnyObject],
-              let totalItems = json["totalItems"] as? Int, totalItems > 0 else {
+            let totalItems = json["totalItems"] as? Int, totalItems > 0
+        else {
             return []
         }
 

--- a/Modules/Sources/WordPressKit/ActivityServiceRemote.swift
+++ b/Modules/Sources/WordPressKit/ActivityServiceRemote.swift
@@ -23,6 +23,7 @@ open class ActivityServiceRemote: ServiceRemoteWordPressComREST {
     ///     - after: Only activies after the given Date will be returned
     ///     - before: Only activies before the given Date will be returned
     ///     - group: Array of strings of activity types, eg. post, attachment, user
+    ///     - notGroup: Array of strings of activity types to exclude, eg. rewind, scan
     ///     - success: Closure to be executed on success
     ///     - failure: Closure to be executed on error.
     ///
@@ -35,6 +36,7 @@ open class ActivityServiceRemote: ServiceRemoteWordPressComREST {
         after: Date? = nil,
         before: Date? = nil,
         group: [String] = [],
+        notGroup: [String] = [],
         rewindable: Bool? = nil,
         searchText: String? = nil,
         success: @escaping (_ activities: [Activity], _ hasMore: Bool) -> Void,
@@ -46,6 +48,7 @@ open class ActivityServiceRemote: ServiceRemoteWordPressComREST {
         }
 
         path?.queryItems = group.map { URLQueryItem(name: "group[]", value: $0) }
+        path?.queryItems?.append(contentsOf: notGroup.map { URLQueryItem(name: "not_group[]", value: $0) })
 
         let pageNumber = (offset / count) + 1
         path?.queryItems?.append(URLQueryItem(name: "number", value: "\(count)"))
@@ -94,6 +97,7 @@ open class ActivityServiceRemote: ServiceRemoteWordPressComREST {
     ///     - siteID: The target site's ID.
     ///     - after: Only activity groups after the given Date will be returned.
     ///     - before: Only activity groups before the given Date will be returned.
+    ///     - notGroup: Array of strings of activity groups to exclude, eg. rewind, scan
     ///     - success: Closure to be executed on success.
     ///     - failure: Closure to be executed on error.
     ///
@@ -103,12 +107,17 @@ open class ActivityServiceRemote: ServiceRemoteWordPressComREST {
         _ siteID: Int,
         after: Date? = nil,
         before: Date? = nil,
+        notGroup: [String] = [],
         success: @escaping (_ groups: [ActivityGroup]) -> Void,
         failure: @escaping (Error) -> Void
     ) {
         let endpoint = "sites/\(siteID)/activity/count/group"
         let path = self.path(forEndpoint: endpoint, withVersion: ._2_0)
         var parameters: [String: AnyObject] = [:]
+
+        if !notGroup.isEmpty {
+            parameters["not_group"] = notGroup as AnyObject
+        }
 
         if let after, let before, let lastSecondOfBeforeDay = before.endOfDay() {
             parameters["after"] = formatter.string(from: after) as AnyObject

--- a/Modules/Tests/WordPressDataTests/BlogCapabilitiesTests.swift
+++ b/Modules/Tests/WordPressDataTests/BlogCapabilitiesTests.swift
@@ -1,0 +1,58 @@
+import CoreData
+import Testing
+
+@testable import WordPressData
+
+@MainActor
+struct BlogCapabilitiesTests {
+    private let contextManager = ContextManager.forTesting()
+    private var mainContext: NSManagedObjectContext { contextManager.mainContext }
+
+    @Test("backup and scan capabilities without self-serve features stay hidden")
+    func capabilitiesWithoutSelfServeFeatures() {
+        // Personal and Premium WordPress.com plans grant the backup and scan
+        // capabilities because WordPress.com backs up and scans those sites
+        // internally, but neither has a user-facing UI on those plans.
+        let blog = BlogBuilder(mainContext)
+            .with(capabilities: ["backup": true, "backup-daily": true, "scan": true])
+            .with(planActiveFeatures: ["backups", "backups-daily", "scan", "scan-managed"])
+            .build()
+
+        #expect(!blog.isBackupsAllowed())
+        #expect(!blog.isScanAllowed())
+    }
+
+    @Test("backup capability with backups-self-serve enables backups")
+    func backupCapabilityWithSelfServeFeature() {
+        let blog = BlogBuilder(mainContext)
+            .with(capabilities: ["backup": true])
+            .with(planActiveFeatures: ["backups", "backups-self-serve"])
+            .build()
+
+        #expect(blog.isBackupsAllowed())
+    }
+
+    @Test("a Jetpack Scan product site keeps scan without backups-self-serve")
+    func scanProductOnlySite() {
+        // A site with only a Jetpack Scan product has a working scan screen,
+        // so scan must be gated on scan-self-serve, not backups-self-serve.
+        let blog = BlogBuilder(mainContext)
+            .with(capabilities: ["scan": true])
+            .with(planActiveFeatures: ["scan", "scan-self-serve"])
+            .build()
+
+        #expect(blog.isScanAllowed())
+        #expect(!blog.isBackupsAllowed())
+    }
+
+    @Test("plan features without the capabilities are not enough")
+    func featuresWithoutCapabilities() {
+        let blog = BlogBuilder(mainContext)
+            .with(capabilities: [:])
+            .with(planActiveFeatures: ["backups-self-serve", "scan-self-serve"])
+            .build()
+
+        #expect(!blog.isBackupsAllowed())
+        #expect(!blog.isScanAllowed())
+    }
+}

--- a/Modules/Tests/WordPressDataTests/Helpers/BlogBuilder.swift
+++ b/Modules/Tests/WordPressDataTests/Helpers/BlogBuilder.swift
@@ -209,6 +209,11 @@ class BlogBuilder {
         return self
     }
 
+    func with(capabilities: [String: Bool]) -> Self {
+        blog.capabilities = capabilities
+        return self
+    }
+
     @discardableResult
     func build() -> Blog {
         blog

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,7 @@
 * [*] Stats: Fix the screen getting stuck on a loading indicator for self-hosted sites that are not connected to Jetpack [#25858]
 * [*] Stats: Fix an issue where new post may not appear in the Subscribers -> Emails card [#25895]
 * [*] [internal] Experimental Gutenberg editor: add a per-site "Use Third-Party Blocks (Beta)" toggle to Site Settings, matching Android [#25889]
+* [*] Fixes an isuse where back up logs incorrectly show up in some Personal plan sites
 
 27.1
 -----

--- a/Tests/KeystoneTests/Tests/Features/Activity/ActivityLogsViewModelTests.swift
+++ b/Tests/KeystoneTests/Tests/Features/Activity/ActivityLogsViewModelTests.swift
@@ -1,0 +1,44 @@
+import Foundation
+import Testing
+
+@testable import WordPress
+@testable import WordPressData
+
+@MainActor
+@Suite("ActivityLogsViewModel Tests")
+struct ActivityLogsViewModelTests {
+    @Test("sites without backups-self-serve hide the backup and scan activity groups")
+    func excludesRewindAndScanWithoutSelfServeBackups() {
+        let context = ContextManager.forTesting().mainContext
+        // A Personal or Premium WordPress.com plan grants backups but not
+        // backups-self-serve, which is what gates the groups on the web.
+        let blog = BlogBuilder(context)
+            .with(planActiveFeatures: ["backups", "backups-daily", "scan"])
+            .build()
+        let viewModel = ActivityLogsViewModel(blog: blog)
+
+        #expect(viewModel.excludedActivityGroups == ["rewind", "scan"])
+    }
+
+    @Test("sites with backups-self-serve see every activity group")
+    func excludesNothingWithSelfServeBackups() {
+        let context = ContextManager.forTesting().mainContext
+        let blog = BlogBuilder(context)
+            .with(planActiveFeatures: ["backups", "backups-self-serve", "scan"])
+            .build()
+        let viewModel = ActivityLogsViewModel(blog: blog)
+
+        #expect(viewModel.excludedActivityGroups.isEmpty)
+    }
+
+    @Test("the backup list is never filtered")
+    func excludesNothingInBackupMode() {
+        let context = ContextManager.forTesting().mainContext
+        let blog = BlogBuilder(context)
+            .with(planActiveFeatures: [])
+            .build()
+        let viewModel = ActivityLogsViewModel(blog: blog, isBackupMode: true)
+
+        #expect(viewModel.excludedActivityGroups.isEmpty)
+    }
+}

--- a/Tests/WordPressKitTests/WordPressKitTests/Tests/ActivityServiceRemoteTests.swift
+++ b/Tests/WordPressKitTests/WordPressKitTests/Tests/ActivityServiceRemoteTests.swift
@@ -195,6 +195,30 @@ class ActivityServiceRemoteTests: RemoteTestCase, RESTTestable {
         waitForExpectations(timeout: timeout, handler: nil)
     }
 
+    func testGetActivityWithNotGroup() {
+        let expect = expectation(description: "Get activity for site success when calling with notGroup")
+
+        stubRemoteResponse(
+            "not_group%5B%5D=rewind&not_group%5B%5D=scan&number=20&page=1",
+            filename: getActivitySuccessOneMockFilename,
+            contentType: .ApplicationJSON
+        )
+        remote.getActivityForSite(
+            siteID,
+            count: 20,
+            notGroup: ["rewind", "scan"],
+            success: { _, _ in
+                expect.fulfill()
+            },
+            failure: { _ in
+                XCTFail("This callback shouldn't get called")
+                expect.fulfill()
+            }
+        )
+
+        waitForExpectations(timeout: timeout, handler: nil)
+    }
+
     func testGetActivityWithBadAuthFails() {
         let expect = expectation(description: "Get activity with bad auth failure")
 
@@ -331,6 +355,30 @@ class ActivityServiceRemoteTests: RemoteTestCase, RESTTestable {
             }
         )
 
+        waitForExpectations(timeout: timeout, handler: nil)
+    }
+
+    func testGetActivityGroupsWithNotGroup() {
+        let expect = expectation(
+            description: "Get activity groups for site success when calling with notGroup"
+        )
+
+        stubRemoteResponse(
+            "not_group%5B%5D=rewind&not_group%5B%5D=scan",
+            filename: getActivityGroupsSuccessMockFilename,
+            contentType: .ApplicationJSON
+        )
+        remote.getActivityGroupsForSite(
+            siteID,
+            notGroup: ["rewind", "scan"],
+            success: { _ in
+                expect.fulfill()
+            },
+            failure: { _ in
+                XCTFail("This callback shouldn't get called")
+                expect.fulfill()
+            }
+        )
         waitForExpectations(timeout: timeout, handler: nil)
     }
 

--- a/Tests/WordPressKitTests/WordPressKitTests/Tests/ActivityServiceRemoteTests.swift
+++ b/Tests/WordPressKitTests/WordPressKitTests/Tests/ActivityServiceRemoteTests.swift
@@ -30,10 +30,10 @@ class ActivityServiceRemoteTests: RemoteTestCase, RESTTestable {
 
     // MARK: - Properties
 
-    var siteActivityEndpoint: String { return "sites/\(siteID)/activity" }
-    var siteActivityGroupsEndpoint: String { return "sites/\(siteID)/activity/count/group" }
-    var restoreEndpoint: String { return "activity-log/\(siteID)/rewind/to/\(rewindID)" }
-    var rewindStatusEndpoint: String { return "sites/\(siteID)/rewind" }
+    var siteActivityEndpoint: String { "sites/\(siteID)/activity" }
+    var siteActivityGroupsEndpoint: String { "sites/\(siteID)/activity/count/group" }
+    var restoreEndpoint: String { "activity-log/\(siteID)/rewind/to/\(rewindID)" }
+    var rewindStatusEndpoint: String { "sites/\(siteID)/rewind" }
 
     var remoteV1: ActivityServiceRemote_ApiVersion1_0!
     var remote: ActivityServiceRemote!
@@ -64,36 +64,50 @@ class ActivityServiceRemoteTests: RemoteTestCase, RESTTestable {
     func testGetActivitySucceedsOne() {
         let expect = expectation(description: "Get activity for site success one")
 
-        stubRemoteResponse(siteActivityEndpoint, filename: getActivitySuccessOneMockFilename, contentType: .ApplicationJSON)
-        remote.getActivityForSite(siteID,
-                                  offset: 0,
-                                  count: 20,
-                                  success: { activities, hasMore in
-                                      XCTAssertEqual(activities.count, 8, "The activity count should be 8")
-                                      XCTAssertEqual(hasMore, false, "The value of hasMore should be false")
-                                      expect.fulfill()
-                                  }, failure: { _ in
-                                      XCTFail("This callback shouldn't get called")
-                                      expect.fulfill()
-                                  })
+        stubRemoteResponse(
+            siteActivityEndpoint,
+            filename: getActivitySuccessOneMockFilename,
+            contentType: .ApplicationJSON
+        )
+        remote.getActivityForSite(
+            siteID,
+            offset: 0,
+            count: 20,
+            success: { activities, hasMore in
+                XCTAssertEqual(activities.count, 8, "The activity count should be 8")
+                XCTAssertEqual(hasMore, false, "The value of hasMore should be false")
+                expect.fulfill()
+            },
+            failure: { _ in
+                XCTFail("This callback shouldn't get called")
+                expect.fulfill()
+            }
+        )
         waitForExpectations(timeout: timeout, handler: nil)
     }
 
     func testGetActivitySucceedsTwo() {
         let expect = expectation(description: "Get activity for site success two")
 
-        stubRemoteResponse(siteActivityEndpoint, filename: getActivitySuccessTwoMockFilename, contentType: .ApplicationJSON)
-        remote.getActivityForSite(siteID,
-                                  offset: 0,
-                                  count: 20,
-                                  success: { activities, hasMore in
-                                      XCTAssertEqual(activities.count, 20, "The activity count should be 20")
-                                      XCTAssertEqual(hasMore, true, "The value of hasMore should be true")
-                                      expect.fulfill()
-                                  }, failure: { _ in
-                                      XCTFail("This callback shouldn't get called")
-                                      expect.fulfill()
-                                  })
+        stubRemoteResponse(
+            siteActivityEndpoint,
+            filename: getActivitySuccessTwoMockFilename,
+            contentType: .ApplicationJSON
+        )
+        remote.getActivityForSite(
+            siteID,
+            offset: 0,
+            count: 20,
+            success: { activities, hasMore in
+                XCTAssertEqual(activities.count, 20, "The activity count should be 20")
+                XCTAssertEqual(hasMore, true, "The value of hasMore should be true")
+                expect.fulfill()
+            },
+            failure: { _ in
+                XCTFail("This callback shouldn't get called")
+                expect.fulfill()
+            }
+        )
 
         waitForExpectations(timeout: timeout, handler: nil)
     }
@@ -101,41 +115,57 @@ class ActivityServiceRemoteTests: RemoteTestCase, RESTTestable {
     func testGetActivitySucceedsThree() {
         let expect = expectation(description: "Get activity for site success three")
 
-        stubRemoteResponse(siteActivityEndpoint, filename: getActivitySuccessThreeMockFilename, contentType: .ApplicationJSON)
-        remote.getActivityForSite(siteID,
-                                  offset: 100,
-                                  count: 20,
-                                  success: { activities, hasMore in
-                                      XCTAssertEqual(activities.count, 19, "The activity count should be 19")
-                                      XCTAssertEqual(hasMore, false, "The value of hasMore should be false")
-                                      expect.fulfill()
-                                  }, failure: { _ in
-                                      XCTFail("This callback shouldn't get called")
-                                      expect.fulfill()
-                                  })
+        stubRemoteResponse(
+            siteActivityEndpoint,
+            filename: getActivitySuccessThreeMockFilename,
+            contentType: .ApplicationJSON
+        )
+        remote.getActivityForSite(
+            siteID,
+            offset: 100,
+            count: 20,
+            success: { activities, hasMore in
+                XCTAssertEqual(activities.count, 19, "The activity count should be 19")
+                XCTAssertEqual(hasMore, false, "The value of hasMore should be false")
+                expect.fulfill()
+            },
+            failure: { _ in
+                XCTFail("This callback shouldn't get called")
+                expect.fulfill()
+            }
+        )
 
         waitForExpectations(timeout: timeout, handler: nil)
     }
 
     func testGetActivityWithParameters() {
-        let expect = expectation(description: "Get activity for site success when calling with after, before, and group")
+        let expect = expectation(
+            description: "Get activity for site success when calling with after, before, and group"
+        )
         let dateFormatter = ISO8601DateFormatter()
 
-        stubRemoteResponse("group%5B%5D=post&group%5B%5D=user&number=20&page=6&after=1970-01-01%2010:44:00&before=1970-01-03%2010:43:59", filename: getActivitySuccessThreeMockFilename, contentType: .ApplicationJSON)
-        remote.getActivityForSite(siteID,
-                                  offset: 100,
-                                  count: 20,
-                                  after: dateFormatter.date(from: "1970-01-01T10:44:00+0000"),
-                                  before: dateFormatter.date(from: "1970-01-02T10:44:00+0000"),
-                                  group: ["post", "user"],
-                                  success: { activities, hasMore in
-                                      XCTAssertEqual(activities.count, 19, "The activity count should be 19")
-                                      XCTAssertEqual(hasMore, false, "The value of hasMore should be false")
-                                      expect.fulfill()
-                                  }, failure: { _ in
-                                      XCTFail("This callback shouldn't get called")
-                                      expect.fulfill()
-                                  })
+        stubRemoteResponse(
+            "group%5B%5D=post&group%5B%5D=user&number=20&page=6&after=1970-01-01%2010:44:00&before=1970-01-03%2010:43:59",
+            filename: getActivitySuccessThreeMockFilename,
+            contentType: .ApplicationJSON
+        )
+        remote.getActivityForSite(
+            siteID,
+            offset: 100,
+            count: 20,
+            after: dateFormatter.date(from: "1970-01-01T10:44:00+0000"),
+            before: dateFormatter.date(from: "1970-01-02T10:44:00+0000"),
+            group: ["post", "user"],
+            success: { activities, hasMore in
+                XCTAssertEqual(activities.count, 19, "The activity count should be 19")
+                XCTAssertEqual(hasMore, false, "The value of hasMore should be false")
+                expect.fulfill()
+            },
+            failure: { _ in
+                XCTFail("This callback shouldn't get called")
+                expect.fulfill()
+            }
+        )
 
         waitForExpectations(timeout: timeout, handler: nil)
     }
@@ -144,16 +174,23 @@ class ActivityServiceRemoteTests: RemoteTestCase, RESTTestable {
         let expect = expectation(description: "Get activity for site success when calling with after")
         let dateFormatter = ISO8601DateFormatter()
 
-        stubRemoteResponse("wpcom/v2/sites/321/activity?number=20&page=1&on=1970-01-01%2010:44:00", filename: getActivitySuccessThreeMockFilename, contentType: .ApplicationJSON)
-        remote.getActivityForSite(siteID,
-                                  count: 20,
-                                  after: dateFormatter.date(from: "1970-01-01T10:44:00+0000"),
-                                  success: { _, _ in
-                                      expect.fulfill()
-                                  }, failure: { _ in
-                                      XCTFail("This callback shouldn't get called")
-                                      expect.fulfill()
-                                  })
+        stubRemoteResponse(
+            "wpcom/v2/sites/321/activity?number=20&page=1&on=1970-01-01%2010:44:00",
+            filename: getActivitySuccessThreeMockFilename,
+            contentType: .ApplicationJSON
+        )
+        remote.getActivityForSite(
+            siteID,
+            count: 20,
+            after: dateFormatter.date(from: "1970-01-01T10:44:00+0000"),
+            success: { _, _ in
+                expect.fulfill()
+            },
+            failure: { _ in
+                XCTFail("This callback shouldn't get called")
+                expect.fulfill()
+            }
+        )
 
         waitForExpectations(timeout: timeout, handler: nil)
     }
@@ -161,18 +198,34 @@ class ActivityServiceRemoteTests: RemoteTestCase, RESTTestable {
     func testGetActivityWithBadAuthFails() {
         let expect = expectation(description: "Get activity with bad auth failure")
 
-        stubRemoteResponse(siteActivityEndpoint, filename: getActivityAuthFailureMockFilename, contentType: .ApplicationJSON, status: 403)
-        remote.getActivityForSite(siteID,
-                                  count: 20,
-                                  success: { _, _ in
-                                      XCTFail("This callback shouldn't get called")
-                                      expect.fulfill()
-                                  }, failure: { error in
-                                      let error = error as NSError
-                                      XCTAssertEqual(error.domain, "WordPressKit.WordPressComRestApiError", "The error domain should be WordPressComRestApiError")
-                                      XCTAssertEqual(error.code, WordPressComRestApiErrorCode.authorizationRequired.rawValue, "The error code should be 2 - authorization_required")
-                                      expect.fulfill()
-                                  })
+        stubRemoteResponse(
+            siteActivityEndpoint,
+            filename: getActivityAuthFailureMockFilename,
+            contentType: .ApplicationJSON,
+            status: 403
+        )
+        remote.getActivityForSite(
+            siteID,
+            count: 20,
+            success: { _, _ in
+                XCTFail("This callback shouldn't get called")
+                expect.fulfill()
+            },
+            failure: { error in
+                let error = error as NSError
+                XCTAssertEqual(
+                    error.domain,
+                    "WordPressKit.WordPressComRestApiError",
+                    "The error domain should be WordPressComRestApiError"
+                )
+                XCTAssertEqual(
+                    error.code,
+                    WordPressComRestApiErrorCode.authorizationRequired.rawValue,
+                    "The error code should be 2 - authorization_required"
+                )
+                expect.fulfill()
+            }
+        )
 
         waitForExpectations(timeout: timeout, handler: nil)
     }
@@ -180,15 +233,23 @@ class ActivityServiceRemoteTests: RemoteTestCase, RESTTestable {
     func testGetActivityWithBadJsonFails() {
         let expect = expectation(description: "Get activity with invalid json response failure")
 
-        stubRemoteResponse(siteActivityEndpoint, filename: getActivityBadJsonFailureMockFilename, contentType: .ApplicationJSON, status: 200)
-        remote.getActivityForSite(siteID,
-                                  count: 20,
-                                  success: { _, _ in
-                                      XCTFail("This callback shouldn't get called")
-                                      expect.fulfill()
-                                 }, failure: { _ in
-                                      expect.fulfill()
-                                 })
+        stubRemoteResponse(
+            siteActivityEndpoint,
+            filename: getActivityBadJsonFailureMockFilename,
+            contentType: .ApplicationJSON,
+            status: 200
+        )
+        remote.getActivityForSite(
+            siteID,
+            count: 20,
+            success: { _, _ in
+                XCTFail("This callback shouldn't get called")
+                expect.fulfill()
+            },
+            failure: { _ in
+                expect.fulfill()
+            }
+        )
 
         waitForExpectations(timeout: timeout, handler: nil)
     }
@@ -196,20 +257,31 @@ class ActivityServiceRemoteTests: RemoteTestCase, RESTTestable {
     func testGetActivityGroupsSucceeds() {
         let expect = expectation(description: "Get activity groups success")
 
-        stubRemoteResponse(siteActivityGroupsEndpoint, filename: getActivityGroupsSuccessMockFilename, contentType: .ApplicationJSON)
-        remote.getActivityGroupsForSite(siteID,
-                                        success: { groups in
-                                            XCTAssertEqual(groups.count, 4, "The activity group count should be 4")
-                                            XCTAssertTrue(groups.contains(where: { $0.key == "post" && $0.name == "Posts and Pages" && $0.count == 69}))
-                                            XCTAssertTrue(groups.contains(where: { $0.key == "attachment" && $0.name == "Media" && $0.count == 5}))
-                                            XCTAssertTrue(groups.contains(where: { $0.key == "user" && $0.name == "People" && $0.count == 2}))
-                                            XCTAssertTrue(groups.contains(where: { $0.key == "rewind" && $0.name == "Backups and Restores" && $0.count == 10}))
-                                            expect.fulfill()
-                                        },
-                                        failure: { _ in
-                                            XCTFail("This callback shouldn't get called")
-                                            expect.fulfill()
-                                        })
+        stubRemoteResponse(
+            siteActivityGroupsEndpoint,
+            filename: getActivityGroupsSuccessMockFilename,
+            contentType: .ApplicationJSON
+        )
+        remote.getActivityGroupsForSite(
+            siteID,
+            success: { groups in
+                XCTAssertEqual(groups.count, 4, "The activity group count should be 4")
+                XCTAssertTrue(
+                    groups.contains(where: { $0.key == "post" && $0.name == "Posts and Pages" && $0.count == 69 })
+                )
+                XCTAssertTrue(groups.contains(where: { $0.key == "attachment" && $0.name == "Media" && $0.count == 5 }))
+                XCTAssertTrue(groups.contains(where: { $0.key == "user" && $0.name == "People" && $0.count == 2 }))
+                XCTAssertTrue(
+                    groups.contains(where: { $0.key == "rewind" && $0.name == "Backups and Restores" && $0.count == 10 }
+                    )
+                )
+                expect.fulfill()
+            },
+            failure: { _ in
+                XCTFail("This callback shouldn't get called")
+                expect.fulfill()
+            }
+        )
         waitForExpectations(timeout: timeout, handler: nil)
     }
 
@@ -217,17 +289,23 @@ class ActivityServiceRemoteTests: RemoteTestCase, RESTTestable {
         let expect = expectation(description: "Get activity groups for site success when calling with before, after")
         let dateFormatter = ISO8601DateFormatter()
 
-        stubRemoteResponse("1970-01-01%2010%3A44%3A00&before=1970-01-03%2010%3A43%3A59", filename: getActivityGroupsSuccessMockFilename, contentType: .ApplicationJSON)
-        remote.getActivityGroupsForSite(siteID,
-                                        after: dateFormatter.date(from: "1970-01-01T10:44:00+0000"),
-                                        before: dateFormatter.date(from: "1970-01-02T10:44:00+0000"),
-                                        success: { _ in
-                                            expect.fulfill()
-                                        },
-                                        failure: { _ in
-                                            XCTFail("This callback shouldn't get called")
-                                            expect.fulfill()
-                                        })
+        stubRemoteResponse(
+            "1970-01-01%2010%3A44%3A00&before=1970-01-03%2010%3A43%3A59",
+            filename: getActivityGroupsSuccessMockFilename,
+            contentType: .ApplicationJSON
+        )
+        remote.getActivityGroupsForSite(
+            siteID,
+            after: dateFormatter.date(from: "1970-01-01T10:44:00+0000"),
+            before: dateFormatter.date(from: "1970-01-02T10:44:00+0000"),
+            success: { _ in
+                expect.fulfill()
+            },
+            failure: { _ in
+                XCTFail("This callback shouldn't get called")
+                expect.fulfill()
+            }
+        )
         waitForExpectations(timeout: timeout, handler: nil)
     }
 
@@ -235,16 +313,23 @@ class ActivityServiceRemoteTests: RemoteTestCase, RESTTestable {
         let expect = expectation(description: "Get activity groups for site success when calling with after")
         let dateFormatter = ISO8601DateFormatter()
 
-        stubRemoteResponse("on=1970-01-01", filename: getActivityGroupsSuccessMockFilename, contentType: .ApplicationJSON)
-        remote.getActivityGroupsForSite(siteID,
-                                        before: dateFormatter.date(from: "1970-01-01T10:44:00+0000"),
-                                        success: { groups in
-                                            XCTAssertEqual(groups.count, 4, "The activity count should be 4")
-                                            expect.fulfill()
-                                        }, failure: { _ in
-                                            XCTFail("This callback shouldn't get called")
-                                            expect.fulfill()
-                                        })
+        stubRemoteResponse(
+            "on=1970-01-01",
+            filename: getActivityGroupsSuccessMockFilename,
+            contentType: .ApplicationJSON
+        )
+        remote.getActivityGroupsForSite(
+            siteID,
+            before: dateFormatter.date(from: "1970-01-01T10:44:00+0000"),
+            success: { groups in
+                XCTAssertEqual(groups.count, 4, "The activity count should be 4")
+                expect.fulfill()
+            },
+            failure: { _ in
+                XCTFail("This callback shouldn't get called")
+                expect.fulfill()
+            }
+        )
 
         waitForExpectations(timeout: timeout, handler: nil)
     }
@@ -252,14 +337,22 @@ class ActivityServiceRemoteTests: RemoteTestCase, RESTTestable {
     func testGetActivityGroupsWithBadJsonFails() {
         let expect = expectation(description: "Get activity groups with invalid json response failure")
 
-        stubRemoteResponse(siteActivityGroupsEndpoint, filename: getActivityGroupsBadJsonFailureMockFilename, contentType: .ApplicationJSON, status: 200)
-        remote.getActivityGroupsForSite(siteID,
-                                  success: { _ in
-                                      XCTFail("This callback shouldn't get called")
-                                      expect.fulfill()
-                                 }, failure: { _ in
-                                      expect.fulfill()
-                                 })
+        stubRemoteResponse(
+            siteActivityGroupsEndpoint,
+            filename: getActivityGroupsBadJsonFailureMockFilename,
+            contentType: .ApplicationJSON,
+            status: 200
+        )
+        remote.getActivityGroupsForSite(
+            siteID,
+            success: { _ in
+                XCTFail("This callback shouldn't get called")
+                expect.fulfill()
+            },
+            failure: { _ in
+                expect.fulfill()
+            }
+        )
 
         waitForExpectations(timeout: timeout, handler: nil)
     }
@@ -269,16 +362,19 @@ class ActivityServiceRemoteTests: RemoteTestCase, RESTTestable {
 
         stubRemoteResponse(restoreEndpoint, filename: restoreSuccessMockFilename, contentType: .ApplicationJSON)
 
-        remoteV1.restoreSite(siteID,
-                             rewindID: rewindID,
-                             success: { restoreID, jobID in
-                                XCTAssertEqual(restoreID, self.restoreID)
-                                XCTAssertEqual(jobID, self.jobID)
-                                expect.fulfill()
-                             }, failure: { _ in
-                                XCTFail("This callback shouldn't get called")
-                                expect.fulfill()
-                             })
+        remoteV1.restoreSite(
+            siteID,
+            rewindID: rewindID,
+            success: { restoreID, jobID in
+                XCTAssertEqual(restoreID, self.restoreID)
+                XCTAssertEqual(jobID, self.jobID)
+                expect.fulfill()
+            },
+            failure: { _ in
+                XCTFail("This callback shouldn't get called")
+                expect.fulfill()
+            }
+        )
         waitForExpectations(timeout: timeout, handler: nil)
     }
 
@@ -287,24 +383,29 @@ class ActivityServiceRemoteTests: RemoteTestCase, RESTTestable {
 
         stubRemoteResponse(restoreEndpoint, filename: restoreSuccessMockFilename, contentType: .ApplicationJSON)
 
-        let restoreTypes = JetpackRestoreTypes(themes: true,
-                                               plugins: true,
-                                               uploads: true,
-                                               sqls: true,
-                                               roots: true,
-                                               contents: true)
+        let restoreTypes = JetpackRestoreTypes(
+            themes: true,
+            plugins: true,
+            uploads: true,
+            sqls: true,
+            roots: true,
+            contents: true
+        )
 
-        remoteV1.restoreSite(siteID,
-                             rewindID: rewindID,
-                             types: restoreTypes,
-                             success: { restoreID, jobID in
-                                XCTAssertEqual(restoreID, self.restoreID)
-                                XCTAssertEqual(jobID, self.jobID)
-                                expect.fulfill()
-                             }, failure: { _ in
-                                XCTFail("This callback shouldn't get called")
-                                expect.fulfill()
-                             })
+        remoteV1.restoreSite(
+            siteID,
+            rewindID: rewindID,
+            types: restoreTypes,
+            success: { restoreID, jobID in
+                XCTAssertEqual(restoreID, self.restoreID)
+                XCTAssertEqual(jobID, self.jobID)
+                expect.fulfill()
+            },
+            failure: { _ in
+                XCTFail("This callback shouldn't get called")
+                expect.fulfill()
+            }
+        )
         waitForExpectations(timeout: timeout, handler: nil)
     }
 
@@ -329,96 +430,131 @@ class ActivityServiceRemoteTests: RemoteTestCase, RESTTestable {
     func testGetRewindStatusSuccess() {
         let expect = expectation(description: "Check rewind status success")
 
-        stubRemoteResponse(rewindStatusEndpoint, filename: rewindStatusSuccessMockFilename, contentType: .ApplicationJSON)
+        stubRemoteResponse(
+            rewindStatusEndpoint,
+            filename: rewindStatusSuccessMockFilename,
+            contentType: .ApplicationJSON
+        )
 
-        remote.getRewindStatus(siteID,
-                               success: { rewindStatus in
-                                   XCTAssertEqual(rewindStatus.state, .active)
-                                   XCTAssertNotNil(rewindStatus.lastUpdated)
-                                   XCTAssertNil(rewindStatus.restore)
-                                   expect.fulfill()
-                               }, failure: { _ in
-                                    XCTFail("This callback shouldn't get called")
-                                    expect.fulfill()
-                               })
+        remote.getRewindStatus(
+            siteID,
+            success: { rewindStatus in
+                XCTAssertEqual(rewindStatus.state, .active)
+                XCTAssertNotNil(rewindStatus.lastUpdated)
+                XCTAssertNil(rewindStatus.restore)
+                expect.fulfill()
+            },
+            failure: { _ in
+                XCTFail("This callback shouldn't get called")
+                expect.fulfill()
+            }
+        )
         waitForExpectations(timeout: timeout, handler: nil)
     }
 
     func testGetRewindStatusRestoreFinish() {
         let expect = expectation(description: "Check rewind status, restore finished")
 
-        stubRemoteResponse(rewindStatusEndpoint, filename: rewindStatusRestoreFinishedMockFilename, contentType: .ApplicationJSON)
+        stubRemoteResponse(
+            rewindStatusEndpoint,
+            filename: rewindStatusRestoreFinishedMockFilename,
+            contentType: .ApplicationJSON
+        )
 
-        remote.getRewindStatus(siteID,
-                               success: { rewindStatus in
-                                   XCTAssertNotNil(rewindStatus.restore)
-                                   XCTAssertNotNil(rewindStatus.restore!.id)
-                                   XCTAssertEqual(rewindStatus.restore!.status, .finished)
-                                   XCTAssertEqual(rewindStatus.restore!.progress, 100)
-                                   XCTAssertNil(rewindStatus.restore!.failureReason)
-                                   expect.fulfill()
-                                }, failure: { _ in
-                                   XCTFail("This callback shouldn't get called")
-                                   expect.fulfill()
-                                })
+        remote.getRewindStatus(
+            siteID,
+            success: { rewindStatus in
+                XCTAssertNotNil(rewindStatus.restore)
+                XCTAssertNotNil(rewindStatus.restore!.id)
+                XCTAssertEqual(rewindStatus.restore!.status, .finished)
+                XCTAssertEqual(rewindStatus.restore!.progress, 100)
+                XCTAssertNil(rewindStatus.restore!.failureReason)
+                expect.fulfill()
+            },
+            failure: { _ in
+                XCTFail("This callback shouldn't get called")
+                expect.fulfill()
+            }
+        )
         waitForExpectations(timeout: timeout, handler: nil)
     }
 
     func testGetRewindStatusRestoreFailure() {
         let expect = expectation(description: "Check rewind status, restore failure")
 
-        stubRemoteResponse(rewindStatusEndpoint, filename: rewindStatusRestoreFailureMockFilename, contentType: .ApplicationJSON)
+        stubRemoteResponse(
+            rewindStatusEndpoint,
+            filename: rewindStatusRestoreFailureMockFilename,
+            contentType: .ApplicationJSON
+        )
 
-        remote.getRewindStatus(siteID,
-                               success: { rewindStatus in
-                                   XCTAssertNotNil(rewindStatus.restore)
-                                   XCTAssertNotNil(rewindStatus.restore!.id)
-                                   XCTAssertEqual(rewindStatus.restore!.status, .fail)
-                                   XCTAssertEqual(rewindStatus.restore!.progress, 0)
-                                   XCTAssertNotNil(rewindStatus.restore!.failureReason)
-                                   XCTAssert(!rewindStatus.restore!.failureReason!.isEmpty)
-                                   expect.fulfill()
-                                }, failure: { _ in
-                                   expect.fulfill()
-                                })
+        remote.getRewindStatus(
+            siteID,
+            success: { rewindStatus in
+                XCTAssertNotNil(rewindStatus.restore)
+                XCTAssertNotNil(rewindStatus.restore!.id)
+                XCTAssertEqual(rewindStatus.restore!.status, .fail)
+                XCTAssertEqual(rewindStatus.restore!.progress, 0)
+                XCTAssertNotNil(rewindStatus.restore!.failureReason)
+                XCTAssert(!rewindStatus.restore!.failureReason!.isEmpty)
+                expect.fulfill()
+            },
+            failure: { _ in
+                expect.fulfill()
+            }
+        )
         waitForExpectations(timeout: timeout, handler: nil)
     }
 
     func testGetRewindStatusRestoreInProgress() {
         let expect = expectation(description: "Check rewind status, restore in progress")
 
-        stubRemoteResponse(rewindStatusEndpoint, filename: rewindStatusRestoreInProgressMockFilename, contentType: .ApplicationJSON)
+        stubRemoteResponse(
+            rewindStatusEndpoint,
+            filename: rewindStatusRestoreInProgressMockFilename,
+            contentType: .ApplicationJSON
+        )
 
-        remote.getRewindStatus(siteID,
-                               success: { rewindStatus in
-                                   XCTAssertNotNil(rewindStatus.restore)
-                                   XCTAssertNotNil(rewindStatus.restore!.id)
-                                   XCTAssertEqual(rewindStatus.restore!.status, .running)
-                                   XCTAssert(rewindStatus.restore!.progress > 0)
-                                   XCTAssertNil(rewindStatus.restore!.failureReason)
-                                   expect.fulfill()
-                               }, failure: { _ in
-                                   expect.fulfill()
-                               })
+        remote.getRewindStatus(
+            siteID,
+            success: { rewindStatus in
+                XCTAssertNotNil(rewindStatus.restore)
+                XCTAssertNotNil(rewindStatus.restore!.id)
+                XCTAssertEqual(rewindStatus.restore!.status, .running)
+                XCTAssert(rewindStatus.restore!.progress > 0)
+                XCTAssertNil(rewindStatus.restore!.failureReason)
+                expect.fulfill()
+            },
+            failure: { _ in
+                expect.fulfill()
+            }
+        )
         waitForExpectations(timeout: timeout, handler: nil)
     }
 
     func testGetRestoreStatusRestoreQueued() {
         let expect = expectation(description: "Check rewind status, restore queued")
 
-        stubRemoteResponse(rewindStatusEndpoint, filename: rewindStatusRestoreQueuedMockFilename, contentType: .ApplicationJSON)
+        stubRemoteResponse(
+            rewindStatusEndpoint,
+            filename: rewindStatusRestoreQueuedMockFilename,
+            contentType: .ApplicationJSON
+        )
 
-        remote.getRewindStatus(siteID,
-                               success: { rewindStatus in
-                                   XCTAssertNotNil(rewindStatus.restore)
-                                   XCTAssertNotNil(rewindStatus.restore!.id)
-                                   XCTAssertEqual(rewindStatus.restore!.status, .queued)
-                                   XCTAssertEqual(rewindStatus.restore!.progress, 0)
-                                   XCTAssertNil(rewindStatus.restore!.failureReason)
-                                   expect.fulfill()
-                               }, failure: { _ in
-                                   expect.fulfill()
-                               })
+        remote.getRewindStatus(
+            siteID,
+            success: { rewindStatus in
+                XCTAssertNotNil(rewindStatus.restore)
+                XCTAssertNotNil(rewindStatus.restore!.id)
+                XCTAssertEqual(rewindStatus.restore!.status, .queued)
+                XCTAssertEqual(rewindStatus.restore!.progress, 0)
+                XCTAssertNil(rewindStatus.restore!.failureReason)
+                expect.fulfill()
+            },
+            failure: { _ in
+                expect.fulfill()
+            }
+        )
         waitForExpectations(timeout: timeout, handler: nil)
     }
 

--- a/WordPress/Classes/ViewRelated/Activity/List/ActivityLogsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Activity/List/ActivityLogsViewModel.swift
@@ -38,7 +38,7 @@ final class ActivityLogsViewModel: ObservableObject {
     /// The backup list is exempt: it shows rewindable events only, which all
     /// belong to the `rewind` group, and its entry point has its own gating.
     var excludedActivityGroups: [String] {
-        if isBackupMode || blog.planActiveFeatures?.contains("backups-self-serve") == true {
+        if isBackupMode || blog.hasPlanFeature(.backupsSelfServe) {
             return []
         }
         return ["rewind", "scan"]

--- a/WordPress/Classes/ViewRelated/Activity/List/ActivityLogsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Activity/List/ActivityLogsViewModel.swift
@@ -83,8 +83,13 @@ final class ActivityLogsViewModel: ObservableObject {
 
     func fetchActivityGroups(after: Date? = nil, before: Date? = nil) async throws -> [WordPressKit.ActivityGroup] {
         guard let siteID = blog.dotComID?.intValue,
-              let api = blog.wordPressComRestApi else {
-            throw NSError(domain: "ActivityLogs", code: 0, userInfo: [NSLocalizedDescriptionKey: "Site ID or API not available"])
+            let api = blog.wordPressComRestApi
+        else {
+            throw NSError(
+                domain: "ActivityLogs",
+                code: 0,
+                userInfo: [NSLocalizedDescriptionKey: "Site ID or API not available"]
+            )
         }
 
         let service = ActivityServiceRemote(wordPressComRestApi: api)
@@ -96,11 +101,19 @@ final class ActivityLogsViewModel: ObservableObject {
         return groups.sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
     }
 
-    private func makeResponse(searchText: String?, parameters: GetActivityLogsParameters) async throws -> ActivityLogsPaginatedResponse {
+    private func makeResponse(
+        searchText: String?,
+        parameters: GetActivityLogsParameters
+    ) async throws -> ActivityLogsPaginatedResponse {
         try await ActivityLogsPaginatedResponse { [blog, isBackupMode] offset in
             guard let siteID = blog.dotComID?.intValue,
-                  let api = blog.wordPressComRestApi else {
-                throw NSError(domain: "ActivityLogs", code: 0, userInfo: [NSLocalizedDescriptionKey: SharedStrings.Error.generic])
+                let api = blog.wordPressComRestApi
+            else {
+                throw NSError(
+                    domain: "ActivityLogs",
+                    code: 0,
+                    userInfo: [NSLocalizedDescriptionKey: SharedStrings.Error.generic]
+                )
             }
             let service = ActivityServiceRemote(wordPressComRestApi: api)
             let offset = offset ?? 0
@@ -159,8 +172,15 @@ struct GetActivityLogsParameters: Hashable {
 }
 
 private extension ActivityServiceRemote {
-    func getActivities(siteID: Int, offset: Int, pageSize: Int, searchText: String? = nil, parameters: GetActivityLogsParameters = .init(), rewindable: Bool? = nil) async throws -> ([Activity], hasMore: Bool) {
-        return try await withCheckedThrowingContinuation { continuation in
+    func getActivities(
+        siteID: Int,
+        offset: Int,
+        pageSize: Int,
+        searchText: String? = nil,
+        parameters: GetActivityLogsParameters = .init(),
+        rewindable: Bool? = nil
+    ) async throws -> ([Activity], hasMore: Bool) {
+        try await withCheckedThrowingContinuation { continuation in
             getActivityForSite(
                 siteID,
                 offset: offset,
@@ -178,7 +198,11 @@ private extension ActivityServiceRemote {
         }
     }
 
-    func getActivityGroups(siteID: Int, after: Date? = nil, before: Date? = nil) async throws -> [WordPressKit.ActivityGroup] {
+    func getActivityGroups(
+        siteID: Int,
+        after: Date? = nil,
+        before: Date? = nil
+    ) async throws -> [WordPressKit.ActivityGroup] {
         try await withCheckedThrowingContinuation { continuation in
             getActivityGroupsForSite(
                 siteID,

--- a/WordPress/Classes/ViewRelated/Activity/List/ActivityLogsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Activity/List/ActivityLogsViewModel.swift
@@ -30,6 +30,20 @@ final class ActivityLogsViewModel: ObservableObject {
         blog.isHostedAtWPcom && !blog.hasPaidPlan
     }
 
+    /// Activity groups excluded from every activity request, mirroring the web
+    /// Activity Log (Calypso). WordPress.com backs up Simple sites internally
+    /// regardless of plan, so the activity stream can contain backup and scan
+    /// events even for sites whose plan does not include the backup product.
+    /// Sites without the `backups-self-serve` plan feature should not see them.
+    /// The backup list is exempt: it shows rewindable events only, which all
+    /// belong to the `rewind` group, and its entry point has its own gating.
+    var excludedActivityGroups: [String] {
+        if isBackupMode || blog.planActiveFeatures?.contains("backups-self-serve") == true {
+            return []
+        }
+        return ["rewind", "scan"]
+    }
+
     init(blog: Blog, isBackupMode: Bool = false) {
         self.blog = blog
         self.isBackupMode = isBackupMode
@@ -96,7 +110,8 @@ final class ActivityLogsViewModel: ObservableObject {
         let groups = try await service.getActivityGroups(
             siteID: siteID,
             after: after,
-            before: before
+            before: before,
+            notGroup: excludedActivityGroups
         )
         return groups.sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
     }
@@ -105,7 +120,8 @@ final class ActivityLogsViewModel: ObservableObject {
         searchText: String?,
         parameters: GetActivityLogsParameters
     ) async throws -> ActivityLogsPaginatedResponse {
-        try await ActivityLogsPaginatedResponse { [blog, isBackupMode] offset in
+        let excludedGroups = excludedActivityGroups
+        return try await ActivityLogsPaginatedResponse { [blog, isBackupMode] offset in
             guard let siteID = blog.dotComID?.intValue,
                 let api = blog.wordPressComRestApi
             else {
@@ -125,6 +141,7 @@ final class ActivityLogsViewModel: ObservableObject {
                 pageSize: pageSize,
                 searchText: searchText,
                 parameters: parameters,
+                notGroup: excludedGroups,
                 rewindable: isBackupMode ? true : nil
             )
             let viewModels = await makeViewModels(for: activities)
@@ -178,6 +195,7 @@ private extension ActivityServiceRemote {
         pageSize: Int,
         searchText: String? = nil,
         parameters: GetActivityLogsParameters = .init(),
+        notGroup: [String] = [],
         rewindable: Bool? = nil
     ) async throws -> ([Activity], hasMore: Bool) {
         try await withCheckedThrowingContinuation { continuation in
@@ -188,6 +206,7 @@ private extension ActivityServiceRemote {
                 after: parameters.startDate,
                 before: parameters.endDate,
                 group: Array(parameters.activityTypes),
+                notGroup: notGroup,
                 rewindable: rewindable,
                 searchText: searchText
             ) { activities, hasMore in
@@ -201,13 +220,15 @@ private extension ActivityServiceRemote {
     func getActivityGroups(
         siteID: Int,
         after: Date? = nil,
-        before: Date? = nil
+        before: Date? = nil,
+        notGroup: [String] = []
     ) async throws -> [WordPressKit.ActivityGroup] {
         try await withCheckedThrowingContinuation { continuation in
             getActivityGroupsForSite(
                 siteID,
                 after: after,
-                before: before
+                before: before,
+                notGroup: notGroup
             ) { groups in
                 continuation.resume(returning: groups)
             } failure: { error in


### PR DESCRIPTION
## Description

Fixes https://linear.app/a8c/issue/CMM-2130

Replicate [this wp-calypso change](https://github.com/Automattic/wp-calypso/pull/108740). I'm not sure why this change is not done on the API endpoint, though. Maybe we don't want to affect other endpoint consumers?

## Testing instructions

I can't reproduce the issue following the steps described in the Linear issue. You can give it go. Or, you can ask to join the test site mentioned in the Linear issue comments.