### PR TITLE
Remove obsolete `ios_build_preflight`

### DIFF
--- a/.buildkite/commands/release-build-wordpress.sh
+++ b/.buildkite/commands/release-build-wordpress.sh
@@ -8,6 +8,5 @@
 echo "--- :hammer_and_wrench: Building"
 bundle exec fastlane build_and_upload_app_store_connect \
   skip_confirm:true \
-  skip_prechecks:true \
   create_release:true \
   beta_release:${1:-true} # use first call param, default to true for safety

--- a/fastlane/lanes/build.rb
+++ b/fastlane/lanes/build.rb
@@ -144,12 +144,11 @@ platform :ios do
   # Builds the WordPress app and uploads it to TestFlight, for beta-testing or final release
   #
   # @param [Boolean] skip_confirm (default: false) If true, avoids any interactive prompt
-  # @param [Boolean] skip_prechecks (default: false) If true, don't run the prechecks
   # @param [Boolean] create_release If true, creates a GitHub Release draft after the upload, with zipped xcarchive as artefact
   # @param [Boolean] beta_release If true, the GitHub release will be marked as being a pre-release
   #
-  lane :build_and_upload_app_store_connect do |skip_confirm: false, skip_prechecks: false, create_release: false, beta_release: false|
-    ensure_git_status_clean unless skip_prechecks || is_ci
+  lane :build_and_upload_app_store_connect do |skip_confirm: false, create_release: false, beta_release: false|
+    ensure_git_status_clean unless is_ci
 
     UI.important("Building version #{release_version_current} (#{build_code_current}) and uploading to TestFlight")
     UI.user_error!('Aborted by user request') unless skip_confirm || UI.confirm('Do you want to continue?')

--- a/fastlane/lanes/build.rb
+++ b/fastlane/lanes/build.rb
@@ -149,9 +149,7 @@ platform :ios do
   # @param [Boolean] beta_release If true, the GitHub release will be marked as being a pre-release
   #
   lane :build_and_upload_app_store_connect do |skip_confirm: false, skip_prechecks: false, create_release: false, beta_release: false|
-    unless skip_prechecks
-      ensure_git_status_clean unless is_ci
-    end
+    ensure_git_status_clean unless skip_prechecks || is_ci
 
     UI.important("Building version #{release_version_current} (#{build_code_current}) and uploading to TestFlight")
     UI.user_error!('Aborted by user request') unless skip_confirm || UI.confirm('Do you want to continue?')

--- a/fastlane/lanes/build.rb
+++ b/fastlane/lanes/build.rb
@@ -144,14 +144,13 @@ platform :ios do
   # Builds the WordPress app and uploads it to TestFlight, for beta-testing or final release
   #
   # @param [Boolean] skip_confirm (default: false) If true, avoids any interactive prompt
-  # @param [Boolean] skip_prechecks (default: false) If true, don't run the prechecks and ios_build_preflight
+  # @param [Boolean] skip_prechecks (default: false) If true, don't run the prechecks
   # @param [Boolean] create_release If true, creates a GitHub Release draft after the upload, with zipped xcarchive as artefact
   # @param [Boolean] beta_release If true, the GitHub release will be marked as being a pre-release
   #
   lane :build_and_upload_app_store_connect do |skip_confirm: false, skip_prechecks: false, create_release: false, beta_release: false|
     unless skip_prechecks
       ensure_git_status_clean unless is_ci
-      ios_build_preflight
     end
 
     UI.important("Building version #{release_version_current} (#{build_code_current}) and uploading to TestFlight")


### PR DESCRIPTION
The action runs check that are mostly unnecessary:

- Decrypt secrets, which should already be decrypted
- Ensure ImageMagick and GhostScript are available, but they are not
  required by builds
- Check gems are up to date, unrelated to app builds

It also

- Runs CocoaPods, which we no longer use
- Deleted the DerivedData folder, but build actions have "clean" options
  for that

See https://github.com/wordpress-mobile/release-toolkit/blob/9322fff453fb4622d4d1add8040dc8d13cee2a1d/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_build_preflight.rb#L6-L39

Closes https://linear.app/a8c/issue/AINFRA-2959

## Validation

Throwaway [#25935](https://github.com/wordpress-mobile/WordPress-iOS/pull/25935) / [Buildkite #33935](https://buildkite.com/automattic/wordpress-ios/builds/33935) ran `build_and_upload_app_store_connect` through gym after this change, then stopped before TestFlight:

> Archive Succeeded
> Successfully exported and signed the ipa file
> VALIDATION: archive succeeded (178219213 bytes at …/Artifacts/WordPress.ipa); stopping before ASC upload

`ios_build_preflight` was not required. App Store Connect acceptance was not tested.