### PR TITLE
Comments v2: fix the comment body's indicator inset and sub-point scrolling

### DIFF
--- a/Modules/Sources/WordPressComments/Services/CommentContentRendering.swift
+++ b/Modules/Sources/WordPressComments/Services/CommentContentRendering.swift
@@ -2,7 +2,10 @@ import UIKit
 
 /// Contract: the returned view MUST scroll internally when content exceeds
 /// its bounds. The fixed-region detail layout has no other scroll surface
-/// and no Show More fallback.
+/// and no Show More fallback. The view is given the full region, edge to
+/// edge, so its scroll indicator sits at the screen edge; the renderer MUST
+/// inset its own content (horizontally by the header's padding, so the text
+/// lines up with it).
 @MainActor
 public protocol CommentContentRendering: AnyObject {
     var view: UIView { get }

--- a/Modules/Sources/WordPressComments/Views/Detail/CommentContentRegion.swift
+++ b/Modules/Sources/WordPressComments/Views/Detail/CommentContentRegion.swift
@@ -1,20 +1,17 @@
 import SwiftUI
 import UIKit
-import WordPressUI
 
-/// Hosts the injected comment content renderer as a fixed, edge-pinned
-/// subview. The renderer scrolls internally (its contract), so this is the
-/// only scroll surface for the comment body. `render(html:)` runs on the first
-/// update and whenever the HTML changes.
+/// Hosts the injected comment content renderer as a fixed subview filling the
+/// region. The renderer scrolls internally and insets its own content (its
+/// contract), so this is the only scroll surface for the comment body and it
+/// applies no padding of its own. `render(html:)` runs on the first update and
+/// whenever the HTML changes.
 struct CommentContentRegion: UIViewRepresentable {
     let renderer: any CommentContentRendering
     let html: String
 
     func makeUIView(context: Context) -> UIView {
-        let container = UIView()
-        container.addSubview(renderer.view)
-        renderer.view.pinEdges()
-        return container
+        IntegralFrameContainer(content: renderer.view)
     }
 
     func updateUIView(_ uiView: UIView, context: Context) {
@@ -29,5 +26,32 @@ struct CommentContentRegion: UIViewRepresentable {
 
     final class Coordinator {
         var lastRenderedHTML: String?
+    }
+}
+
+/// Gives its content a whole-point frame. SwiftUI hands the region whatever
+/// height the header leaves, usually fractional; WebKit lays a document out
+/// at a whole-point viewport rounded up, so a comment that fits would still
+/// overflow by under a point and scroll by that much. Flooring leaves at most
+/// a point uncovered at the trailing edges, which the clear background hides.
+private final class IntegralFrameContainer: UIView {
+    private let content: UIView
+
+    init(content: UIView) {
+        self.content = content
+        super.init(frame: .zero)
+        // The frame set below is the content's layout; no constraints apply.
+        content.translatesAutoresizingMaskIntoConstraints = true
+        addSubview(content)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        content.frame = CGRect(x: 0, y: 0, width: bounds.width.rounded(.down), height: bounds.height.rounded(.down))
     }
 }

--- a/Modules/Sources/WordPressComments/Views/Detail/CommentDetailView.swift
+++ b/Modules/Sources/WordPressComments/Views/Detail/CommentDetailView.swift
@@ -70,7 +70,6 @@ struct CommentDetailView: View {
             failureView
         case .loaded(let detail):
             CommentContentRegion(renderer: renderer, html: detail.contentHTML)
-                .padding(.horizontal)
         }
     }
 

--- a/Modules/Sources/WordPressReader/Comments/Views/WebCommentContentRenderer.swift
+++ b/Modules/Sources/WordPressReader/Comments/Views/WebCommentContentRenderer.swift
@@ -34,6 +34,18 @@ public final class WebCommentContentRenderer: NSObject, CommentContentRenderer {
         }
     }
 
+    /// Padding applied to the document body, in CSS pixels (equal to points
+    /// at the standard display size). Use this when the web view fills its
+    /// region and scrolls on its own: the text is inset while the scroll
+    /// indicator stays at the view's edge, and the padding scrolls with the
+    /// content. Hosts that inset the web view themselves should leave it at
+    /// zero. The height reported through the delegate includes the padding.
+    ///
+    /// - warning: This has to be configured _before_ you render.
+    public var contentPadding: UIEdgeInsets = .zero {
+        didSet { cachedHead = nil }
+    }
+
     /// Google requires an HTTP referrer for YouTube embeds, otherwise the player shows an error
     /// instead of the video. Matches the referrer `ReaderWebView` uses for post content so that
     /// embeds behave the same way in comments.
@@ -62,12 +74,6 @@ public final class WebCommentContentRenderer: NSObject, CommentContentRenderer {
         // WebKit turns this on for its scroll view; off so a comment that
         // fits its region stays still.
         webView.scrollView.alwaysBounceVertical = false
-        if isScrollEnabled {
-            // A scrolling host owns the layout. Without this, the safe-area
-            // inset UIKit adds gives a viewport-tall document a scrollable
-            // range, so even a one-line comment rubber-bands.
-            webView.scrollView.contentInsetAdjustmentBehavior = .never
-        }
         webView.scrollView.showsVerticalScrollIndicator = isScrollEnabled
 
         NotificationCenter.default.addObserver(
@@ -210,7 +216,11 @@ private extension WebCommentContentRenderer {
     private func actuallyMakeHead() -> String {
         let meta =
             "width=device-width,initial-scale=\(displaySettings.size.scale),maximum-scale=\(displaySettings.size.scale),user-scalable=no,shrink-to-fit=no"
-        let styles = displaySettings.makeStyles(tintColor: webView.tintColor)
+        var styles = displaySettings.makeStyles(tintColor: webView.tintColor)
+        if contentPadding != .zero {
+            let p = contentPadding
+            styles += "\nbody { padding: \(p.top)px \(p.right)px \(p.bottom)px \(p.left)px; }"
+        }
         return String(format: Self.headTemplate, meta, styles)
     }
 

--- a/WordPress/Classes/ViewRelated/Comments/V2/CommentsWebContentRendererAdapter.swift
+++ b/WordPress/Classes/ViewRelated/Comments/V2/CommentsWebContentRendererAdapter.swift
@@ -1,5 +1,4 @@
 import UIKit
-import WebKit
 import WordPressComments
 import WordPressReader
 
@@ -10,9 +9,11 @@ import WordPressReader
 final class CommentsWebContentRendererAdapter: NSObject, CommentContentRendering {
     private let renderer: WebCommentContentRenderer = {
         let renderer = WebCommentContentRenderer(isScrollEnabled: true)
-        // Breathing room above and below the body; content still scrolls
-        // under the region's edges. Horizontal padding is the module's job.
-        (renderer.view as? WKWebView)?.scrollView.contentInset = UIEdgeInsets(top: 12, left: 0, bottom: 16, right: 0)
+        // The web view fills the region so its scroll indicator sits at the
+        // screen edge; the document insets the text instead. Scroll view
+        // content insets would not work horizontally: the document keeps the
+        // frame width and pans sideways.
+        renderer.contentPadding = UIEdgeInsets(top: 12, left: 16, bottom: 16, right: 16)
         return renderer
     }()
 


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/CMM-2388

I must have tested some intermediate build because the implementation around controlling how the comment content scrolls is not quite right.

The recording does not show touch points, but I dragged all the comments content to see if they scroll

https://github.com/user-attachments/assets/5678c74f-2961-4625-8553-f7a695d52906


