### PR TITLE
Remove decorative icons from Stats metric labels

### DIFF
--- a/Modules/Sources/JetpackStats/Cards/RealtimeMetricsCard.swift
+++ b/Modules/Sources/JetpackStats/Cards/RealtimeMetricsCard.swift
@@ -35,7 +35,6 @@ struct RealtimeMetricsCard: View {
 
             HStack(spacing: 16) {
                 realtimeStatRow(
-                    systemImage: SiteMetric.views.systemImage,
                     label: SiteMetric.views.localizedTitle,
                     value: viewsLast30Min.formatted(.number.notation(.compactName))
                 )
@@ -43,7 +42,6 @@ struct RealtimeMetricsCard: View {
                 .accessibilityLabel("\(SiteMetric.views.localizedTitle), \(viewsLast30Min.formatted())")
 
                 realtimeStatRow(
-                    systemImage: SiteMetric.visitors.systemImage,
                     label: SiteMetric.visitors.localizedTitle,
                     value: visitorsLast30Min.formatted(.number.notation(.compactName))
                 )
@@ -51,7 +49,6 @@ struct RealtimeMetricsCard: View {
                 .accessibilityLabel("\(SiteMetric.visitors.localizedTitle), \(visitorsLast30Min.formatted())")
 
                 realtimeStatRow(
-                    systemImage: SiteMetric.visitors.systemImage,
                     label: Strings.SiteMetrics.visitorsNow,
                     value: activeVisitors.formatted(.number.notation(.compactName))
                 )
@@ -68,18 +65,11 @@ struct RealtimeMetricsCard: View {
         }
     }
 
-    private func realtimeStatRow(systemImage: String, label: String, value: String) -> some View {
+    private func realtimeStatRow(label: String, value: String) -> some View {
         VStack(alignment: .leading, spacing: 0) {
-            VStack(alignment: .leading, spacing: 4) {
-                Image(systemName: systemImage)
-                    .font(.caption2.weight(.medium))
-                    .foregroundColor(.secondary)
-                    .accessibilityHidden(true)
-
-                Text(label.uppercased())
-                    .font(.caption.weight(.medium))
-                    .foregroundColor(.secondary)
-            }
+            Text(label.uppercased())
+                .font(.caption.weight(.medium))
+                .foregroundColor(.secondary)
 
             Text(value)
                 .contentTransition(.numericText())

--- a/Modules/Sources/JetpackStats/Cards/TodayCard.swift
+++ b/Modules/Sources/JetpackStats/Cards/TodayCard.swift
@@ -56,16 +56,11 @@ struct TodayCard: View {
     }
 
     private var prominentMetricLabel: some View {
-        HStack(spacing: 2) {
-            Image(systemName: SiteMetric.views.systemImage)
-                .font(.caption2.weight(.medium))
-                .scaleEffect(x: 0.9, y: 0.9)
-            Text(SiteMetric.views.localizedTitle.uppercased())
-                .font(.caption.weight(.medium))
-        }
-        .foregroundStyle(Color.secondary)
-        .offset(y: 3) // Get it close to the value
-        .dynamicTypeSize(...DynamicTypeSize.large)
+        Text(SiteMetric.views.localizedTitle.uppercased())
+            .font(.caption.weight(.medium))
+            .foregroundStyle(Color.secondary)
+            .offset(y: 3) // Get it close to the value
+            .dynamicTypeSize(...DynamicTypeSize.large)
     }
 
     private var currentDateText: String {

--- a/Modules/Sources/JetpackStats/Screens/AuthorStatsView.swift
+++ b/Modules/Sources/JetpackStats/Screens/AuthorStatsView.swift
@@ -117,16 +117,10 @@ struct AuthorStatsView: View {
 
     private func makeViewsView(current: Int, previous: Int?) -> some View {
         VStack(alignment: .leading, spacing: 4) {
-            HStack(spacing: 4) {
-                Image(systemName: SiteMetric.views.systemImage)
-                    .font(.caption.weight(.medium))
-                    .foregroundColor(.secondary)
-
-                Text(SiteMetric.views.localizedTitle)
-                    .font(.caption.weight(.medium))
-                    .foregroundColor(.secondary)
-                    .textCase(.uppercase)
-            }
+            Text(SiteMetric.views.localizedTitle)
+                .font(.caption.weight(.medium))
+                .foregroundColor(.secondary)
+                .textCase(.uppercase)
 
             HStack(alignment: .center, spacing: Constants.step1) {
                 Text(StatsValueFormatter.formatNumber(current, onlyLarge: true))

--- a/Modules/Sources/JetpackStats/Screens/PostStatsView.swift
+++ b/Modules/Sources/JetpackStats/Screens/PostStatsView.swift
@@ -400,10 +400,6 @@ private struct PostStatsMetricsStripView: View {
         var body: some View {
             VStack(alignment: .leading, spacing: 0) {
                 HStack(spacing: 2) {
-                    Image(systemName: metric.systemImage)
-                        .font(.caption2.weight(.medium))
-                        .foregroundColor(.secondary)
-
                     Text(metric.localizedTitle.uppercased())
                         .font(.caption.weight(.medium))
                         .foregroundColor(.secondary)
@@ -474,27 +470,23 @@ private struct PostStatsEmailMetricsView: View {
             EmailMetric(
                 id: "sends",
                 title: Strings.PostDetails.emailsSent.uppercased(),
-                value: emailData.totalSends ?? 0,
-                icon: "envelope"
+                value: emailData.totalSends ?? 0
             ),
             EmailMetric(
                 id: "rate",
                 title: Strings.PostDetails.openRate.uppercased(),
                 value: nil,
-                rate: emailData.opensRate,
-                icon: "percent"
+                rate: emailData.opensRate
             ),
             EmailMetric(
                 id: "unique",
                 title: Strings.PostDetails.uniqueOpens.uppercased(),
-                value: emailData.uniqueOpens ?? 0,
-                icon: "envelope.open"
+                value: emailData.uniqueOpens ?? 0
             ),
             EmailMetric(
                 id: "total",
                 title: Strings.PostDetails.totalOpens.uppercased(),
-                value: emailData.totalOpens ?? 0,
-                icon: "envelope.open.fill"
+                value: emailData.totalOpens ?? 0
             )
         ]
     }
@@ -504,7 +496,6 @@ private struct PostStatsEmailMetricsView: View {
         let title: String
         let value: Int?
         var rate: Double?
-        let icon: String
     }
 
     struct MetricView: View {
@@ -514,15 +505,9 @@ private struct PostStatsEmailMetricsView: View {
 
         var body: some View {
             VStack(alignment: .leading, spacing: 4) {
-                HStack(alignment: .center, spacing: 2) {
-                    Image(systemName: metric.icon)
-                        .font(.caption2.weight(.medium))
-                        .foregroundColor(.secondary)
-
-                    Text(metric.title)
-                        .font(.caption.weight(.medium))
-                        .foregroundColor(.secondary)
-                }
+                Text(metric.title)
+                    .font(.caption.weight(.medium))
+                    .foregroundColor(.secondary)
                 HStack {
                     Text(formattedValue)
                         .contentTransition(.numericText())

--- a/Modules/Sources/JetpackStats/Screens/UTMMetricStatsView.swift
+++ b/Modules/Sources/JetpackStats/Screens/UTMMetricStatsView.swift
@@ -106,16 +106,10 @@ struct UTMMetricStatsView: View {
 
     private func makeViewsView(current: Int, previous: Int?) -> some View {
         VStack(alignment: .leading, spacing: 4) {
-            HStack(spacing: 4) {
-                Image(systemName: SiteMetric.views.systemImage)
-                    .font(.caption.weight(.medium))
-                    .foregroundColor(.secondary)
-
-                Text(SiteMetric.views.localizedTitle)
-                    .font(.caption.weight(.medium))
-                    .foregroundColor(.secondary)
-                    .textCase(.uppercase)
-            }
+            Text(SiteMetric.views.localizedTitle)
+                .font(.caption.weight(.medium))
+                .foregroundColor(.secondary)
+                .textCase(.uppercase)
 
             HStack(spacing: Constants.step2) {
                 Text(StatsValueFormatter.formatNumber(current, onlyLarge: true))

--- a/Modules/Sources/JetpackStats/Views/MetricsOverviewTabView.swift
+++ b/Modules/Sources/JetpackStats/Views/MetricsOverviewTabView.swift
@@ -97,18 +97,11 @@ private struct MetricItemView<Metric: MetricType>: View {
     }
 
     private var headerView: some View {
-        HStack(spacing: 2) {
-            if showTrend {
-                Image(systemName: data.metric.systemImage)
-                    .font(.caption2.weight(.medium))
-                    .scaleEffect(x: 0.9, y: 0.9)
-            }
-            Text(data.metric.localizedTitle.uppercased())
-                .font(.caption.weight(.medium))
-        }
-        .foregroundColor(isSelected ? .primary : .secondary)
-        .animation(.easeInOut(duration: 0.25), value: isSelected)
-        .padding(.trailing, 4) // Visually spacing matters less than for metricsView
+        Text(data.metric.localizedTitle.uppercased())
+            .font(.caption.weight(.medium))
+            .foregroundColor(isSelected ? .primary : .secondary)
+            .animation(.easeInOut(duration: 0.25), value: isSelected)
+            .padding(.trailing, 4) // Visually spacing matters less than for metricsView
     }
 
     private var metricsView: some View {

--- a/Modules/Sources/JetpackStats/Views/StandaloneMetricView.swift
+++ b/Modules/Sources/JetpackStats/Views/StandaloneMetricView.swift
@@ -7,16 +7,10 @@ struct StandaloneMetricView: View {
 
     var body: some View {
         VStack(alignment: .trailing, spacing: 0) {
-            HStack(spacing: 4) {
-                Image(systemName: metric.systemImage)
-                    .font(.caption.weight(.medium))
-                    .foregroundColor(.secondary)
-
-                Text(metric.localizedTitle)
-                    .font(.caption.weight(.medium))
-                    .foregroundColor(.secondary)
-                    .textCase(.uppercase)
-            }
+            Text(metric.localizedTitle)
+                .font(.caption.weight(.medium))
+                .foregroundColor(.secondary)
+                .textCase(.uppercase)
             Text(StatsValueFormatter.formatNumber(value, onlyLarge: true))
                 .font(Constants.Typography.smallDisplayFont)
                 .foregroundColor(.primary)


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/CMM-2306

| Before | After |
|---|---|
| <img width="400" alt="CMM-2306-before-stats-overview" src="https://github.com/user-attachments/assets/21e18453-4cdc-42ba-a835-75052087281b" /> | <img width="400" alt="CMM-2306-after-stats-overview" src="https://github.com/user-attachments/assets/431c9a9a-648d-4aa3-86dc-e4f474b1c430" /> |
| <img width="400" alt="CMM-2306-before-post-stats-metrics" src="https://github.com/user-attachments/assets/d82cc03e-67bf-41cd-9861-3ee7095f65ab" /> | <img width="400" alt="CMM-2306-after-post-stats-metrics" src="https://github.com/user-attachments/assets/03b36bc4-e5db-47d2-9e23-e47f4c7b7235" /> |
| <img width="400" alt="CMM-2306-before-post-stats-email" src="https://github.com/user-attachments/assets/044f992b-5083-4b9c-bbc6-8142c289a27d" /> | <img width="400" alt="CMM-2306-after-post-stats-email" src="https://github.com/user-attachments/assets/2da6352c-8d57-47a4-acf2-edde1f4665a1" /> |
| <img width="400" alt="CMM-2306-before-referrer-detail" src="https://github.com/user-attachments/assets/1664e7ee-f4d6-4129-b059-0dc2cc20c7a0" /> | <img width="400" alt="CMM-2306-after-referrer-detail" src="https://github.com/user-attachments/assets/7672edd3-e313-4ea1-bbff-d1914f9a0eaf" /> |
| <img width="400" alt="CMM-2306-before-external-link-detail" src="https://github.com/user-attachments/assets/57b76908-2cf5-4b4a-aa0a-40015c5ec2ef" /> | <img width="400" alt="CMM-2306-after-external-link-detail" src="https://github.com/user-attachments/assets/9e47ab55-0e2a-4f40-8caf-cb427abf0987" /> |
| <img width="400" alt="CMM-2306-before-archive-detail" src="https://github.com/user-attachments/assets/62e06961-665a-47f9-8077-5058693cb25e" /> | <img width="400" alt="CMM-2306-after-archive-detail" src="https://github.com/user-attachments/assets/a9c50ad2-25fd-4849-b2d3-4ade2977a784" /> |
| <img width="400" alt="CMM-2306-before-author-detail" src="https://github.com/user-attachments/assets/0d26e191-7aa0-4b0e-8c65-c62ff5176eac" /> | <img width="400" alt="CMM-2306-after-author-detail" src="https://github.com/user-attachments/assets/6fd30dbc-5c72-4db7-bf02-75e5ef6608da" /> |