### PR TITLE
[DO NOT MERGE] Validate App Store archive for #25934

### DIFF
--- a/.buildkite/commands/validate-app-store-archive.sh
+++ b/.buildkite/commands/validate-app-store-archive.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(dirname "${BASH_SOURCE[0]}")"
+REPO_ROOT="$(dirname "${SCRIPT_DIR}")/.."
+IPA="${REPO_ROOT}/Artifacts/WordPress.ipa"
+
+"${SCRIPT_DIR}/shared-set-up.sh"
+"${SCRIPT_DIR}/shared-set-up-distribution.sh"
+"${SCRIPT_DIR}/install-secrets.sh"
+
+echo "--- :hammer_and_wrench: Building App Store archive (stop before ASC upload)"
+LOG="$(mktemp)"
+bundle exec fastlane build_and_upload_app_store_connect skip_confirm:true | tee "${LOG}"
+
+if ! grep -F 'VALIDATION: archive succeeded' "${LOG}"; then
+  echo "VALIDATION: lane did not print the archive-succeeded marker; refusing to treat this as a pass"
+  exit 1
+fi
+
+if [[ ! -f "${IPA}" ]]; then
+  echo "VALIDATION: expected IPA at ${IPA}"
+  exit 1
+fi
+
+SIZE="$(stat -f%z "${IPA}")"
+if (( SIZE == 0 )); then
+  echo "VALIDATION: IPA at ${IPA} is empty"
+  exit 1
+fi
+
+echo "VALIDATION: archive succeeded (${SIZE} bytes at ${IPA}); ASC upload was not invoked"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,188 +1,21 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
 ---
 
-# Most of the steps need to run on a macOS agent, so let's define it as a root property.
+# Validation-only for wordpress-mobile/WordPress-iOS#25934. Close; do not merge.
+
 agents:
   queue: mac
 env:
   IMAGE_ID: $IMAGE_ID
 
-# This is the default pipeline – it will build and test the app
 steps:
-  #################
-  # Create Prototype Builds for WP and JP
-  #################
-  - group: "🛠 Prototype Builds"
-    key: prototype_builds_group
-    steps:
-      - label: "🛠 WordPress Prototype Build"
-        command: ".buildkite/commands/prototype-build-wordpress.sh"
-        plugins: [$CI_TOOLKIT_PLUGIN]
-        if: "build.pull_request.id != null || build.pull_request.draft"
-        notify:
-          - github_commit_status:
-              context: "WordPress Prototype Build"
-
-      - label: "🛠 Jetpack Prototype Build"
-        command: ".buildkite/commands/prototype-build-jetpack.sh"
-        plugins: [$CI_TOOLKIT_PLUGIN]
-        if: "build.pull_request.id != null || build.pull_request.draft"
-        notify:
-          - github_commit_status:
-              context: "Jetpack Prototype Build"
-
-  #################
-  # Continuous Delivery: build & upload each app to TestFlight (internal testers) from trunk
-  #################
-  - group: ":testflight: TestFlight Builds"
-    key: testflight_builds_group
-    steps:
-      - label: ":testflight: Build & Upload {{matrix}}"
-        command: ".buildkite/commands/build-and-upload-testflight.sh {{matrix}}"
-        plugins: [$CI_TOOLKIT_PLUGIN]
-        if: "build.branch == 'trunk'"
-        matrix:
-          - "wordpress"
-          - "jetpack"
-          # Reader is omitted: its App Store archive has been broken since #25321
-          # (PostHelper moved to the app target without updating the Reader target),
-          # and went undetected after #25179 removed Reader from CI. Re-add once
-          # the Reader target archives again.
-          # - "reader"
-        notify:
-          - github_commit_status:
-              context: "TestFlight Build ({{matrix}})"
-
-  #################
-  # Create Builds for Testing
-  #################
-  - group: "🛠 Builds for Testing"
-    steps:
-      - label: "🛠 :wordpress: Build for Testing"
-        key: "build_wordpress"
-        command: ".buildkite/commands/build-for-testing.sh wordpress"
-        plugins: [$CI_TOOLKIT_PLUGIN]
-        notify:
-          - github_commit_status:
-              context: "WordPress Build for Testing"
-
-      - label: "🛠 :jetpack: Build for Testing"
-        key: "build_jetpack"
-        command: ".buildkite/commands/build-for-testing.sh jetpack"
-        plugins: [$CI_TOOLKIT_PLUGIN]
-        notify:
-          - github_commit_status:
-              context: "Jetpack Build for Testing"
-
-  #################
-  # Run Unit Tests
-  #################
-  - group: "🔬 Unit Tests"
-    key: unit_tests_group
-    steps:
-      - label: "🔬 :swift: Swift Package Tests"
-        command: .buildkite/commands/run-swift-package-tests.sh
-        plugins: [$CI_TOOLKIT_PLUGIN]
-        notify:
-          - github_commit_status:
-              context: "Swift Package Tests"
-
-      - label: "🔬 :wordpress: Unit Tests"
-        command: ".buildkite/commands/run-unit-tests.sh"
-        depends_on: "build_wordpress"
-        plugins:
-          - $CI_TOOLKIT_PLUGIN
-          - ${TEST_COLLECTOR}:
-              files: build/results/report.junit
-              format: junit
-              missing-error: 0
-              api-token-env-name: BUILDKITE_ANALYTICS_TOKEN_UNIT_TESTS
-        artifact_paths:
-          - "build/results/*"
-        notify:
-          - github_commit_status:
-              context: "Unit Tests"
-      - label: "🔬 Reader Unit Tests"
-        command: ".buildkite/commands/run-unit-tests-reader.sh"
-        plugins: [$CI_TOOLKIT_PLUGIN]
-        artifact_paths:
-          - "build/results/*"
-        notify:
-          - github_commit_status:
-              context: "Reader Unit Tests"
-      # Disabled till https://github.com/wordpress-mobile/WordPress-iOS/pull/24537 is completed
-      # - label: "🔬 Keystone Unit Tests"
-      #   command: .buildkite/commands/run-unit-tests-for-scheme.sh Keystone
-      #   plugins: [$CI_TOOLKIT_PLUGIN]
-      #   artifact_paths:
-      #     - "build/results/*"
-      #   notify:
-      #     - github_commit_status:
-      #         context: "Unit Tests Keystone"
-
-  #################
-  # Linters
-  #################
-  - group: "Linters"
-    key: linters_group
-    steps:
-      - label: ":danger: Danger - PR Check"
-        command: danger
-        key: danger
-        # No "build.pull_request.id" condition as we want this check to run also on merge queues where it is a no-op
-        retry:
-          manual:
-            permit_on_passed: true
-        agents:
-          queue: "linter"
-
-      - label: ":swift: SwiftLint"
-        command: swiftlint
-        notify:
-          - github_commit_status:
-              context: "SwiftLint"
-        agents:
-          queue: "linter"
-
-      - label: "🧹 Lint Translations"
-        command: "gplint /workdir/WordPress/Resources/AppStoreStrings.po"
-        plugins:
-          - docker#v3.8.0:
-              image: "public.ecr.aws/automattic/glotpress-validator:1.0.0"
-        agents:
-          queue: "default"
-        notify:
-          - github_commit_status:
-              context: "Lint Translations"
-
-      - label: ":sleuth_or_spy: Lint Localized Strings Format"
-        command: .buildkite/commands/lint-localized-strings-format.sh
-        plugins: [$CI_TOOLKIT_PLUGIN]
-
-      - label: ":mag: Verify String Catalog Coverage"
-        command: .buildkite/commands/verify-strings-catalog.sh
-        plugins: [$CI_TOOLKIT_PLUGIN]
-        notify:
-          - github_commit_status:
-              context: "Verify String Catalog Coverage"
-
-      - label: ":test_tube: Localization Tooling Unit Tests"
-        command: .buildkite/commands/test-localization-tooling.sh
-        plugins: [$CI_TOOLKIT_PLUGIN]
-        notify:
-          - github_commit_status:
-              context: "Localization Tooling Unit Tests"
-
-  #################
-  # Claude Build Analysis - dynamically uploaded so Build result conditions evaluate at runtime after the wait
-  #################
-  - label: ":claude: 🕵️ Check for Build Failures and Run Claude Analysis"
-    command: .buildkite/commands/upload-claude-analysis.sh
-    # Add specific group dependencies. Using a `wait` step wouldn't work as it would never start given the prompt block
-    depends_on:
-      - linters_group
-      - prototype_builds_group
-      - unit_tests_group
-    allow_dependency_failure: true
-    agents:
-      queue: upload
+  - label: ":wordpress: Validate App Store archive (no ASC upload)"
+    key: validate_app_store_archive
+    command: .buildkite/commands/validate-app-store-archive.sh
+    plugins: [$CI_TOOLKIT_PLUGIN]
+    artifact_paths:
+      - Artifacts/*.ipa
+      - Artifacts/*.dSYM.zip
+    notify:
+      - github_commit_status:
+          context: Validate App Store archive

--- a/fastlane/lanes/build.rb
+++ b/fastlane/lanes/build.rb
@@ -169,6 +169,14 @@ platform :ios do
       export_options: { **COMMON_EXPORT_OPTIONS, method: 'app-store' }
     )
 
+    # THROW AWAY: stop before TestFlight. Close the validation PR after this answers.
+    ipa_path = lane_context[SharedValues::IPA_OUTPUT_PATH]
+    UI.user_error!('VALIDATION: gym did not produce an IPA') if ipa_path.nil? || !File.exist?(ipa_path)
+    ipa_size = File.size(ipa_path)
+    UI.user_error!("VALIDATION: IPA at #{ipa_path} is empty") if ipa_size.zero?
+    UI.success("VALIDATION: archive succeeded (#{ipa_size} bytes at #{ipa_path}); stopping before ASC upload")
+    next
+
     upload_build_to_testflight(
       ipa_path: lane_context[SharedValues::IPA_OUTPUT_PATH],
       whats_new_path: WORDPRESS_RELEASE_NOTES_PATH,


### PR DESCRIPTION
## Validation only — do not merge

Stacked on #25934 ([AINFRA-2959](https://linear.app/a8c/issue/AINFRA-2959)).
Close this PR once the archive job has answered; never merge it.

## Why the ordinary pipeline misses this

`build_and_upload_app_store_connect` is only invoked from `release-build-wordpress.sh`, and that script is only used by the API-triggered `release-builds.yml` pipeline.
PR jobs archive a prototype (enterprise / Firebase), a simulator test build, or (on `trunk` only) a different TestFlight lane.

## Which job to read

**Validate App Store archive (no ASC upload)** is expected to **pass**.
Red means #25934 actually broke the lane — do not "fix" this PR.

Assertions:

- The lane prints `VALIDATION: archive succeeded` — gym ran and the early return fired, so `upload_to_testflight` was not called.
- `Artifacts/WordPress.ipa` exists and is non-empty — an App Store export was produced.

The IPA and dSYM zip are uploaded as artifacts.

## What CI still cannot answer

Whether App Store Connect would accept the IPA.
The job stops before `upload_to_testflight` on purpose.