### PR TITLE
Show the selected period on snapshot stats detail screens

### DIFF
--- a/Modules/Sources/JetpackStats/Screens/ArchiveStatsView.swift
+++ b/Modules/Sources/JetpackStats/Screens/ArchiveStatsView.swift
@@ -45,7 +45,7 @@ struct ArchiveStatsView: View {
                 Spacer()
 
                 if let totalViews = archiveSection.metrics.views {
-                    StandaloneMetricView(metric: .views, value: totalViews)
+                    StandaloneMetricView(metric: .views, value: totalViews, dateInterval: dateRange.dateInterval)
                 }
             }
         }

--- a/Modules/Sources/JetpackStats/Screens/ArchiveStatsView.swift
+++ b/Modules/Sources/JetpackStats/Screens/ArchiveStatsView.swift
@@ -75,7 +75,7 @@ struct ArchiveStatsView: View {
     }
 
     private var itemsChartData: TopListData {
-        return TopListData(
+        TopListData(
             item: .archive,
             metric: .views,
             items: archiveSection.items

--- a/Modules/Sources/JetpackStats/Screens/ExternalLinkStatsView.swift
+++ b/Modules/Sources/JetpackStats/Screens/ExternalLinkStatsView.swift
@@ -66,8 +66,9 @@ struct ExternalLinkStatsView: View {
     @ViewBuilder
     var linkIcon: some View {
         if let url = URL(string: externalLink.url),
-           let host = url.host,
-           let iconURL = URL(string: "https://www.google.com/s2/favicons?domain=\(host)&sz=128") {
+            let host = url.host,
+            let iconURL = URL(string: "https://www.google.com/s2/favicons?domain=\(host)&sz=128")
+        {
             CachedAsyncImage(url: iconURL) { image in
                 image
                     .resizable()
@@ -131,7 +132,7 @@ struct ExternalLinkStatsView: View {
     }
 
     private var childrenChartData: TopListData {
-        return TopListData(
+        TopListData(
             item: .externalLinks,
             metric: .views,
             items: externalLink.children

--- a/Modules/Sources/JetpackStats/Screens/ExternalLinkStatsView.swift
+++ b/Modules/Sources/JetpackStats/Screens/ExternalLinkStatsView.swift
@@ -101,7 +101,7 @@ struct ExternalLinkStatsView: View {
     @ViewBuilder
     var viewsCount: some View {
         if let views = externalLink.metrics.views {
-            StandaloneMetricView(metric: .views, value: views)
+            StandaloneMetricView(metric: .views, value: views, dateInterval: dateRange.dateInterval)
         }
     }
 

--- a/Modules/Sources/JetpackStats/Screens/ReferrerStatsView.swift
+++ b/Modules/Sources/JetpackStats/Screens/ReferrerStatsView.swift
@@ -133,7 +133,7 @@ struct ReferrerStatsView: View {
     @ViewBuilder
     var viewsCount: some View {
         if let views = referrer.metrics.views {
-            StandaloneMetricView(metric: .views, value: views)
+            StandaloneMetricView(metric: .views, value: views, dateInterval: dateRange.dateInterval)
         }
     }
 
@@ -216,7 +216,7 @@ struct ReferrerStatsView: View {
     NavigationView {
         ReferrerStatsView(
             referrer: .mock,
-            dateRange: Calendar.demo.makeDateRange(for: .thisYear)
+            dateRange: Calendar.demo.makeDateRange(for: .last7Days)
         )
     }
     .navigationViewStyle(.stack)

--- a/Modules/Sources/JetpackStats/Views/StandaloneMetricView.swift
+++ b/Modules/Sources/JetpackStats/Views/StandaloneMetricView.swift
@@ -4,6 +4,9 @@ import DesignSystem
 struct StandaloneMetricView: View {
     let metric: SiteMetric
     let value: Int
+    var dateInterval: DateInterval?
+
+    @Environment(\.context) private var context
 
     var body: some View {
         VStack(alignment: .trailing, spacing: 0) {
@@ -15,11 +18,23 @@ struct StandaloneMetricView: View {
                 .font(Constants.Typography.smallDisplayFont)
                 .foregroundColor(.primary)
                 .contentTransition(.numericText())
+            if let dateInterval {
+                Text(context.formatters.dateRange.string(from: dateInterval))
+                    .font(.footnote)
+                    .foregroundColor(.secondary)
+            }
         }
     }
 }
 
 #Preview {
-    StandaloneMetricView(metric: .views, value: 12345)
-        .padding()
+    VStack(spacing: 32) {
+        StandaloneMetricView(metric: .views, value: 12345)
+        StandaloneMetricView(
+            metric: .views,
+            value: 12345,
+            dateInterval: Calendar.demo.makeDateRange(for: .last7Days).dateInterval
+        )
+    }
+    .padding()
 }


### PR DESCRIPTION
## Description

Fixes https://linear.app/a8c/issue/CMM-2319.

The issue description is not accurate, because I misunderstood the chart. The date range control is visible at screen level (the first two screenshots in the Linear issue) and chart level (the third screenshot). What is not clear is some stats screens do not display the range.

| Before | After |
| - | - |
| <img width="590" height="1278" alt="IMG_2821" src="https://github.com/user-attachments/assets/8eaa16cb-ebc4-4974-bbce-147941edbd0a" /> | <img width="590" height="1278" alt="IMG_2824" src="https://github.com/user-attachments/assets/56dcc11d-9b1f-49dd-bfb5-d32a1532cb08" /> |
| <img width="590" height="1278" alt="IMG_2822" src="https://github.com/user-attachments/assets/57942ea6-d2e1-4b82-8af1-1efcc776874e" /> | <img width="590" height="1278" alt="IMG_2825" src="https://github.com/user-attachments/assets/13b16a69-392e-43a7-8631-ef04f0bc3ea8" /> |
| <img width="590" height="1278" alt="IMG_2823" src="https://github.com/user-attachments/assets/30a790af-e6da-4d00-9bf5-07639074d700" /> | <img width="590" height="1278" alt="IMG_2826" src="https://github.com/user-attachments/assets/cf298f0e-d847-453f-821b-85ff36042e8c" /> |
