### PR TITLE
Rediscover the REST API root when its host does not match the site

### DIFF
--- a/Tests/KeystoneTests/Tests/Utility/ApplicationPasswordsRepositoryTests.swift
+++ b/Tests/KeystoneTests/Tests/Utility/ApplicationPasswordsRepositoryTests.swift
@@ -138,6 +138,52 @@ class ApplicationPasswordsRepositoryTests {
     }
 
     @Test
+    func cancelDuringStaleRestApiRootUrlRediscovery() async throws {
+        defer { HTTPStubs.removeAllStubs() }
+
+        let staleRootURL = "https://public-api.wordpress.com/wp-json/?rest_route=/sites/atomic.com"
+
+        try await signInWPComAccount()
+        let blog = try await createAtomicSite(existingApplicationPassword: "existing token")
+        try await setRestApiRootURL(staleRootURL, of: blog)
+
+        // Discovery that can never succeed: a slow homepage and a 404 API root. Without this,
+        // discovery may still succeed after cancellation and `WordPressLoginClient.details`
+        // itself reports the cancellation, hiding the fallback path under test.
+        let discoveryMonitor = Monitor(delay: 0.5)
+        stubWPComProxyRestNoRoute()
+        stub(condition: isHost("atomic.com") && isPath("/")) { _ in
+            discoveryMonitor.requestReceived()
+
+            let response = HTTPStubsResponse(
+                data: "<html>homepage</html>".data(using: .utf8)!,
+                statusCode: 200,
+                headers: ["Link": "<https://atomic.com/wp-json/>; rel=\"https://api.w.org/\""]
+            )
+            response.responseTime = 0.5
+            return response
+        }
+        stub(condition: isHost("atomic.com") && isPath("/wp-json")) { _ in
+            HTTPStubsResponse(data: "<html>page not found</html>".data(using: .utf8)!, statusCode: 404, headers: nil)
+        }
+        stubJetpackProxyCreateApplicationPassword(siteId: 456, password: "new token")
+
+        let repository = ApplicationPasswordRepository.forTesting(coreDataStack: coreDataStack, keychain: keychain)
+        let task = Task {
+            try await repository.createPasswordIfNeeded(for: blog)
+        }
+
+        await discoveryMonitor.hasReceivedRequest()
+        task.cancel()
+
+        let result = await task.result
+        #expect(result.isCancellationError())
+
+        let restApiRootURL = await restApiRootURL(of: blog)
+        #expect(restApiRootURL == staleRootURL)
+    }
+
+    @Test
     func selfHostedSite() async throws {
         defer { HTTPStubs.removeAllStubs() }
 

--- a/Tests/KeystoneTests/Tests/Utility/ApplicationPasswordsRepositoryTests.swift
+++ b/Tests/KeystoneTests/Tests/Utility/ApplicationPasswordsRepositoryTests.swift
@@ -76,6 +76,68 @@ class ApplicationPasswordsRepositoryTests {
     }
 
     @Test
+    func staleRestApiRootUrlIsRediscovered() async throws {
+        defer { HTTPStubs.removeAllStubs() }
+
+        try await signInWPComAccount()
+        let blog = try await createAtomicSite(existingApplicationPassword: "existing token")
+        // A WP.com proxy API root saved while the site was a Simple site (CMM-2282).
+        try await setRestApiRootURL("https://public-api.wordpress.com/wp-json/?rest_route=/sites/atomic.com", of: blog)
+
+        stubWPComProxyRestNoRoute()
+        stubApiDiscovery(siteHost: "atomic.com")
+        stubJetpackProxyCreateApplicationPassword(siteId: 456, password: "new token")
+
+        let repository = ApplicationPasswordRepository.forTesting(coreDataStack: coreDataStack, keychain: keychain)
+        try await repository.createPasswordIfNeeded(for: blog)
+
+        let restApiRootURL = await restApiRootURL(of: blog)
+        #expect(restApiRootURL == "https://atomic.com/wp-json/")
+    }
+
+    @Test
+    func matchingRestApiRootUrlSkipsRediscovery() async throws {
+        defer { HTTPStubs.removeAllStubs() }
+
+        try await signInWPComAccount()
+        let blog = try await createAtomicSite(existingApplicationPassword: "existing token")
+
+        let discoveryMonitor = Monitor()
+        stubApiDiscovery(siteHost: "atomic.com", monitor: discoveryMonitor)
+        stubCurrentApplicationPassword(host: "atomic.com")
+        stubJetpackProxyCreateApplicationPassword(siteId: 456, password: "new token")
+
+        let repository = ApplicationPasswordRepository.forTesting(coreDataStack: coreDataStack, keychain: keychain)
+        try await repository.createPasswordIfNeeded(for: blog)
+
+        #expect(discoveryMonitor.numberOfRequests == 0)
+
+        let restApiRootURL = await restApiRootURL(of: blog)
+        #expect(restApiRootURL == "https://atomic.com/wp-json")
+    }
+
+    @Test
+    func staleRestApiRootUrlKeptWhenRediscoveryFails() async throws {
+        defer { HTTPStubs.removeAllStubs() }
+
+        let staleRootURL = "https://public-api.wordpress.com/wp-json/?rest_route=/sites/atomic.com"
+
+        try await signInWPComAccount()
+        let blog = try await createAtomicSite(existingApplicationPassword: "existing token")
+        try await setRestApiRootURL(staleRootURL, of: blog)
+
+        stubWPComProxyRestNoRoute()
+        stubApiDiscoveryFailure(siteHost: "atomic.com")
+        stubJetpackProxyCreateApplicationPassword(siteId: 456, password: "new token")
+
+        let repository = ApplicationPasswordRepository.forTesting(coreDataStack: coreDataStack, keychain: keychain)
+        try await repository.createPasswordIfNeeded(for: blog)
+
+        let restApiRootURL = await restApiRootURL(of: blog)
+        #expect(restApiRootURL == staleRootURL)
+    }
+
+    @Test
     func selfHostedSite() async throws {
         defer { HTTPStubs.removeAllStubs() }
 
@@ -325,6 +387,27 @@ private extension ApplicationPasswordsRepositoryTests {
         }
     }
 
+    func setRestApiRootURL(_ url: String, of blog: TaggedManagedObjectID<Blog>) async throws {
+        try await coreDataStack.performAndSave { context in
+            try context.existingObject(with: blog).restApiRootURL = url
+        }
+    }
+
+    func restApiRootURL(of blog: TaggedManagedObjectID<Blog>) async -> String? {
+        await coreDataStack.performQuery { context in
+            (try? context.existingObject(with: blog))?.restApiRootURL
+        }
+    }
+
+    /// WP.com does not serve `?rest_route=/sites/{site}/...` URLs; they all return `rest_no_route`.
+    func stubWPComProxyRestNoRoute() {
+        stub(condition: isHost("public-api.wordpress.com") && isPath("/wp-json")) { _ in
+            let json =
+                #"{"code":"rest_no_route","message":"No route was found matching the URL and request method.","data":{"status":404}}"#
+            return HTTPStubsResponse(data: json.data(using: .utf8)!, statusCode: 404, headers: nil)
+        }
+    }
+
     func createSelfHostedSite(host: String) async throws -> TaggedManagedObjectID<Blog> {
         try await coreDataStack.performAndSave { context in
             let blog = Blog(context: context)
@@ -567,9 +650,11 @@ private extension ApplicationPasswordsRepositoryTests {
         }
     }
 
-    func stubApiDiscovery(siteHost: String) {
+    func stubApiDiscovery(siteHost: String, monitor: Monitor? = nil) {
         stub(condition: isHost(siteHost) && isPath("/")) { _ in
-            HTTPStubsResponse(
+            monitor?.requestReceived()
+
+            return HTTPStubsResponse(
                 data: "<html>homepage</html>".data(using: .utf8)!,
                 statusCode: 200,
                 headers: ["Link": "<https://\(siteHost)/wp-json/>; rel=\"https://api.w.org/\""]

--- a/WordPress/Classes/Services/ApplicationPasswordRepository.swift
+++ b/WordPress/Classes/Services/ApplicationPasswordRepository.swift
@@ -343,7 +343,7 @@ private extension ApplicationPasswordRepository {
     func updateRestAPIURLIfNeeded(_ blogId: TaggedManagedObjectID<Blog>) async throws -> ParsedUrl {
         let (siteUrl, restApiRootUrl) = try await coreDataStack.performQuery { context in
             let blog = try context.existingObject(with: blogId)
-            return try (blog.getUrlString(), blog.restApiRootURL)
+            return try (blog.getUrl(), blog.restApiRootURL)
         }
 
         // A stored API root on a different host than the site is stale and must be rediscovered.
@@ -352,7 +352,7 @@ private extension ApplicationPasswordRepository {
         // change also leaves the stored root pointing at the old host.
         if let restApiRootUrl,
             let parsed = try? ParsedUrl.parse(input: restApiRootUrl),
-            host(of: restApiRootUrl) == host(of: siteUrl)
+            parsed.asURL().host?.lowercased() == siteUrl.host?.lowercased()
         {
             return parsed
         }
@@ -361,7 +361,7 @@ private extension ApplicationPasswordRepository {
         let loginClient = WordPressLoginClient(urlSession: session)
         let apiRootURL: ParsedUrl
         do {
-            apiRootURL = try await loginClient.details(ofSite: siteUrl).apiRootUrl
+            apiRootURL = try await loginClient.details(ofSite: siteUrl.absoluteString).apiRootUrl
         } catch {
             // A cancelled discovery surfaces as a discovery failure, not as a `CancellationError`,
             // so check for cancellation explicitly. Falling back on cancellation would let a
@@ -388,10 +388,6 @@ private extension ApplicationPasswordRepository {
         }
 
         return apiRootURL
-    }
-
-    private func host(of urlString: String) -> String? {
-        URL(string: urlString)?.host?.lowercased()
     }
 
     func updateSiteUsernameIfNeeded(_ blogId: TaggedManagedObjectID<Blog>) async throws -> String {

--- a/WordPress/Classes/Services/ApplicationPasswordRepository.swift
+++ b/WordPress/Classes/Services/ApplicationPasswordRepository.swift
@@ -346,14 +346,36 @@ private extension ApplicationPasswordRepository {
             return try (blog.getUrlString(), blog.restApiRootURL)
         }
 
+        // A stored API root on a different host than the site is stale and must be rediscovered.
+        // Notably, WP.com Simple sites advertise a `public-api.wordpress.com/wp-json/?rest_route=...`
+        // API root, which stops working once the site moves to Atomic (CMM-2282). A site's domain
+        // change also leaves the stored root pointing at the old host.
+        if let restApiRootUrl,
+            let parsed = try? ParsedUrl.parse(input: restApiRootUrl),
+            host(of: restApiRootUrl) == host(of: siteUrl)
+        {
+            return parsed
+        }
+
         let session = URLSession(configuration: .ephemeral)
         let loginClient = WordPressLoginClient(urlSession: session)
         let apiRootURL: ParsedUrl
-        if let restApiRootUrl, let parsed = try? ParsedUrl.parse(input: restApiRootUrl) {
-            apiRootURL = parsed
-        } else {
+        do {
             apiRootURL = try await loginClient.details(ofSite: siteUrl).apiRootUrl
+        } catch {
+            // Rediscovery of a stale root is best-effort. Keep using the stored root when
+            // discovery fails (e.g. the site is temporarily unreachable), rather than breaking
+            // flows that used to work with it.
+            if !error.isCancellationError(),
+                let restApiRootUrl,
+                let stored = try? ParsedUrl.parse(input: restApiRootUrl)
+            {
+                return stored
+            }
+            throw error
+        }
 
+        if apiRootURL.url() != restApiRootUrl {
             try await coreDataStack.performAndSave { context in
                 let blog = try context.existingObject(with: blogId)
                 blog.restApiRootURL = apiRootURL.url()
@@ -361,6 +383,10 @@ private extension ApplicationPasswordRepository {
         }
 
         return apiRootURL
+    }
+
+    private func host(of urlString: String) -> String? {
+        URL(string: urlString)?.host?.lowercased()
     }
 
     func updateSiteUsernameIfNeeded(_ blogId: TaggedManagedObjectID<Blog>) async throws -> String {

--- a/WordPress/Classes/Services/ApplicationPasswordRepository.swift
+++ b/WordPress/Classes/Services/ApplicationPasswordRepository.swift
@@ -88,6 +88,11 @@ actor ApplicationPasswordRepository {
     }
 
     /// When returning true, a valid application password is guaranteed to be returned by the `Blog.getApplicationToken` function.
+    ///
+    /// This function is safe to call multiple times, but every call performs real work, including
+    /// HTTP requests (password validation, and REST API root rediscovery when the stored root is
+    /// stale). Limit calls to once per "site launch" (app launch, switching site, etc.) to avoid
+    /// that unnecessary work.
     func createPasswordIfNeeded(for blogId: TaggedManagedObjectID<Blog>) async throws {
         if let _ = try await validatePasswords(in: blogId) {
             return

--- a/WordPress/Classes/Services/ApplicationPasswordRepository.swift
+++ b/WordPress/Classes/Services/ApplicationPasswordRepository.swift
@@ -363,6 +363,11 @@ private extension ApplicationPasswordRepository {
         do {
             apiRootURL = try await loginClient.details(ofSite: siteUrl).apiRootUrl
         } catch {
+            // A cancelled discovery surfaces as a discovery failure, not as a `CancellationError`,
+            // so check for cancellation explicitly. Falling back on cancellation would let a
+            // cancelled operation continue running.
+            try Task.checkCancellation()
+
             // Rediscovery of a stale root is best-effort. Keep using the stored root when
             // discovery fails (e.g. the site is temporarily unreachable), rather than breaking
             // flows that used to work with it.


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/CMM-2282

WordPress.com site's `restApiRootURL` is never re-validated after the `Blog` instance is added. When the site transition from simple site to atomic site, the `restApiRootURL` is no longer correct.