### PR TITLE
Reuse the shared object model when restoring a store copy

### DIFF
--- a/Modules/Sources/WordPressData/Swift/CoreDataHelper.swift
+++ b/Modules/Sources/WordPressData/Swift/CoreDataHelper.swift
@@ -365,10 +365,9 @@ public extension CoreDataStack {
     }
 
     private func migrateDatabaseIfNecessary(at databaseLocation: URL) throws {
-        guard let modelFileURL = Bundle.wordPressData.url(forResource: "WordPress", withExtension: "momd"),
-              let objectModel = NSManagedObjectModel(contentsOf: modelFileURL) else {
-            return
-        }
-        try ContextManager.migrateDataModelsIfNecessary(storeURL: databaseLocation, objectModel: objectModel)
+        try ContextManager.migrateDataModelsIfNecessary(
+            storeURL: databaseLocation,
+            objectModel: ContextManager.currentObjectModel
+        )
     }
 }


### PR DESCRIPTION
We should not repeatedly parse the model file.