### PR TITLE
Reader: Harden the Skip button and add interest-selection debug controls

### DIFF
--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -73,6 +73,7 @@ import WordPressShared
     // Reader
     case selectInterestsShown
     case selectInterestsPicked
+    case selectInterestsSkipped
     case readerDiscoverShown
     case readerFollowingShown
     case readerSavedListShown
@@ -821,6 +822,8 @@ import WordPressShared
             return "select_interests_shown"
         case .selectInterestsPicked:
             return "select_interests_picked"
+        case .selectInterestsSkipped:
+            return "select_interests_skipped"
         case .readerDiscoverShown:
             return "reader_discover_shown"
         case .readerFollowingShown:

--- a/WordPress/Classes/ViewRelated/Me/App Settings/DebugMenuViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/DebugMenuViewController.swift
@@ -90,7 +90,10 @@ struct DebugMenuView: View {
         }
         Button(Strings.resetReaderInterestsPrompt) {
             UserDefaults.standard.readerDidSelectInterestsKey = false
-            showSuccessNotice()
+            // A bare emoji notice is illegible on the notice's inverted
+            // background in dark mode; a text title renders legibly in both.
+            let notice = Notice(title: Strings.readerInterestsPromptResetNotice, feedbackType: .success)
+            ActionDispatcher.dispatch(NoticeAction.post(notice))
         }
     }
 
@@ -330,6 +333,7 @@ private enum Strings {
     static let readerURLHint = NSLocalizedString("debugMenu.readerHit", value: "Add a custom CSS URL here to be loaded in Reader. If you're running Calypso locally this can be something like: http://192.168.15.23:3000/calypso/reader-mobile.css", comment: "Hint for the reader CSS URL field")
     static let showReaderInterests = NSLocalizedString("debugMenu.showReaderInterests", value: "Show Reader Interests Screen", comment: "Debug menu action that presents the Reader select interests screen")
     static let resetReaderInterestsPrompt = NSLocalizedString("debugMenu.resetReaderInterestsPrompt", value: "Reset Reader Interests Prompt", comment: "Debug menu action that clears the flag so the Reader select interests prompt can appear again")
+    static let readerInterestsPromptResetNotice = NSLocalizedString("debugMenu.readerInterestsPromptReset", value: "Reader interests prompt reset", comment: "Debug menu confirmation shown after clearing the flag that suppresses the Reader select interests prompt")
     static let remoteConfigTitle = NSLocalizedString("debugMenu.remoteConfig.title", value: "Remote Config", comment: "Remote Config debug menu title")
     static let analyics = NSLocalizedString("debugMenu.analytics", value: "Analytics", comment: "Debug menu item title")
     static let featureFlags = NSLocalizedString("debugMenu.featureFlags", value: "Feature Flags", comment: "Feature flags menu item")

--- a/WordPress/Classes/ViewRelated/Me/App Settings/DebugMenuViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/DebugMenuViewController.swift
@@ -85,6 +85,13 @@ struct DebugMenuView: View {
         NavigationLink(Strings.readerCssTitle) {
             readerSettings
         }
+        Button(Strings.showReaderInterests) {
+            presentReaderInterests()
+        }
+        Button(Strings.resetReaderInterestsPrompt) {
+            UserDefaults.standard.readerDidSelectInterestsKey = false
+            showSuccessNotice()
+        }
     }
 
     @ViewBuilder private var tipKit: some View {
@@ -193,6 +200,17 @@ struct DebugMenuView: View {
 
         let webViewController = WebViewControllerFactory.controller(url: url, source: "debug_menu")
         navigation.push(webViewController)
+    }
+
+    /// Presents the Reader "Discover" select-interests screen directly, bypassing
+    /// the `readerDidSelectInterestsKey` flag *and* the `isFollowingInterests`
+    /// check that normally gate it, so it can be inspected on any account.
+    private func presentReaderInterests() {
+        let interestsViewController = ReaderSelectInterestsViewController(configuration: .discover)
+        interestsViewController.didSaveInterests = { [weak interestsViewController] _ in
+            interestsViewController?.presentingViewController?.dismiss(animated: true)
+        }
+        navigation.parentViewController?.present(interestsViewController, animated: true)
     }
 
     private var readerSettings: some View {
@@ -310,6 +328,8 @@ private enum Strings {
     static let readerCssTitle = NSLocalizedString("debugMenu.readerCellTitle", value: "Reader CSS URL", comment: "Title of the screen that allows the user to change the Reader CSS URL for debug builds")
     static let readerURLPlaceholder = NSLocalizedString("debugMenu.readerDefaultURL", value: "Default URL", comment: "Placeholder for the reader CSS URL")
     static let readerURLHint = NSLocalizedString("debugMenu.readerHit", value: "Add a custom CSS URL here to be loaded in Reader. If you're running Calypso locally this can be something like: http://192.168.15.23:3000/calypso/reader-mobile.css", comment: "Hint for the reader CSS URL field")
+    static let showReaderInterests = NSLocalizedString("debugMenu.showReaderInterests", value: "Show Reader Interests Screen", comment: "Debug menu action that presents the Reader select interests screen")
+    static let resetReaderInterestsPrompt = NSLocalizedString("debugMenu.resetReaderInterestsPrompt", value: "Reset Reader Interests Prompt", comment: "Debug menu action that clears the flag so the Reader select interests prompt can appear again")
     static let remoteConfigTitle = NSLocalizedString("debugMenu.remoteConfig.title", value: "Remote Config", comment: "Remote Config debug menu title")
     static let analyics = NSLocalizedString("debugMenu.analytics", value: "Analytics", comment: "Debug menu item title")
     static let featureFlags = NSLocalizedString("debugMenu.featureFlags", value: "Feature Flags", comment: "Feature flags menu item")

--- a/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderSelectInterestsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderSelectInterestsViewController.swift
@@ -197,7 +197,7 @@ class ReaderSelectInterestsViewController: UIViewController {
         let button = UIButton(type: .system)
         button.setTitle(Strings.skipButtonTitle, for: .normal)
         button.translatesAutoresizingMaskIntoConstraints = false
-        button.addTarget(self, action: #selector(skipButtonTapped), for: .touchUpInside)
+        button.addTarget(self, action: #selector(skipButtonTapped(_:)), for: .touchUpInside)
         ReaderInterestsStyleGuide.applySkipButtonStyle(button: button)
 
         if let index = contentContainerView.arrangedSubviews.firstIndex(of: buttonContainerView) {
@@ -207,8 +207,19 @@ class ReaderSelectInterestsViewController: UIViewController {
         }
     }
 
-    @objc private func skipButtonTapped() {
+    @objc private func skipButtonTapped(_ sender: UIButton) {
+        // Disable on first tap so a fast double-tap can't complete the flow
+        // (re-triggering dismiss / stream refresh) twice, matching the primary
+        // button, which disables itself before dismissing.
+        sender.isEnabled = false
+
+        WPAnalytics.trackReader(.selectInterestsSkipped)
+
         didSaveInterests?([])
+        // Keep skip symmetric with the save-success path so a flow that both
+        // shows the Skip button and sets `readerDiscoverFlowDelegate` still
+        // completes. The only current Skip flow (Discover) leaves this nil.
+        readerDiscoverFlowDelegate?.didCompleteReaderDiscoverFlow()
     }
 
     private func applyStyles() {


### PR DESCRIPTION
Follow-up to the Skip button (#25921, now merged): review fixes to the new Skip button, plus internal tooling to exercise the interest-selection screen.

## What changed

### Skip button (user-facing)

- **Track a `select_interests_skipped` event.** Tapping Skip completes the flow and permanently sets `readerDidSelectInterestsKey`, but emitted nothing — so the funnel couldn't tell a skip from an abandonment (`select_interests_shown` with no terminal event). Adds the event alongside the existing `select_interests_shown` / `select_interests_picked`.
- **Debounce the Skip button.** The primary save path disables its button and fades the content before dismissing; Skip did neither, so a fast double-tap during the ~0.35s dismiss animation could re-enter `ReaderDiscoverViewController.didSaveInterests()` — a second `dismiss` and another forced stream refresh. `sender.isEnabled = false` on first tap prevents the re-entry.
- **Complete the flow on Skip.** The save-success path calls `readerDiscoverFlowDelegate?.didCompleteReaderDiscoverFlow()`; Skip didn't. This is **inert today** — the only flow that shows Skip (`.discover`) never sets the delegate, and the only flow that sets the delegate (Stats' "Grow your audience" nudge) uses a config with `showsSkipButton == false`. But those two config flags are independent: flip `showsSkipButton` on the Stats config and Skip would silently fail to mark the nudge complete, so the card would reappear on every visit. Calling the delegate on Skip closes that with **no** change to current behavior.

### Debug controls (internal builds only)

The select-interests screen is a one-time onboarding prompt, hard to see again during development. Adds two actions under **Developer → Settings**:

- **Show Reader Interests Screen** — presents the `.discover` screen (with the Skip button) directly, bypassing both the `readerDidSelectInterestsKey` flag **and** the `isFollowingInterests` check that gate it, so it works on any account.
- **Reset Reader Interests Prompt** — clears `readerDidSelectInterestsKey` so the real auto-prompt fires again on the next Reader → Discover visit (still subject to `isFollowingInterests` — an account following no tags).

The reset action posts a text confirmation notice. It first reused the debug menu's shared `showSuccessNotice()`, which posts a bare "✅"; app notices render on an inverted background (light in dark mode), so an emoji-only toast reads as a blank light box in dark mode. A text title renders legibly in both appearances.

## Not in this PR — Skip is unavailable in the offline / empty state

When the interests request fails or returns empty, the Discover flow shows only the "Try Again" NoResults overlay: Skip — like the primary button — lives inside `contentContainerView`, which fades to `alpha 0` during loading and is covered by the overlay, and the sheet is presented without a nav bar and with `isModalInPresentation = true`, so there is no way out until the network recovers. This **predates the Skip button** (the primary button is equally unavailable there); fixing it means extending the deprecated `NoResultsViewController` or restructuring the empty/error presentation — both larger than a review follow-up and risky for the Stats flow that shares this screen.

## Test plan

- [ ] Reader → Discover as an account that hasn't picked interests: tap **Skip** → the sheet dismisses, the stream refreshes, and the prompt doesn't return.
- [ ] A `select_interests_skipped` event fires on Skip (Tracks debug console); `select_interests_picked` still fires on the Done path.
- [ ] Double-tap **Skip** rapidly → one dismiss, no second stream refresh.
- [ ] VoiceOver reads the Skip button as "Skip, button".
- [ ] Developer → Settings → **Show Reader Interests Screen** presents the screen on an account that already follows tags.
- [x] Developer → Settings → **Reset Reader Interests Prompt** shows a legible "Reader interests prompt reset" toast in dark mode (verified on an iPhone 15 Pro, iOS 27).

## Related

- Follows #25921 (merged)
