### PR TITLE
Never use an http REST API endpoint for https self-hosted sites

### DIFF
--- a/Modules/Sources/WordPressData/Swift/Blog+SelfHostedRestApi.swift
+++ b/Modules/Sources/WordPressData/Swift/Blog+SelfHostedRestApi.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+extension Blog {
+
+    /// The WordPress REST API root URL to use for self-hosted network requests.
+    ///
+    /// Prefers `restApiRootURL` — the root observed during REST API discovery, which is
+    /// served over https for an https site — over a URL derived from the raw `xmlrpc`
+    /// string. An older app version could silently downgrade and persist an http `xmlrpc`
+    /// endpoint for an https site (GHSA-qxpr-7v78-mh5g), and `url(withPath:)` copies that
+    /// scheme verbatim, so a REST client built from it would carry the application password
+    /// (sent as a Basic auth header) over plaintext http.
+    ///
+    /// `restApiRootURL` is written together with the application token (see
+    /// `ApplicationPasswordRepository.assign` and `Blog.createRestApiBlog`), so it is always
+    /// present when the token is. That makes this a discovery-backed choice rather than a
+    /// scheme-rewriting guess: an intentionally-http site is left on http (its discovered
+    /// root is http), and an https site uses the https root that discovery observed.
+    ///
+    /// Falls back to the `xmlrpc`-derived `wp-json/` URL only when no discovered root was
+    /// persisted (legacy XML-RPC sign-ins), leaving behavior unchanged for those sites.
+    public var selfHostedRestApiRootURL: URL? {
+        if let restApiRootURL, let url = URL(string: restApiRootURL) {
+            return url
+        }
+        return url(withPath: "wp-json/").flatMap { URL(string: $0) }
+    }
+}

--- a/Modules/Sources/WordPressData/Swift/WordPressOrgRestApi+WordPress.swift
+++ b/Modules/Sources/WordPressData/Swift/WordPressOrgRestApi+WordPress.swift
@@ -8,11 +8,10 @@ private func apiBase(blog: Blog) -> URL? {
         return nil
     }
 
-    guard let urlString = blog.url(withPath: "wp-json/") else {
-        return nil
-    }
-
-    return URL(string: urlString)
+    // Prefer the REST root observed during discovery over one derived from the raw
+    // `xmlrpc` string, which an older app version could have persisted as http for an
+    // https site (GHSA-qxpr-7v78-mh5g). See `Blog.selfHostedRestApiRootURL`.
+    return blog.selfHostedRestApiRootURL
 }
 
 extension WordPressOrgRestApi {

--- a/Modules/Tests/WordPressDataTests/BlogSelfHostedRestApiTests.swift
+++ b/Modules/Tests/WordPressDataTests/BlogSelfHostedRestApiTests.swift
@@ -1,0 +1,44 @@
+import CoreData
+import Testing
+@testable import WordPressData
+
+@MainActor
+struct BlogSelfHostedRestApiTests {
+    private let contextManager = ContextManager.forTesting()
+
+    private func makeBlog(url: String?, xmlrpc: String?, restApiRootURL: String?) -> Blog {
+        let blog = BlogBuilder(contextManager.mainContext, dotComID: nil).build()
+        blog.account = nil
+        blog.url = url
+        blog.xmlrpc = xmlrpc
+        blog.restApiRootURL = restApiRootURL
+        return blog
+    }
+
+    @Test func prefersDiscoveredHTTPSRootOverDowngradedXMLRPCEndpoint() {
+        // An older app version could persist an http xmlrpc endpoint for an https site; the
+        // https REST root observed during discovery must win so the application password is
+        // never sent over plaintext http.
+        let blog = makeBlog(
+            url: "https://example.com",
+            xmlrpc: "http://example.com/xmlrpc.php",
+            restApiRootURL: "https://example.com/wp-json/"
+        )
+        #expect(blog.selfHostedRestApiRootURL?.absoluteString == "https://example.com/wp-json/")
+    }
+
+    @Test func fallsBackToXMLRPCDerivedRootWhenNoDiscoveredRoot() {
+        // Legacy XML-RPC sign-ins never persisted a REST root, so behavior is unchanged.
+        let blog = makeBlog(
+            url: "https://example.com",
+            xmlrpc: "https://example.com/xmlrpc.php",
+            restApiRootURL: nil
+        )
+        #expect(blog.selfHostedRestApiRootURL?.absoluteString == "https://example.com/wp-json/")
+    }
+
+    @Test func returnsNilWhenNeitherRootIsAvailable() {
+        let blog = makeBlog(url: "https://example.com", xmlrpc: nil, restApiRootURL: nil)
+        #expect(blog.selfHostedRestApiRootURL == nil)
+    }
+}

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 
 27.2
 -----
+* [*] Fix an issue where an https self-hosted site's application password could be sent over insecure http when using its REST API [#25914]
 * [*] Custom Post Types: Make custom post types with REST API and editor support available in My Site [#25849]
 * [*] Stop the media picker from removing gallery images when you cancel it in the experimental editor [#25866]
 * [*] Stats: Fix the screen getting stuck on a loading indicator for self-hosted sites that are not connected to Jetpack [#25858]


### PR DESCRIPTION
Follow-up to #25869. That PR closed the XML-RPC credential-over-http downgrade for https self-hosted sites; the same downgraded `xmlrpc` value also feeds the REST API base, which it left unaddressed.

> [!Note]
> Like #25869, this only bites a site whose `xmlrpc` an older app version persisted as `http://` for an `https://` site (GHSA-qxpr-7v78-mh5g) — an uncommon state, but the credential exposure is the same class.

## Summary

- `WordPressOrgRestApi(blog:)` built its base URL from `Blog.url(withPath: "wp-json/")`, which rewrites the raw `xmlrpc` string and copies its scheme verbatim.
- For a downgraded site that base was `http://…/wp-json/`, and the application password rides every request as a preemptive `Authorization: Basic …` header — so it could be sent in plaintext. ATS does not block it (`NSAllowsArbitraryLoads` is set in both apps' `Info.plist`).
- The fix prefers `restApiRootURL` — the REST root observed during discovery — over the xmlrpc-derived URL.

## Root Cause

`Blog.url(withPath:)` derives sibling URLs by regex-replacing `xmlrpc.php` in the stored `xmlrpc` string, so it inherits whatever scheme was persisted. `apiBase(blog:)` used it directly and ignored `restApiRootURL`, even though `restApiRootURL` holds the https root that discovery actually observed (and `EditorConfiguration` already prefers it).

## Fix

- Add `Blog.selfHostedRestApiRootURL`: prefer `restApiRootURL`, fall back to the `xmlrpc`-derived `wp-json/` URL only when no discovered root was persisted.
- Route `apiBase(blog:)` through it.

`restApiRootURL` is written together with the application token (`ApplicationPasswordRepository.assign`, `Blog.createRestApiBlog`), so it is always present when the token is. That makes this a discovery-backed choice, not a scheme-rewriting guess: an intentionally-http site stays http (its discovered root is http); an https site uses the https root discovery saw.

## Scope — what this does not cover

- **Legacy account-password sites** (username/password, no application token) never ran REST discovery, so `restApiRootURL` is nil and the fallback still yields the `xmlrpc`-derived URL. Their password rides the cookie-nonce login POST to `loginURL` (which already prefers the https `login_url` option); the residual is the data requests' nonce/cookies. Fully closing that needs transport-layer enforcement — see below.
- **Server-issued https→http redirects** at request time are out of scope here — the same deferral #25869 documents. The durable fix for both this and the XML-RPC path is refusing to put credentials on http in the client itself.
- **Non-pretty-permalink sites**: a discovered `restApiRootURL` can be `…/?rest_route=/` rather than `…/wp-json/`, which would trip `assert(apiURL.lastPathComponent == "wp-json")` in `WordPressOrgRestApi.init(selfHostedSiteWPJSONURL:)` (debug only). Pretty permalinks are near-universal so the common case is unaffected, but the assert may want relaxing.

## Test Plan

- [x] Unit tests for `selfHostedRestApiRootURL` (added; run in CI): prefers the https discovered root over a downgraded http xmlrpc endpoint; falls back to the xmlrpc-derived root when none was discovered; nil when neither is available.
- [ ] Manual: add an https self-hosted site with an application password, confirm REST traffic (plugins, block editor settings) goes over https.
- [ ] Regression: a normal https site and a genuinely-http site both continue to work.

## Related

- #25869 — the XML-RPC half of this fix
- `GHSA-qxpr-7v78-mh5g`
