### PR TITLE
Make the Stats traffic card list lazy

### DIFF
--- a/Modules/Sources/JetpackStats/Screens/TrafficTabView.swift
+++ b/Modules/Sources/JetpackStats/Screens/TrafficTabView.swift
@@ -21,7 +21,7 @@ struct TrafficTabView: View {
     var body: some View {
         ScrollViewReader { proxy in
             ScrollView {
-                VStack(spacing: Constants.step3) {
+                LazyVStack(spacing: Constants.step3) {
                     cards
                     buttonAddChart
                     timeZoneInfo

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,6 @@
 27.3
 -----
-
+* [*] Stats: Improve performance when opening the Stats screen [#25938]
 
 27.2
 -----


### PR DESCRIPTION
This change is extracted out from the #25931. I will iterate the chart skeleton view on #25931, and land this small change first.