### PR TITLE
Open latest post from Stats summary card

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 * [*] Stats: Improve performance when opening the Stats screen [#25938]
 * [*] [internal] Stop donating screen activities as Siri predictions now that App Shortcuts cover them [#25757]
 * [*] Fix an issue where the Reader tab and Me tab show incorrect state after logging out [#25952]
+* [*] Stats: Open the latest post when tapping the Latest Post Summary card in the Insights tab [#25896]
 
 27.2
 -----

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
@@ -62,6 +62,7 @@ class SiteStatsInsightsTableViewController: SiteStatsBaseTableViewController {
         WPStyleGuide.Stats.configureTable(tableView)
         refreshControl.addTarget(self, action: #selector(refreshData), for: .valueChanged)
         ImmuTable.registerRows(tableRowTypes(), tableView: tableView)
+        tableHandler.automaticallyDeselectCells = true
         loadPinnedCards()
         initViewModel()
         sendScrollEventsToBanner()

--- a/WordPress/Classes/ViewRelated/Stats/Insights/StatsLatestPostSummaryInsightsCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/StatsLatestPostSummaryInsightsCell.swift
@@ -196,6 +196,7 @@ class StatsLatestPostSummaryInsightsCell: StatsBaseCell, LatestPostSummaryConfig
         selectionStyle = lastPostInsight == nil ? .none : .default
 
         guard let lastPostInsight else {
+            isAccessibilityElement = false
             toggleNoData(show: true)
             return
         }
@@ -211,6 +212,23 @@ class StatsLatestPostSummaryInsightsCell: StatsBaseCell, LatestPostSummaryConfig
         viewCountLabel.text = lastPostInsight.viewsCount.abbreviatedString()
         likeCountLabel.text = lastPostInsight.likesCount.abbreviatedString()
         commentCountLabel.text = lastPostInsight.commentsCount.abbreviatedString()
+
+        configureAccessibility(with: lastPostInsight)
+    }
+
+    // Present the card as a single button so VoiceOver announces the whole card
+    // and its tap action.
+    private func configureAccessibility(with lastPostInsight: StatsLastPostInsight) {
+        isAccessibilityElement = true
+        accessibilityTraits = .button
+        accessibilityLabel = [
+            postTitleLabel.text,
+            postTimestampLabel.text,
+            "\(lastPostInsight.viewsCount.abbreviatedString()) \(TextContent.views)",
+            "\(lastPostInsight.likesCount.abbreviatedString()) \(TextContent.likes)",
+            "\(lastPostInsight.commentsCount.abbreviatedString()) \(TextContent.comments)"
+        ].compactMap { $0 }.joined(separator: ", ")
+        accessibilityHint = TextContent.cardAccessibilityHint
     }
 
     // Switches out the no data views into the main stack view if we have no data.
@@ -268,5 +286,6 @@ class StatsLatestPostSummaryInsightsCell: StatsBaseCell, LatestPostSummaryConfig
         static let views = NSLocalizedString("stats.insights.latestPostSummary.views", value: "Views", comment: "Title for Views count in Latest Post Summary stats card.")
         static let likes = NSLocalizedString("stats.insights.latestPostSummary.likes", value: "Likes", comment: "Title for Likes count in Latest Post Summary stats card.")
         static let comments = NSLocalizedString("stats.insights.latestPostSummary.comments", value: "Comments", comment: "Title for Comments count in Latest Post Summary stats card.")
+        static let cardAccessibilityHint = NSLocalizedString("stats.insights.latestPostSummary.card.accessibilityHint", value: "Opens the post", comment: "VoiceOver accessibility hint for the Latest Post Summary stats card, informing the user that tapping opens the post.")
     }
 }

--- a/WordPress/Classes/ViewRelated/Stats/Insights/StatsLatestPostSummaryInsightsCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/StatsLatestPostSummaryInsightsCell.swift
@@ -193,6 +193,7 @@ class StatsLatestPostSummaryInsightsCell: StatsBaseCell, LatestPostSummaryConfig
     func configure(withInsightData lastPostInsight: StatsLastPostInsight?, andDelegate delegate: SiteStatsInsightsDelegate?) {
         siteStatsInsightsDelegate = delegate
         statSection = .insightsLatestPostSummary
+        selectionStyle = lastPostInsight == nil ? .none : .default
 
         guard let lastPostInsight else {
             toggleNoData(show: true)

--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsTableViewCells.swift
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsTableViewCells.swift
@@ -217,7 +217,17 @@ struct LatestPostSummaryRow: StatsHashableImmuTableRow {
     let summaryData: StatsLastPostInsight?
     let chartData: StatsPostDetails?
     weak var siteStatsInsightsDelegate: SiteStatsInsightsDelegate?
-    let action: ImmuTableAction? = nil
+    var action: ImmuTableAction? {
+        guard let url = summaryData?.url else {
+            return nil
+        }
+
+        let delegate = siteStatsInsightsDelegate
+        return { [weak delegate] _ in
+            WPAppAnalytics.track(.statsItemTappedLatestPostSummaryPost)
+            delegate?.displayWebViewWithURL?(url)
+        }
+    }
     let statSection: StatSection?
 
     func configureCell(_ cell: UITableViewCell) {


### PR DESCRIPTION
## Description

Fixes https://linear.app/a8c/issue/CMM-2313

To reproduce the issue: In Jetpack, open Stats, select Insights, and tap the populated Latest Post Summary card. Nothing happens.

Tapping the card now opens the post in the authenticated browser. The no-data state remains unchanged.
