### PR TITLE
Stats: Restore referrer spam action eligibility

### DIFF
--- a/Modules/Sources/JetpackStats/Cards/TopListCard.swift
+++ b/Modules/Sources/JetpackStats/Cards/TopListCard.swift
@@ -185,7 +185,8 @@ struct TopListCard: View {
             service: context.service,
             context: context,
             initialData: viewModel.data,
-            filter: viewModel.filter
+            filter: viewModel.filter,
+            onRefresh: viewModel.refresh
         )
         .environment(\.context, context)
         .environment(\.router, router)
@@ -341,7 +342,8 @@ struct TopListCard: View {
                 data: data,
                 itemLimit: showMoreInline && isExpanded ? data.items.count : itemLimit,
                 dateRange: viewModel.effectiveDateRange,
-                reserveSpace: reserveSpace
+                reserveSpace: reserveSpace,
+                onReferrerMarkedAsSpam: viewModel.refresh
             )
             if showMoreInline && data.items.count > itemLimit {
                 showMoreInlineButton

--- a/Modules/Sources/JetpackStats/Cards/TopListViewModel.swift
+++ b/Modules/Sources/JetpackStats/Cards/TopListViewModel.swift
@@ -121,7 +121,11 @@ final class TopListViewModel: ObservableObject, TrafficCardViewModel {
         loadData()
     }
 
-    private func loadData() {
+    func refresh() {
+        loadData(invalidatingCache: true)
+    }
+
+    private func loadData(invalidatingCache: Bool = false) {
         loadingTask?.cancel()
         staleTimer?.cancel()
 
@@ -150,6 +154,9 @@ final class TopListViewModel: ObservableObject, TrafficCardViewModel {
             }
 
             guard !Task.isCancelled else { return }
+            if invalidatingCache {
+                await service.invalidateTopListData(for: selection.item)
+            }
             await self.actuallyLoadData(for: selection, dateRange: effectiveDateRange)
         }
     }

--- a/Modules/Sources/JetpackStats/Screens/ReferrerStatsView.swift
+++ b/Modules/Sources/JetpackStats/Screens/ReferrerStatsView.swift
@@ -5,6 +5,7 @@ import DesignSystem
 struct ReferrerStatsView: View {
     let referrer: TopListItem.Referrer
     let dateRange: StatsDateRange
+    var onMarkedAsSpam: () -> Void = {}
 
     private let imageSize: CGFloat = 28
 
@@ -164,7 +165,8 @@ struct ReferrerStatsView: View {
             TopListItemsView(
                 data: childrenChartData,
                 itemLimit: referrer.children.count,
-                dateRange: dateRange
+                dateRange: dateRange,
+                onReferrerMarkedAsSpam: onMarkedAsSpam
             )
         }
         .padding(.vertical, Constants.step2)
@@ -188,6 +190,7 @@ struct ReferrerStatsView: View {
             try await context.service.toggleSpamState(for: domain, currentValue: isMarkedAsSpam)
             // Update local state to reflect the change
             isMarkedAsSpam = true
+            onMarkedAsSpam()
         } catch {
             errorMessage =
                 error.localizedDescription.isEmpty

--- a/Modules/Sources/JetpackStats/Screens/ReferrerStatsView.swift
+++ b/Modules/Sources/JetpackStats/Screens/ReferrerStatsView.swift
@@ -55,21 +55,23 @@ struct ReferrerStatsView: View {
     var headerCard: some View {
         VStack(spacing: Constants.step2) {
             referrerInfoRow
-            Divider()
-            markAsSpamButton
-                .confirmationDialog(
-                    Strings.ReferrerDetails.markAsSpam,
-                    isPresented: $showConfirmationDialog
-                ) {
-                    Button(Strings.ReferrerDetails.markAsSpam, role: .destructive) {
-                        Task {
-                            await markAsSpam()
+            if referrer.canMarkAsSpam {
+                Divider()
+                markAsSpamButton
+                    .confirmationDialog(
+                        Strings.ReferrerDetails.markAsSpam,
+                        isPresented: $showConfirmationDialog
+                    ) {
+                        Button(Strings.ReferrerDetails.markAsSpam, role: .destructive) {
+                            Task {
+                                await markAsSpam()
+                            }
                         }
+                        Button(Strings.Buttons.cancel, role: .cancel) {}
+                    } message: {
+                        Text(Strings.ReferrerDetails.confirmAsSpamMessage(domain: referrer.spamDomain ?? ""))
                     }
-                    Button(Strings.Buttons.cancel, role: .cancel) {}
-                } message: {
-                    Text(Strings.ReferrerDetails.confirmAsSpamMessage(domain: referrer.domain ?? ""))
-                }
+            }
         }
         .padding(Constants.step2)
         .cardStyle()
@@ -178,7 +180,7 @@ struct ReferrerStatsView: View {
     }
 
     private func markAsSpam() async {
-        guard let domain = referrer.domain else { return }
+        guard let domain = referrer.spamDomain else { return }
 
         isMarkingAsSpam = true
 
@@ -214,11 +216,13 @@ private extension TopListItem.Referrer {
     static let mock = TopListItem.Referrer(
         name: "Google Search",
         domain: "google.com",
+        url: nil,
         iconURL: URL(string: "https://www.google.com/favicon.ico"),
         children: [
             TopListItem.Referrer(
                 name: "wordpress development tutorial",
                 domain: "google.com",
+                url: nil,
                 iconURL: URL(string: "https://www.google.com/favicon.ico"),
                 children: [],
                 metrics: SiteMetricsSet(views: 850)
@@ -226,6 +230,7 @@ private extension TopListItem.Referrer {
             TopListItem.Referrer(
                 name: "swift programming blog",
                 domain: "google.com",
+                url: nil,
                 iconURL: URL(string: "https://www.google.com/favicon.ico"),
                 children: [],
                 metrics: SiteMetricsSet(views: 750)
@@ -233,6 +238,7 @@ private extension TopListItem.Referrer {
             TopListItem.Referrer(
                 name: "ios app development best practices",
                 domain: "google.com",
+                url: nil,
                 iconURL: URL(string: "https://www.google.com/favicon.ico"),
                 children: [],
                 metrics: SiteMetricsSet(views: 600)

--- a/Modules/Sources/JetpackStats/Screens/ReferrerStatsView.swift
+++ b/Modules/Sources/JetpackStats/Screens/ReferrerStatsView.swift
@@ -39,7 +39,7 @@ struct ReferrerStatsView: View {
         .navigationTitle(Strings.ReferrerDetails.title)
         .navigationBarTitleDisplayMode(.inline)
         .alert(Strings.ReferrerDetails.errorAlertTitle, isPresented: $showErrorAlert) {
-            Button(Strings.Buttons.ok, role: .cancel) { }
+            Button(Strings.Buttons.ok, role: .cancel) {}
         } message: {
             Text(errorMessage)
         }
@@ -66,7 +66,7 @@ struct ReferrerStatsView: View {
                             await markAsSpam()
                         }
                     }
-                    Button(Strings.Buttons.cancel, role: .cancel) { }
+                    Button(Strings.Buttons.cancel, role: .cancel) {}
                 } message: {
                     Text(Strings.ReferrerDetails.confirmAsSpamMessage(domain: referrer.domain ?? ""))
                 }
@@ -170,7 +170,7 @@ struct ReferrerStatsView: View {
     }
 
     private var childrenChartData: TopListData {
-        return TopListData(
+        TopListData(
             item: .referrers,
             metric: .views,
             items: referrer.children
@@ -187,7 +187,9 @@ struct ReferrerStatsView: View {
             // Update local state to reflect the change
             isMarkedAsSpam = true
         } catch {
-            errorMessage = error.localizedDescription.isEmpty ? Strings.ReferrerDetails.markAsSpamError : error.localizedDescription
+            errorMessage =
+                error.localizedDescription.isEmpty
+                ? Strings.ReferrerDetails.markAsSpamError : error.localizedDescription
             showErrorAlert = true
         }
 

--- a/Modules/Sources/JetpackStats/Screens/ReferrerStatsView.swift
+++ b/Modules/Sources/JetpackStats/Screens/ReferrerStatsView.swift
@@ -21,8 +21,16 @@ struct ReferrerStatsView: View {
     var body: some View {
         ScrollView {
             VStack(spacing: Constants.step3) {
-                headerCard
-                    .dynamicTypeSize(...DynamicTypeSize.xLarge)
+                VStack(alignment: .leading, spacing: Constants.step1) {
+                    headerCard
+                        .dynamicTypeSize(...DynamicTypeSize.xLarge)
+                    if referrer.canMarkAsSpam && !isMarkedAsSpam {
+                        Text(Strings.ReferrerDetails.markAsSpamExplanation)
+                            .font(.footnote)
+                            .foregroundStyle(.secondary)
+                            .padding(.horizontal, Constants.step2)
+                    }
+                }
                 if !referrer.children.isEmpty {
                     childrenCard
                 }
@@ -204,10 +212,21 @@ struct ReferrerStatsView: View {
 
 // MARK: - Preview
 
-#Preview {
+#Preview("Without Spam Button") {
     NavigationView {
         ReferrerStatsView(
             referrer: .mock,
+            dateRange: Calendar.demo.makeDateRange(for: .thisYear)
+        )
+    }
+    .navigationViewStyle(.stack)
+    .tint(Constants.Colors.jetpack)
+}
+
+#Preview("With Spam Button") {
+    NavigationView {
+        ReferrerStatsView(
+            referrer: .spamEligibleMock,
             dateRange: Calendar.demo.makeDateRange(for: .thisYear)
         )
     }
@@ -248,5 +267,14 @@ private extension TopListItem.Referrer {
             )
         ],
         metrics: SiteMetricsSet(views: 2200)
+    )
+
+    static let spamEligibleMock = TopListItem.Referrer(
+        name: "google.com",
+        domain: mock.domain,
+        url: mock.url,
+        iconURL: mock.iconURL,
+        children: mock.children,
+        metrics: mock.metrics
     )
 }

--- a/Modules/Sources/JetpackStats/Screens/TopListScreenView.swift
+++ b/Modules/Sources/JetpackStats/Screens/TopListScreenView.swift
@@ -11,6 +11,8 @@ struct TopListScreenView: View {
     @Environment(\.context) var context
     @Environment(\.horizontalSizeClass) var horizontalSizeClass
 
+    private let onRefresh: () -> Void
+
     init(
         selection: TopListViewModel.Selection,
         dateRange: StatsDateRange,
@@ -18,7 +20,9 @@ struct TopListScreenView: View {
         context: StatsContext,
         initialData: TopListData? = nil,
         filter: TopListViewModel.Filter? = nil,
+        onRefresh: @escaping () -> Void = {}
     ) {
+        self.onRefresh = onRefresh
         let configuration = TopListCardConfiguration(
             item: selection.item,
             metric: selection.metric
@@ -239,11 +243,17 @@ struct TopListScreenView: View {
                 previousValue: data.previousItem(for: item)?.metrics[viewModel.selection.metric],
                 metric: viewModel.selection.metric,
                 maxValue: data.metrics.maxValue,
-                dateRange: viewModel.effectiveDateRange
+                dateRange: viewModel.effectiveDateRange,
+                onReferrerMarkedAsSpam: refreshReferrers
             )
             .frame(height: TopListItemView.defaultCellHeight)
         }
         .listRowInsets(EdgeInsets(top: Constants.step0_5 / 2, leading: 0, bottom: Constants.step0_5 / 2, trailing: 0))
+    }
+
+    private func refreshReferrers() {
+        viewModel.refresh()
+        onRefresh()
     }
 
     private func getDisplayedItems(

--- a/Modules/Sources/JetpackStats/Services/Data/TopListData.swift
+++ b/Modules/Sources/JetpackStats/Services/Data/TopListData.swift
@@ -154,11 +154,13 @@ extension TopListData {
             return TopListItem.Referrer(
                 name: data.0,
                 domain: data.1,
+                url: nil,
                 iconURL: nil,
                 children: [
                     TopListItem.Referrer(
                         name: "wordpress development tutorial",
                         domain: "google.com",
+                        url: nil,
                         iconURL: URL(string: "https://www.google.com/favicon.ico"),
                         children: [],
                         metrics: SiteMetricsSet(views: 850)
@@ -166,6 +168,7 @@ extension TopListData {
                     TopListItem.Referrer(
                         name: "swift programming blog",
                         domain: "google.com",
+                        url: nil,
                         iconURL: URL(string: "https://www.google.com/favicon.ico"),
                         children: [],
                         metrics: SiteMetricsSet(views: 750)
@@ -173,6 +176,7 @@ extension TopListData {
                     TopListItem.Referrer(
                         name: "ios app development best practices",
                         domain: "google.com",
+                        url: nil,
                         iconURL: URL(string: "https://www.google.com/favicon.ico"),
                         children: [],
                         metrics: SiteMetricsSet(views: 600)

--- a/Modules/Sources/JetpackStats/Services/Data/TopListItem+WordPressKit.swift
+++ b/Modules/Sources/JetpackStats/Services/Data/TopListItem+WordPressKit.swift
@@ -20,6 +20,7 @@ extension TopListItem.Referrer {
         self.init(
             name: referrer.title,
             domain: referrer.url?.host,
+            url: referrer.url,
             iconURL: referrer.iconURL,
             children: referrer.children.map { TopListItem.Referrer($0) },
             metrics: SiteMetricsSet(views: referrer.viewsCount)

--- a/Modules/Sources/JetpackStats/Services/Data/TopListItem.swift
+++ b/Modules/Sources/JetpackStats/Services/Data/TopListItem.swift
@@ -45,6 +45,7 @@ extension TopListItem {
     struct Referrer: Codable, TopListItemProtocol {
         let name: String
         let domain: String?
+        let url: URL?
         let iconURL: URL?
         let children: [Referrer]
         var metrics: SiteMetricsSet
@@ -55,6 +56,18 @@ extension TopListItem {
 
         var displayName: String {
             name
+        }
+
+        var spamDomain: String? {
+            domain ?? children.first?.domain
+        }
+
+        var canMarkAsSpam: Bool {
+            guard spamDomain != nil else { return false }
+            if let url {
+                return url.absoluteString.contains(name)
+            }
+            return name.contains(".")
         }
     }
 

--- a/Modules/Sources/JetpackStats/Services/Mocks/MockStatsService.swift
+++ b/Modules/Sources/JetpackStats/Services/Mocks/MockStatsService.swift
@@ -192,6 +192,9 @@ actor MockStatsService: ObservableObject, StatsServiceProtocol {
         return TopListResponse(items: Array(sortedItems.prefix(limit ?? Int.max)))
     }
 
+    func invalidateTopListData(for item: TopListItemType) {
+    }
+
     func getRealtimeTopListData(_ dataType: TopListItemType) async throws -> TopListResponse {
         // Load base items from JSON
         let baseItems = loadRealtimeBaseItems(for: dataType)
@@ -320,6 +323,18 @@ actor MockStatsService: ObservableObject, StatsServiceProtocol {
         let shouldSucceed = Double.random(in: 0...1) > 0.1 // 90% success rate
         if !shouldSucceed {
             throw URLError(.networkConnectionLost)
+        }
+
+        guard !currentValue else { return }
+        for key in dailyTopListData.keys where key.itemType == .referrers {
+            guard var data = dailyTopListData[key] else { continue }
+            for (date, items) in data {
+                data[date] = items.filter {
+                    guard let referrer = $0 as? TopListItem.Referrer else { return true }
+                    return referrer.spamDomain != referrerDomain
+                }
+            }
+            dailyTopListData[key] = data
         }
     }
 

--- a/Modules/Sources/JetpackStats/Services/StatsService.swift
+++ b/Modules/Sources/JetpackStats/Services/StatsService.swift
@@ -212,6 +212,10 @@ actor StatsService: StatsServiceProtocol {
         }
     }
 
+    func invalidateTopListData(for item: TopListItemType) {
+        topListCache = topListCache.filter { $0.key.item != item }
+    }
+
     private func _getTopListData(_ item: TopListItemType, metric: SiteMetric, interval: DateInterval, granularity: DateRangeGranularity, limit: Int?, options: TopListItemOptions) async throws -> TopListResponse {
 
         func getData<T: WordPressKit.StatsTimeIntervalData>(

--- a/Modules/Sources/JetpackStats/Services/StatsServiceProtocol.swift
+++ b/Modules/Sources/JetpackStats/Services/StatsServiceProtocol.swift
@@ -15,5 +15,6 @@ protocol StatsServiceProtocol: AnyObject, Sendable {
     func getPostDetails(for postID: Int) async throws -> StatsPostDetails
     func getPostLikes(for postID: Int, count: Int) async throws -> PostLikesData
     func getEmailOpens(for postID: Int) async throws -> StatsEmailOpensData
+    func invalidateTopListData(for item: TopListItemType) async
     func toggleSpamState(for referrerDomain: String, currentValue: Bool) async throws
 }

--- a/Modules/Sources/JetpackStats/Strings.swift
+++ b/Modules/Sources/JetpackStats/Strings.swift
@@ -243,6 +243,11 @@ enum Strings {
     enum ReferrerDetails {
         static let title = AppLocalizedString("jetpackStats.referrerDetails.title", value: "Referrer", comment: "Title for the referrer details screen")
         static let markAsSpam = AppLocalizedString("jetpackStats.referrerDetails.markAsSpam", value: "Mark as Spam", comment: "Button to mark a referrer as spam")
+        static let markAsSpamExplanation = AppLocalizedString(
+            "jetpackStats.referrerDetails.markAsSpamExplanation",
+            value: "Marking this referrer as spam removes it from your referrer stats. Your other stats are not affected.",
+            comment: "Explanation shown below the button to mark a referrer as spam"
+        )
         static let markedAsSpam = AppLocalizedString("jetpackStats.referrerDetails.markedAsSpam", value: "Marked as Spam", comment: "Label shown when a referrer is already marked as spam")
         static let referralSources = AppLocalizedString("jetpackStats.referrerDetails.referralSources", value: "Referral Sources", comment: "Section title for the list of referral sources")
         static let markAsSpamError = AppLocalizedString("jetpackStats.referrerDetails.markAsSpamError", value: "Failed to mark as spam", comment: "Error message when marking a referrer as spam fails")

--- a/Modules/Sources/JetpackStats/Views/TopList/TopListItemView.swift
+++ b/Modules/Sources/JetpackStats/Views/TopList/TopListItemView.swift
@@ -270,6 +270,7 @@ private func makePreviewItems() -> some View {
             TopListItem.Referrer(
                 name: "Google Search",
                 domain: "google.com",
+                url: nil,
                 iconURL: URL(string: "https://www.google.com/favicon.ico"),
                 children: [],
                 metrics: SiteMetricsSet(views: 50000)
@@ -281,6 +282,7 @@ private func makePreviewItems() -> some View {
             TopListItem.Referrer(
                 name: "Direct Traffic",
                 domain: nil,
+                url: nil,
                 iconURL: nil,
                 children: [],
                 metrics: SiteMetricsSet(views: 12300)

--- a/Modules/Sources/JetpackStats/Views/TopList/TopListItemView.swift
+++ b/Modules/Sources/JetpackStats/Views/TopList/TopListItemView.swift
@@ -11,6 +11,7 @@ struct TopListItemView: View {
     let maxValue: Int
     let dateRange: StatsDateRange
     var totalValue: Int?
+    var onReferrerMarkedAsSpam: () -> Void = {}
 
     @State private var isPressed = false
 
@@ -170,7 +171,11 @@ private extension TopListItemView {
                 .environment(\.router, router)
             router.navigate(to: detailsView, title: Strings.AuthorDetails.title)
         case let referrer as TopListItem.Referrer:
-            let detailsView = ReferrerStatsView(referrer: referrer, dateRange: dateRange)
+            let detailsView = ReferrerStatsView(
+                referrer: referrer,
+                dateRange: dateRange,
+                onMarkedAsSpam: onReferrerMarkedAsSpam
+            )
                 .environment(\.context, context)
                 .environment(\.router, router)
             router.navigate(to: detailsView, title: Strings.ReferrerDetails.title)

--- a/Modules/Sources/JetpackStats/Views/TopList/TopListItemsView.swift
+++ b/Modules/Sources/JetpackStats/Views/TopList/TopListItemsView.swift
@@ -5,6 +5,7 @@ struct TopListItemsView: View {
     let itemLimit: Int
     let dateRange: StatsDateRange
     var reserveSpace: Bool = false
+    var onReferrerMarkedAsSpam: () -> Void = {}
 
     @ScaledMetric(relativeTo: .callout) private var cellHeight = 52
 
@@ -34,7 +35,8 @@ struct TopListItemsView: View {
             metric: data.metric,
             maxValue: data.metrics.maxValue,
             dateRange: dateRange,
-            totalValue: data.metrics.total
+            totalValue: data.metrics.total,
+            onReferrerMarkedAsSpam: onReferrerMarkedAsSpam
         )
         .frame(height: cellHeight)
     }

--- a/Modules/Tests/JetpackStatsTests/MockStatsServiceTests.swift
+++ b/Modules/Tests/JetpackStatsTests/MockStatsServiceTests.swift
@@ -57,4 +57,44 @@ struct MockStatsServiceTests {
         // THEN - Basic validations
         #expect(!response.metrics.isEmpty, "Should return at least one data point")
     }
+
+    @Test("Marking a referrer as spam removes it from subsequent responses")
+    func markingReferrerAsSpamRemovesIt() async throws {
+        let service = MockStatsService(timeZone: .eastern)
+        await service.disableDelays()
+        let dateInterval = calendar.makeDateInterval(for: .today)
+        let response = try await service.getTopListData(
+            .referrers,
+            metric: .views,
+            interval: dateInterval,
+            granularity: dateInterval.preferredGranularity,
+            limit: nil,
+            options: TopListItemOptions()
+        )
+        let referrer = try #require(response.items.compactMap { $0 as? TopListItem.Referrer }.first)
+        let domain = try #require(referrer.spamDomain)
+
+        for _ in 0..<20 {
+            do {
+                try await service.toggleSpamState(for: domain, currentValue: false)
+                break
+            } catch {
+                continue
+            }
+        }
+
+        let refreshedResponse = try await service.getTopListData(
+            .referrers,
+            metric: .views,
+            interval: dateInterval,
+            granularity: dateInterval.preferredGranularity,
+            limit: nil,
+            options: TopListItemOptions()
+        )
+        let domains = refreshedResponse.items
+            .compactMap { $0 as? TopListItem.Referrer }
+            .compactMap(\.spamDomain)
+
+        #expect(!domains.contains(domain))
+    }
 }

--- a/Modules/Tests/JetpackStatsTests/TopListItemReferrerTests.swift
+++ b/Modules/Tests/JetpackStatsTests/TopListItemReferrerTests.swift
@@ -1,0 +1,97 @@
+import Foundation
+import Testing
+@preconcurrency import WordPressKit
+@testable import JetpackStats
+
+@Suite
+struct TopListItemReferrerTests {
+    struct TestCase: Sendable {
+        let name: String
+        let domain: String?
+        let url: URL?
+        let expectedValue: Bool
+    }
+
+    @Test(
+        "Determines whether a referrer can be marked as spam",
+        arguments: [
+            TestCase(
+                name: "example.com",
+                domain: "example.com",
+                url: URL(string: "https://example.com/path"),
+                expectedValue: true
+            ),
+            TestCase(
+                name: "WordPress.com Reader",
+                domain: "wordpress.com",
+                url: URL(string: "https://wordpress.com/read"),
+                expectedValue: false
+            ),
+            TestCase(name: "example.com", domain: "example.com", url: nil, expectedValue: true),
+            TestCase(name: "example.com", domain: nil, url: nil, expectedValue: false),
+            TestCase(name: "Example", domain: nil, url: nil, expectedValue: false)
+        ]
+    )
+    func canMarkAsSpam(testCase: TestCase) {
+        let referrer = TopListItem.Referrer(
+            name: testCase.name,
+            domain: testCase.domain,
+            url: testCase.url,
+            iconURL: nil,
+            children: [],
+            metrics: SiteMetricsSet()
+        )
+
+        #expect(referrer.canMarkAsSpam == testCase.expectedValue)
+    }
+
+    @Test("Uses a child domain when a grouped referrer has no domain")
+    func usesChildDomain() {
+        let child = makeReferrer(name: "example.com", domain: "example.com")
+        let referrer = makeReferrer(name: "example.com", children: [child])
+
+        #expect(referrer.spamDomain == "example.com")
+        #expect(referrer.canMarkAsSpam)
+    }
+
+    @Test("Decodes referrer data cached before the source URL was added")
+    func decodesReferrerWithoutURL() throws {
+        let referrer = makeReferrer(name: "example.com", domain: "example.com")
+        var object = try #require(JSONSerialization.jsonObject(with: JSONEncoder().encode(referrer)) as? [String: Any])
+        object.removeValue(forKey: "url")
+
+        let data = try JSONSerialization.data(withJSONObject: object)
+        let decoded = try JSONDecoder().decode(TopListItem.Referrer.self, from: data)
+
+        #expect(decoded.url == nil)
+    }
+
+    @Test("Preserves the source URL when mapping a WordPressKit referrer")
+    func mapsSourceURL() throws {
+        let sourceURL = try #require(URL(string: "https://example.com/path"))
+        let referrer = StatsReferrer(
+            title: "example.com",
+            viewsCount: 1,
+            url: sourceURL,
+            iconURL: nil,
+            children: []
+        )
+
+        #expect(TopListItem.Referrer(referrer).url == sourceURL)
+    }
+
+    private func makeReferrer(
+        name: String,
+        domain: String? = nil,
+        children: [TopListItem.Referrer] = []
+    ) -> TopListItem.Referrer {
+        TopListItem.Referrer(
+            name: name,
+            domain: domain,
+            url: nil,
+            iconURL: nil,
+            children: children,
+            metrics: SiteMetricsSet()
+        )
+    }
+}

--- a/Modules/Tests/JetpackStatsTests/TopListViewModelTests.swift
+++ b/Modules/Tests/JetpackStatsTests/TopListViewModelTests.swift
@@ -1,0 +1,129 @@
+import Foundation
+import Testing
+@preconcurrency import WordPressKit
+@testable import JetpackStats
+
+@Suite
+@MainActor
+struct TopListViewModelTests {
+    @Test("Refreshes top-list data after invalidating its cache")
+    func refreshesTopListData() async throws {
+        let referrer = TopListItem.Referrer(
+            name: "example.com",
+            domain: "example.com",
+            url: URL(string: "https://example.com"),
+            iconURL: nil,
+            children: [],
+            metrics: SiteMetricsSet(views: 10)
+        )
+        let service = CachingStatsService(response: TopListResponse(items: [referrer]))
+        let calendar = Calendar.mock()
+        let dateRange = StatsDateRange(
+            interval: calendar.makeDateInterval(for: .today),
+            component: .day,
+            comparison: .off,
+            calendar: calendar
+        )
+        let viewModel = TopListViewModel(
+            configuration: TopListCardConfiguration(item: .referrers, metric: .views),
+            dateRange: dateRange,
+            service: service
+        )
+
+        viewModel.onAppear()
+        try await waitUntil { viewModel.data != nil && !viewModel.isLoading }
+        #expect(viewModel.data?.items.count == 1)
+
+        await service.setResponse(TopListResponse(items: []))
+        viewModel.refresh()
+
+        try await waitUntil { viewModel.data?.items.isEmpty == true && !viewModel.isLoading }
+    }
+
+    private func waitUntil(_ condition: () -> Bool) async throws {
+        let clock = ContinuousClock()
+        let deadline = clock.now + .seconds(2)
+        while !condition() {
+            guard clock.now < deadline else {
+                throw TestError.timedOut
+            }
+            try await Task.sleep(for: .milliseconds(10))
+        }
+    }
+}
+
+private enum TestError: Error {
+    case timedOut
+}
+
+private actor CachingStatsService: StatsServiceProtocol {
+    nonisolated let supportedMetrics: [SiteMetric] = [.views]
+    nonisolated let supportedItems: [TopListItemType] = [.referrers]
+
+    private var response: TopListResponse
+    private var cachedResponse: TopListResponse?
+
+    init(response: TopListResponse) {
+        self.response = response
+    }
+
+    nonisolated func getSupportedMetrics(for item: TopListItemType) -> [SiteMetric] {
+        [.views]
+    }
+
+    func setResponse(_ response: TopListResponse) {
+        self.response = response
+    }
+
+    func invalidateTopListData(for item: TopListItemType) async {
+        guard item == .referrers else { return }
+        cachedResponse = nil
+    }
+
+    func getTopListData(
+        _ item: TopListItemType,
+        metric: SiteMetric,
+        interval: DateInterval,
+        granularity: DateRangeGranularity,
+        limit: Int?,
+        options: TopListItemOptions
+    ) async throws -> TopListResponse {
+        if let cachedResponse {
+            return cachedResponse
+        }
+        cachedResponse = response
+        return response
+    }
+
+    func getSiteStats(interval: DateInterval, granularity: DateRangeGranularity) async throws -> SiteMetricsResponse {
+        fatalError("Unused")
+    }
+
+    func getWordAdsStats(date: Date, granularity: DateRangeGranularity) async throws -> WordAdsMetricsResponse {
+        fatalError("Unused")
+    }
+
+    func getWordAdsEarnings() async throws -> WordPressKit.StatsWordAdsEarningsResponse {
+        fatalError("Unused")
+    }
+
+    func getRealtimeTopListData(_ item: TopListItemType) async throws -> TopListResponse {
+        fatalError("Unused")
+    }
+
+    func getPostDetails(for postID: Int) async throws -> StatsPostDetails {
+        fatalError("Unused")
+    }
+
+    func getPostLikes(for postID: Int, count: Int) async throws -> PostLikesData {
+        fatalError("Unused")
+    }
+
+    func getEmailOpens(for postID: Int) async throws -> StatsEmailOpensData {
+        fatalError("Unused")
+    }
+
+    func toggleSpamState(for referrerDomain: String, currentValue: Bool) async throws {
+        fatalError("Unused")
+    }
+}


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/CMM-2315

This PR ports the legacy Stats' "can mark as spam" check: https://github.com/wordpress-mobile/WordPress-iOS/blob/f19e4116621ecc1922be28451febb0a5e6f9f1e6/WordPress/Classes/ViewRelated/Stats/Shared%20Views/StatsTotalRow.swift#L87-L94

With this change, the Search Engine referrers no long show the "Mark as Spam" button. The other sites (which may be spam) shows the button.

https://github.com/user-attachments/assets/1f7ded83-94b9-43bf-a862-c08567642741

Also, added a footer text to explain what "Mark as Spam" does.
<img width="400" src="https://github.com/user-attachments/assets/f3c5aa44-d252-4656-981d-51a94218ce79" />

