### PR TITLE
Wait for TestFlight before Claude build analysis

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -183,6 +183,9 @@ steps:
       - linters_group
       - prototype_builds_group
       - unit_tests_group
+      # The TestFlight uploads outlast every other group, so without this the analysis
+      # runs before they finish and reports a failing build as clean.
+      - testflight_builds_group
     allow_dependency_failure: true
     agents:
       queue: upload


### PR DESCRIPTION
## Description

The `:claude: 🕵️ Check for Build Failures` step lists three groups in `depends_on` and `testflight_builds_group` is not one of them. It therefore fires as soon as the linters, prototype builds and unit tests settle, and `upload-claude-analysis.sh` snapshots the build's job states at that instant — where a job still running counts as not-failed. The TestFlight uploads are the longest jobs in the pipeline, so on trunk they are almost always still running, and they are the only jobs that can detect a release-pipeline outage.

That is not hypothetical. Trunk's TestFlight uploads had been rejected by App Store Connect with error 90186 since the `27.1` train closed, and the analyser reported it away twice on 2026-08-17:

| Build | Uploads failed | Check ran | Result |
|---|---|---|---|
| [#33780](https://buildkite.com/automattic/wordpress-ios/builds/33780) | 04:32:24Z | 04:31:31Z | saw zero failures, skipped the analysis entirely — no annotation |
| [#33786](https://buildkite.com/automattic/wordpress-ios/builds/33786) | 12:48:50Z | annotation published 12:48:45Z | *"The build has one real failure: the Unit Tests job. Everything else either passed or is in expected states."* |

[#33753](https://buildkite.com/automattic/wordpress-ios/builds/33753) diagnosed the outage correctly on 08-13 — naming 90186 and recommending a pre-flight version check — only because an upload happened to fail 28 seconds *before* the check fired. That 28 seconds is the whole difference between the one correct report and twelve days of silence.

Two things a reviewer should know:

- **This closes the instance, not the class.** The analysis still asserts a global all-clear over whatever snapshot it is handed. Making it count non-terminal jobs and say *"N jobs still running, not covered"* is the general fix, and is deliberately not in this PR.
- **The delay is trunk-only.** `testflight_builds_group` is gated on `build.branch == 'trunk'`, so PR builds skip it and the new dependency resolves immediately. On trunk, analysis now waits for the uploads — which is the point.

## Testing instructions

Nothing to test in the app; this is a pipeline-graph change and only Buildkite can exercise it.

The behaviour it relies on is already demonstrated in the builds above: `prototype_builds_group` is PR-only, so on trunk builds [#33780](https://buildkite.com/automattic/wordpress-ios/builds/33780) and [#33786](https://buildkite.com/automattic/wordpress-ios/builds/33786) its jobs are `broken` and the check step ran anyway, because of the `allow_dependency_failure: true` already on the step. `testflight_builds_group` resolves the same way in reverse on PR builds.

To confirm on this PR: the check step should still run and reach its "All steps passed, skipping Claude analysis" branch despite both TestFlight and prototype dependencies being skipped. The real confirmation is the next red trunk build, where the analysis should now start after the uploads finish rather than before.
