### PR TITLE
removed the api and reference of google plus

### DIFF
--- a/Modules/Sources/WordPressData/Swift/PublicizeService.swift
+++ b/Modules/Sources/WordPressData/Swift/PublicizeService.swift
@@ -4,7 +4,6 @@ import WordPressShared
 
 @objc(PublicizeService)
 open class PublicizeService: NSManagedObject {
-    @objc public static let googlePlusServiceID = "google_plus"
     @objc public static let facebookServiceID = "facebook"
     @objc public static let defaultStatus = "ok"
     @objc public static let unsupportedStatus = "unsupported"

--- a/Modules/Sources/WordPressKit/StatsPublicizeInsight.swift
+++ b/Modules/Sources/WordPressKit/StatsPublicizeInsight.swift
@@ -53,9 +53,6 @@ private extension StatsPublicizeService {
         case "tumblr":
             niceName = "Tumblr"
             icon = URL(string: "https://secure.gravatar.com/blavatar/84314f01e87cb656ba5f382d22d85134?s=60")
-        case "google_plus":
-            niceName = "Google+"
-            icon = URL(string: "https://secure.gravatar.com/blavatar/4a4788c1dfc396b1f86355b274cc26b3?s=60")
         case "linkedin":
             niceName = "LinkedIn"
             icon = URL(string: "https://secure.gravatar.com/blavatar/f54db463750940e0e7f7630fe327845e?s=60")

--- a/Modules/Sources/WordPressSharedObjC/include/WPAnalytics.h
+++ b/Modules/Sources/WordPressSharedObjC/include/WPAnalytics.h
@@ -421,7 +421,6 @@ typedef NS_ENUM(NSUInteger, WPAnalyticsStat) {
     WPAnalyticsStatReaderTagPreviewed,
     WPAnalyticsStatReaderTagUnfollowed,
     WPAnalyticsStatSelectedInstallJetpack,
-    WPAnalyticsStatSentItemToGooglePlus,
     WPAnalyticsStatSentItemToInstapaper,
     WPAnalyticsStatSentItemToPocket,
     WPAnalyticsStatSentItemToWordPress,

--- a/WordPress/Classes/Utility/Analytics/TracksMappedEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/TracksMappedEvent.swift
@@ -876,8 +876,6 @@ extension TracksMappedEvent {
             name = "reader_reader_tag_unfollowed"
         case .selectedInstallJetpack:
             name = "install_jetpack_selected"
-        case .sentItemToGooglePlus:
-            name = "sent_item_to_google_plus"
         case .sentItemToInstapaper:
             name = "sent_item_to_instapaper"
         case .sentItemToPocket:

--- a/WordPress/Classes/Utility/Sharing/WPActivityDefaults.m
+++ b/WordPress/Classes/Utility/Sharing/WPActivityDefaults.m
@@ -28,8 +28,6 @@
         stat = WPAnalyticsStatSentItemToInstapaper;
     } else if ([activityType isEqualToString:@"com.ideashower.ReadItLaterPro.AddToPocketExtension"]) {
         stat = WPAnalyticsStatSentItemToPocket;
-    } else if ([activityType isEqualToString:@"com.google.GooglePlus.ShareExtension"]) {
-        stat = WPAnalyticsStatSentItemToGooglePlus;
     } else if ([activityType isEqualToString:UIActivityTypeCopyToPasteboard]) {
         return;
     } else {


### PR DESCRIPTION
## Description

Closes https://github.com/wordpress-mobile/WordPress-iOS/issues/20142

As Google+ shut down in 2019, its reference of API, case and analytic utility still exists in the code, has been removed in this PR.


## Testing instructions

1. Confirm the project builds and the full unit test suite passes (`xcodebuild -workspace WordPress.xcworkspace -scheme WordPress -testPlan WordPressUnitTests test`)
2. Smoke-test Publicize/Sharing still works: connect a site to Facebook/Twitter/LinkedIn/Tumblr under My Site → Sharing, and confirm the Stats "Publicize" insights card still renders icons/names correctly for those services
3. Share a post via the system share sheet (e.g. to Pocket/Instapaper) and confirm analytics still track correctly for the remaining services — no crash, no missing `WPAnalyticsStat` case warnings
