### PR TITLE
Add comment moderation to Comments v2

### DIFF
--- a/Modules/Sources/WordPressComments/Models/CommentChangeEvent.swift
+++ b/Modules/Sources/WordPressComments/Models/CommentChangeEvent.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+/// Emitted after a moderation request commits, so every loaded
+/// `CommentsListViewModel` can keep its in-memory items in sync without a
+/// full refetch.
+enum CommentChangeEvent: Equatable, Sendable {
+    case statusChanged(id: Int64, to: CommentListItem.Status)
+    case deleted(id: Int64)
+}
+
+extension CommentChangeEvent {
+    /// The comment the event is about, used by detail screens to filter the
+    /// coordinator's event stream.
+    var commentID: Int64 {
+        switch self {
+        case .statusChanged(let id, _): id
+        case .deleted(let id): id
+        }
+    }
+}

--- a/Modules/Sources/WordPressComments/Models/CommentDetail.swift
+++ b/Modules/Sources/WordPressComments/Models/CommentDetail.swift
@@ -2,7 +2,7 @@ import Foundation
 import WordPressAPI
 import WordPressShared
 
-/// Value type consumed by the detail screen, mapped from either
+/// Value type consumed by the detail/moderation screen, mapped from either
 /// wordpress-rs view- or edit-context wire types. Edit context adds the
 /// author's email and IP address, which view context omits.
 struct CommentDetail: Equatable, Sendable {
@@ -17,7 +17,7 @@ struct CommentDetail: Equatable, Sendable {
     let contentHTML: String
     let link: URL?
     let date: Date
-    let status: CommentListItem.Status
+    var status: CommentListItem.Status
     /// False when the fetch fell back to view context (no email/IP; M3 edit
     /// needs content.raw, also unavailable).
     let hasEditContext: Bool

--- a/Modules/Sources/WordPressComments/Models/CommentListItem.swift
+++ b/Modules/Sources/WordPressComments/Models/CommentListItem.swift
@@ -20,7 +20,7 @@ struct CommentListItem: Identifiable, Equatable, Sendable {
     let postID: Int64
     let snippet: String
     let date: Date
-    let status: Status
+    var status: Status
 
     init(
         id: Int64,

--- a/Modules/Sources/WordPressComments/Models/CommentsListFilter.swift
+++ b/Modules/Sources/WordPressComments/Models/CommentsListFilter.swift
@@ -44,4 +44,17 @@ enum CommentsListFilter: Int, CaseIterable, AdaptiveTabBarItem, Sendable {
         case .trash: Strings.emptyTrash
         }
     }
+
+    /// Whether a comment with this status belongs in this tab's result set.
+    /// Mirrors core's query semantics: `all` is pending + approved only
+    /// (comment_approved IN ('0','1')); custom statuses match no tab.
+    func matches(_ status: CommentListItem.Status) -> Bool {
+        switch self {
+        case .all: status == .pending || status == .approved
+        case .pending: status == .pending
+        case .approved: status == .approved
+        case .spam: status == .spam
+        case .trash: status == .trash
+        }
+    }
 }

--- a/Modules/Sources/WordPressComments/Services/CommentsDetailRouter.swift
+++ b/Modules/Sources/WordPressComments/Services/CommentsDetailRouter.swift
@@ -11,21 +11,27 @@ final class CommentsDetailRouter {
 
     private let service: any CommentsServiceProtocol
     private let capabilities: any CommentsCapabilitiesProtocol
+    private let coordinator: CommentsModerationCoordinator
     private let titleResolver: PostTitleResolver
     private let tracker: (any CommentsTracker)?
+    private let noticePresenter: any NoticePresenting
     private let makeContentRenderer: @MainActor () -> any CommentContentRendering
 
     init(
         service: any CommentsServiceProtocol,
         capabilities: any CommentsCapabilitiesProtocol,
+        coordinator: CommentsModerationCoordinator,
         titleResolver: PostTitleResolver,
         tracker: (any CommentsTracker)?,
+        noticePresenter: any NoticePresenting,
         makeContentRenderer: @escaping @MainActor () -> any CommentContentRendering
     ) {
         self.service = service
         self.capabilities = capabilities
+        self.coordinator = coordinator
         self.titleResolver = titleResolver
         self.tracker = tracker
+        self.noticePresenter = noticePresenter
         self.makeContentRenderer = makeContentRenderer
     }
 
@@ -37,8 +43,10 @@ final class CommentsDetailRouter {
             seed: seed,
             service: service,
             capabilities: capabilities,
+            coordinator: coordinator,
             titleResolver: titleResolver,
-            tracker: tracker
+            tracker: tracker,
+            noticePresenter: noticePresenter
         )
         let renderer = makeContentRenderer()
         renderer.onLinkTapped = { url in

--- a/Modules/Sources/WordPressComments/Services/CommentsModerationCoordinator.swift
+++ b/Modules/Sources/WordPressComments/Services/CommentsModerationCoordinator.swift
@@ -1,0 +1,243 @@
+import Combine
+import Foundation
+import WordPressAPIInternal
+
+/// A moderation action the user can trigger on a comment. Restore covers both
+/// unspam and untrash; the coordinator probes which bin the comment is in
+/// before issuing the matching core operation.
+enum CommentModerationAction: Hashable, Sendable {
+    case approve // pending -> approved
+    case unapprove // approved -> pending
+    case spam
+    case trash
+    case restore
+    case delete
+
+    /// The analytics event for a successful run. Restore and delete map to no
+    /// event (legacy parity: those actions have no analytics event).
+    func trackedEvent(commentID: Int64, postID: Int64) -> CommentsTrackedEvent? {
+        switch self {
+        case .approve: .approved(commentID: commentID, postID: postID)
+        case .unapprove: .unapproved(commentID: commentID, postID: postID)
+        case .spam: .spammed(commentID: commentID, postID: postID)
+        case .trash: .trashed(commentID: commentID, postID: postID)
+        case .restore, .delete: nil
+        }
+    }
+}
+
+/// Owns every comment mutation for the feature. All state changes flow through
+/// here so the coordinator can enforce two ordering rules the design requires:
+///   1. One mutation in flight per comment.
+///   2. A change event emitted only after the server confirms the request.
+/// Because every event describes committed server state, list fetches never
+/// race an unconfirmed change and no settlement, generation, or reconcile
+/// machinery is needed.
+///
+/// A genuine failure leaves the UI on the true pre-action state. The only
+/// exceptions are three bounded failure mappings, where the desired outcome
+/// holds anyway and the change is emitted: the same-status probe, already-
+/// trashed, and 404.
+///
+/// Deliberately UI-free so it stays testable off the main-thread UI stack.
+@MainActor
+final class CommentsModerationCoordinator {
+    /// Every committed change, in order. List view models apply each event;
+    /// detail view models filter on their comment ID.
+    let events = PassthroughSubject<CommentChangeEvent, Never>()
+
+    private let service: any CommentsServiceProtocol
+    private let tracker: (any CommentsTracker)?
+
+    /// The in-flight mutation task per comment ID. Presence means "mutating";
+    /// `waitForPendingMutation` awaits the stored task's value.
+    private var inFlight: [Int64: Task<Void, Never>] = [:]
+
+    init(service: any CommentsServiceProtocol, tracker: (any CommentsTracker)? = nil) {
+        self.service = service
+        self.tracker = tracker
+    }
+
+    func isMutating(id: Int64) -> Bool {
+        inFlight[id] != nil
+    }
+
+    /// Awaits any in-flight mutation for the comment (re-entry race guard).
+    func waitForPendingMutation(id: Int64) async {
+        await inFlight[id]?.value
+    }
+
+    /// Broadcasts a status change the detail screen observed on load (its seed
+    /// status disagreed with the fetched truth) without running a mutation, so
+    /// loaded list tabs reconcile the corrected status in place.
+    func noteExternalStatus(id: Int64, to: CommentListItem.Status) {
+        events.send(.statusChanged(id: id, to: to))
+    }
+
+    /// Runs `action` pessimistically: the request is issued first and the change
+    /// event is emitted only after it succeeds (or maps to a success). Throws
+    /// the mutation error when the action genuinely failed, leaving the UI on
+    /// the true pre-action state; the caller shows the error.
+    func perform(_ action: CommentModerationAction, on comment: CommentDetail) async throws {
+        guard !isMutating(id: comment.id) else { return } // one mutation per comment; UI already gates
+        try await holdingSlot(for: comment.id) { [weak self] in
+            guard let self else { throw CancellationError() }
+            try await self.runModeration(action, on: comment)
+        }
+    }
+
+    /// Runs `body` in an unstructured task that owns the comment's in-flight
+    /// slot, so the mutation outlives a popped screen while the caller can
+    /// still await its outcome. The slot claim happens synchronously before any
+    /// suspension, so no second claimant can interleave.
+    private func holdingSlot<T: Sendable>(
+        for id: Int64,
+        _ body: @escaping @MainActor () async throws -> T
+    ) async throws -> T {
+        let chain = Task { try await body() }
+        let slot = Task { [weak self] in
+            _ = try? await chain.value
+            self?.inFlight[id] = nil
+        }
+        inFlight[id] = slot
+        // Await the slot first so `isMutating` is false by the time the caller
+        // resumes; the chain has already settled when the slot clears.
+        await slot.value
+        return try await chain.value
+    }
+
+    /// Runs one moderation request. The change event is emitted only after the
+    /// server confirms, so every event describes committed state and list
+    /// fetches never race an unconfirmed change.
+    private func runModeration(_ action: CommentModerationAction, on comment: CommentDetail) async throws {
+        do {
+            let event = try await execute(action, id: comment.id)
+            succeed(action, on: comment, event: event)
+        } catch {
+            try await mapFailure(error, action: action, on: comment)
+        }
+    }
+
+    /// Issues the request for `action` and returns the change event describing
+    /// the state the comment landed on.
+    private func execute(_ action: CommentModerationAction, id: Int64) async throws -> CommentChangeEvent {
+        switch action {
+        case .approve:
+            return .statusChanged(id: id, to: try await service.setStatus(id: id, .approved).status)
+        case .unapprove:
+            return .statusChanged(id: id, to: try await service.setStatus(id: id, .pending).status)
+        case .spam:
+            return .statusChanged(id: id, to: try await service.setStatus(id: id, .spam).status)
+        case .trash:
+            try await service.trash(id: id) // response carries no body
+            return .statusChanged(id: id, to: .trash)
+        case .restore:
+            // Restore (unspam/untrash) is the only non-idempotent action. Core
+            // restores in three steps: read the saved pre-bin status, reapply
+            // it, then delete the saved value. So a second restore finds no
+            // saved status, defaults to pending, and silently downgrades a
+            // comment that had been restored to approved.
+            //
+            // Guard against that by probing the current status first:
+            //   - Still .spam/.trash: genuinely in the bin, so restore it.
+            //   - Any other status: it already left the bin (an earlier attempt
+            //     landed, or another moderator moved it), so report that status
+            //     and skip the corrupting second restore.
+            // A failed probe throws and is handled as an ordinary failure, so no
+            // restore runs on an unconfirmed state.
+            let status = try await service.fetchStatus(id: id)
+            guard status == .spam || status == .trash else { return .statusChanged(id: id, to: status) }
+            // Restore from the probed bin, not the (possibly stale) status the
+            // tap captured, so a comment another moderator moved between spam
+            // and trash still runs the matching unspam/untrash hooks.
+            //
+            // Residual race (accepted): a restore can commit but lose its
+            // response while PHP is still writing. An immediate retry would then
+            // probe the still-pre-commit bin status, issue a second restore, and
+            // hit the pending downgrade above. Why we accept it:
+            //   1. The toolbar is disabled during a request, so a retry only
+            //      follows a resolved error.
+            //   2. If the first call did commit, losing its response means
+            //      enough time passed that the fast untrash already landed, so
+            //      the probe reads the active status and no second restore runs.
+            //   3. If it genuinely failed, the probe reads the bin and the retry
+            //      is safe.
+            //   4. The gap only opens when a server-side untrash is slower than
+            //      the client/proxy timeout (a pathological plugin hook); even
+            //      then the downgrade is conservative and visible in Pending.
+            // Closing it fully would need a restore-only recheck state (the
+            // machinery this rewrite removed) or a server-side idempotent
+            // restore.
+            return .statusChanged(id: id, to: try await service.restore(id: id, from: status).status)
+        case .delete:
+            try await service.delete(id: id)
+            return .deleted(id: id)
+        }
+    }
+
+    /// Emits the single post-success event and fires the action's analytics
+    /// event.
+    private func succeed(_ action: CommentModerationAction, on comment: CommentDetail, event: CommentChangeEvent) {
+        events.send(event)
+        if let tracked = action.trackedEvent(commentID: comment.id, postID: comment.postID) {
+            tracker?.track(tracked)
+        }
+    }
+
+    /// Maps the failures whose desired outcome nevertheless holds; rethrows
+    /// everything else as a genuine failure (the UI kept the pre-action state,
+    /// so no correction is needed).
+    ///
+    /// It's possible that a request fails after the server already committed the
+    /// change (client timeout, a proxy 502/504 while PHP finishes, a corrupted
+    /// response body). The screen then shows the pre-action status alongside an
+    /// error until the next fetch; a retry is confirmed by the same-status probe
+    /// below. We consider that an edge case and accept the risk rather than
+    /// refetching after every failure.
+    private func mapFailure(
+        _ error: Error,
+        action: CommentModerationAction,
+        on comment: CommentDetail
+    ) async throws {
+        let apiError = error as? WpApiError
+        // Core returns 500 rest_comment_failed_edit when the requested status
+        // equals the current one, i.e. the comment is already where the user
+        // wants it (an earlier timed-out attempt landed, or another moderator
+        // made the same change). One sparse status probe confirms; on match
+        // this is a success, not a failure.
+        if apiError?.wpErrorCode == .CommentFailedEdit,
+            let actual = try? await service.fetchStatus(id: comment.id),
+            probeConfirmsSuccess(action, actual: actual)
+        {
+            succeed(action, on: comment, event: .statusChanged(id: comment.id, to: actual))
+            return
+        }
+        // Trash of an already-trashed comment: the goal state holds.
+        if action == .trash, apiError?.wpErrorCode == .AlreadyTrashed {
+            succeed(action, on: comment, event: .statusChanged(id: comment.id, to: .trash))
+            return
+        }
+        // The comment is gone regardless of which action ran; remove it
+        // everywhere. For delete that IS the goal; for anything else the action
+        // still failed.
+        if apiError?.httpStatusCode == 404 {
+            events.send(.deleted(id: comment.id))
+            if action == .delete { return }
+        }
+        throw error
+    }
+
+    /// Whether the probed status proves the action's goal holds. Any active
+    /// status confirms a restore, because untrash/unspam reapply the saved
+    /// pre-bin status (approved or pending).
+    private func probeConfirmsSuccess(_ action: CommentModerationAction, actual: CommentListItem.Status) -> Bool {
+        switch action {
+        case .approve: actual == .approved
+        case .unapprove: actual == .pending
+        case .spam: actual == .spam
+        case .trash: actual == .trash
+        case .restore: actual == .approved || actual == .pending
+        case .delete: false
+        }
+    }
+}

--- a/Modules/Sources/WordPressComments/Services/CommentsService.swift
+++ b/Modules/Sources/WordPressComments/Services/CommentsService.swift
@@ -31,6 +31,38 @@ protocol CommentsServiceProtocol: Sendable {
     /// edit context first (adds author email/IP) and falls back to view
     /// context on a 401/403 (stale cached capability after a demotion).
     func fetchComment(id: Int64, allowsEditContext: Bool) async throws -> CommentDetail
+
+    /// Fetches only the comment's current status. Used for the same-status
+    /// probe, where the caller only needs "where is this comment now" rather
+    /// than the full comment payload.
+    func fetchStatus(id: Int64) async throws -> CommentListItem.Status
+
+    /// Writes `status` and returns the updated detail. Restoring from spam or
+    /// trash goes through `restore(id:from:)` instead: core uses dedicated
+    /// operations for that, not a plain status write.
+    func setStatus(id: Int64, _ status: CommentListItem.Status) async throws -> CommentDetail
+
+    /// Restores a comment from `bin` (`.spam` or `.trash`) via core's dedicated
+    /// unspam/untrash operations, which reapply the saved pre-bin status and
+    /// fire the matching hooks. Returns the updated detail.
+    func restore(id: Int64, from bin: CommentListItem.Status) async throws -> CommentDetail
+
+    /// Soft-deletes the comment (moves it to trash; recoverable).
+    func trash(id: Int64) async throws
+
+    /// Permanently deletes the comment.
+    func delete(id: Int64) async throws
+
+    /// Total number of replies to `id`, read from the list response's
+    /// `X-WP-Total` header rather than the (unused) page of results.
+    func numberOfReplies(for id: Int64) async throws -> Int
+}
+
+/// Errors raised by `CommentsService` that don't originate from wordpress-rs.
+enum CommentsServiceError: Error {
+    /// A sparse field the caller asked for was absent from the response.
+    /// Should not happen: the server always returns requested fields.
+    case missingField
 }
 
 final class CommentsService: CommentsServiceProtocol {
@@ -73,6 +105,67 @@ final class CommentsService: CommentsServiceProtocol {
         )
         return CommentDetail(comment: response.data)
     }
+
+    func fetchStatus(id: Int64) async throws -> CommentListItem.Status {
+        let response = try await client.api.comments.filterRetrieveWithViewContext(
+            commentId: id,
+            params: .init(),
+            fields: [.status]
+        )
+        guard let status = response.data.status else { throw CommentsServiceError.missingField }
+        return CommentListItem.Status(status)
+    }
+
+    func setStatus(id: Int64, _ status: CommentListItem.Status) async throws -> CommentDetail {
+        try await update(id: id, status: Self.updateStatus(for: status))
+    }
+
+    func restore(id: Int64, from bin: CommentListItem.Status) async throws -> CommentDetail {
+        try await update(id: id, status: Self.restoreStatus(from: bin))
+    }
+
+    private func update(id: Int64, status: CommentStatus) async throws -> CommentDetail {
+        let response = try await client.api.comments.update(
+            commentId: id,
+            params: CommentUpdateParams(status: status)
+        )
+        return CommentDetail(comment: response.data)
+    }
+
+    /// The update-body spelling of a status (the body accepts `approved` but
+    /// spells pending as `hold`).
+    static func updateStatus(for status: CommentListItem.Status) -> CommentStatus {
+        switch status {
+        case .approved: .approved
+        case .pending: .hold
+        case .spam: .spam
+        case .trash: .trash
+        case .other(let raw): .custom(raw)
+        }
+    }
+
+    /// Core's dedicated restore operations: they reapply the saved
+    /// pre-spam/pre-trash status (not a plain hold write) and fire the
+    /// unspam_comment/untrash_comment hooks.
+    /// TODO: replace with typed wordpress-rs values when upstreamed.
+    static func restoreStatus(from bin: CommentListItem.Status) -> CommentStatus {
+        bin == .spam ? .custom("unspam") : .custom("untrash")
+    }
+
+    func trash(id: Int64) async throws {
+        _ = try await client.api.comments.trash(commentId: id, params: .init())
+    }
+
+    func delete(id: Int64) async throws {
+        _ = try await client.api.comments.delete(commentId: id, params: .init())
+    }
+
+    func numberOfReplies(for id: Int64) async throws -> Int {
+        let response = try await client.api.comments.listWithViewContext(
+            params: CommentListParams(perPage: 1, parent: [.init(id)], status: .all)
+        )
+        return Int(response.headerMap.wpTotal() ?? 0)
+    }
 }
 
 extension WpApiError {
@@ -83,6 +176,14 @@ extension WpApiError {
         case .RequestExecutionFailed(let statusCode, _, _, _, _): return statusCode
         default: return nil
         }
+    }
+
+    /// The WP REST error code carried by the error, when it has one. Used to
+    /// map the bounded moderation failures (`rest_comment_failed_edit`,
+    /// `rest_already_trashed`) to their real outcomes.
+    var wpErrorCode: WpErrorCode? {
+        if case .WpError(let errorCode, _, _, _, _, _) = self { return errorCode }
+        return nil
     }
 }
 

--- a/Modules/Sources/WordPressComments/Services/CommentsTracker.swift
+++ b/Modules/Sources/WordPressComments/Services/CommentsTracker.swift
@@ -1,5 +1,10 @@
 public enum CommentsTrackedEvent: Equatable, Sendable {
     case detailViewed(commentID: Int64, postID: Int64)
+    case approved(commentID: Int64, postID: Int64)
+    case unapproved(commentID: Int64, postID: Int64)
+    case spammed(commentID: Int64, postID: Int64)
+    case trashed(commentID: Int64, postID: Int64)
+    // Permanent delete: legacy has no analytics event; deliberately untracked.
 }
 
 public protocol CommentsTracker: Sendable {

--- a/Modules/Sources/WordPressComments/Services/NoticePresenting.swift
+++ b/Modules/Sources/WordPressComments/Services/NoticePresenting.swift
@@ -1,0 +1,5 @@
+/// TODO: Move the app-wide Notice API into a shared module and remove this bridge.
+@MainActor
+public protocol NoticePresenting {
+    func present(title: String)
+}

--- a/Modules/Sources/WordPressComments/Strings/Strings.swift
+++ b/Modules/Sources/WordPressComments/Strings/Strings.swift
@@ -97,6 +97,13 @@ enum Strings {
         comment: "Accessibility value announced for a comment row that is awaiting moderation"
     )
 
+    static let moderationFailed = NSLocalizedString(
+        "commentDetail.moderation.failed",
+        value: "That action couldn't be completed. Please try again.",
+        comment:
+            "Notice shown when a moderation action failed; the comment keeps its pre-action status and the user can retry"
+    )
+
     static let statusApproved = NSLocalizedString(
         "commentDetail.status.approved",
         value: "Approved",

--- a/Modules/Sources/WordPressComments/Strings/Strings.swift
+++ b/Modules/Sources/WordPressComments/Strings/Strings.swift
@@ -164,6 +164,79 @@ enum Strings {
         comment: "Prefix of the parent-comment strip. %@ is the parent comment's author name."
     )
 
+    static let approve = NSLocalizedString(
+        "commentDetail.action.approve",
+        value: "Approve",
+        comment: "Moderation toolbar button that approves a pending comment"
+    )
+
+    static let spam = NSLocalizedString(
+        "commentDetail.action.spam",
+        value: "Spam",
+        comment: "Moderation toolbar button that marks a comment as spam"
+    )
+
+    static let trash = NSLocalizedString(
+        "commentDetail.action.trash",
+        value: "Trash",
+        comment: "Moderation toolbar button that moves a comment to the trash"
+    )
+
+    static let moveToPending = NSLocalizedString(
+        "commentDetail.action.moveToPending",
+        value: "Move to Pending",
+        comment: "Moderation menu item that returns an approved comment to the pending state"
+    )
+
+    static let restore = NSLocalizedString(
+        "commentDetail.action.restore",
+        value: "Restore",
+        comment: "Moderation toolbar button that restores a comment from spam or trash"
+    )
+
+    static let deletePermanently = NSLocalizedString(
+        "commentDetail.action.deletePermanently",
+        value: "Delete Permanently",
+        comment: "Moderation toolbar button that permanently deletes a comment"
+    )
+
+    static let detailMoreActions = NSLocalizedString(
+        "commentDetail.action.moreActions",
+        value: "More",
+        comment: "Accessibility label for the overflow menu button on the comment detail screen"
+    )
+
+    static let trashConfirmButton = NSLocalizedString(
+        "commentDetail.confirm.trashButton",
+        value: "Move to Trash",
+        comment: "Confirmation button that trashes a comment"
+    )
+
+    static let trashConfirmGenericTitle = NSLocalizedString(
+        "commentDetail.confirm.trashGeneric",
+        value: "Move this comment to the trash?",
+        comment: "Confirmation title shown before trashing a comment whose reply count is unknown"
+    )
+
+    static let trashHasReplies = NSLocalizedString(
+        "commentDetail.confirm.trashHasReplies",
+        value: "This comment has replies. Trash it anyway?",
+        comment:
+            "Confirmation title before trashing a comment that has replies. Warns the moderator that the comment has replies. Trashing the comment does not trash its replies."
+    )
+
+    static let deleteConfirmTitle = NSLocalizedString(
+        "commentDetail.confirm.deleteTitle",
+        value: "Delete this comment permanently?",
+        comment: "Confirmation title shown before permanently deleting a comment"
+    )
+
+    static let deleteConfirmMessage = NSLocalizedString(
+        "commentDetail.confirm.deleteMessage",
+        value: "This can't be undone.",
+        comment: "Confirmation message shown before permanently deleting a comment"
+    )
+
     static let detailErrorTitle = NSLocalizedString(
         "commentDetail.error.title",
         value: "Couldn't load this comment",

--- a/Modules/Sources/WordPressComments/ViewModels/CommentDetailViewModel.swift
+++ b/Modules/Sources/WordPressComments/ViewModels/CommentDetailViewModel.swift
@@ -48,8 +48,9 @@ final class CommentDetailViewModel: ObservableObject {
     /// `isMutating` only flips after the first suspension).
     @Published private(set) var pendingAction: CommentModerationAction?
     /// Set by a `.deleted` event (a confirmed delete), which turns the toolbar
-    /// off. Cleared by a successful authoritative fetch or a later status
-    /// change proving the comment exists again.
+    /// off and makes the view dismiss itself. Cleared by a successful
+    /// authoritative fetch or a later status change proving the comment exists
+    /// again.
     @Published private(set) var isDeleted = false
 
     let commentID: Int64
@@ -259,7 +260,8 @@ final class CommentDetailViewModel: ObservableObject {
                 content = .loaded(detail)
             }
         case .deleted:
-            // The comment is gone: a terminal state that turns the toolbar off.
+            // The comment is gone: a terminal state that turns the toolbar off
+            // and dismisses the screen.
             isDeleted = true
         }
     }

--- a/Modules/Sources/WordPressComments/ViewModels/CommentDetailViewModel.swift
+++ b/Modules/Sources/WordPressComments/ViewModels/CommentDetailViewModel.swift
@@ -96,10 +96,13 @@ final class CommentDetailViewModel: ObservableObject {
         }
     }
 
-    /// The fetched detail when the user may act on it: the toolbar shows and no
-    /// mutation is in flight for this comment.
+    /// The fetched detail when the user may act on it: the toolbar shows, the
+    /// load has finished, and no mutation is in flight for this comment. The
+    /// load gate matters because the reply count lands after the comment: a
+    /// reply sent before it could be missed by the landed count and let the
+    /// parent be trashed without a warning.
     private var actionableDetail: CommentDetail? {
-        guard showsToolbar, !coordinator.isMutating(id: commentID) else { return nil }
+        guard showsToolbar, !isLoading, !coordinator.isMutating(id: commentID) else { return nil }
         return loadedDetail
     }
 
@@ -192,19 +195,18 @@ final class CommentDetailViewModel: ObservableObject {
         guard let canModerate else { return }
         await coordinator.waitForPendingMutation(id: commentID)
 
-        async let detail = try? service.fetchComment(id: commentID, allowsEditContext: canModerate)
-        // The reply count only feeds the trash confirmation, so skip the
-        // request when the toolbar can never show.
-        async let replies = canModerate ? try? service.numberOfReplies(for: commentID) : nil
-        let (detailResult, repliesResult) = await (detail, replies)
-
-        numberOfReplies = repliesResult
-        if let detail = detailResult {
-            applyLoaded(detail)
-            await loadParentPreview(for: detail)
-        } else {
+        // The reply count only feeds the trash confirmation, so it runs
+        // alongside the comment fetch (`.generic` covers the gap), is applied
+        // last, and is skipped when the toolbar can never show.
+        async let replies: Int? = canModerate ? (try? await service.numberOfReplies(for: commentID)) : nil
+        guard let detail = try? await service.fetchComment(id: commentID, allowsEditContext: canModerate) else {
+            _ = await replies
             content = .failed
+            return
         }
+        applyLoaded(detail)
+        await loadParentPreview(for: detail)
+        numberOfReplies = await replies
     }
 
     private func applyLoaded(_ detail: CommentDetail) {

--- a/Modules/Sources/WordPressComments/ViewModels/CommentDetailViewModel.swift
+++ b/Modules/Sources/WordPressComments/ViewModels/CommentDetailViewModel.swift
@@ -1,9 +1,18 @@
+import Combine
 import Foundation
 import WordPressShared
 
-/// Drives the read-only comment detail screen. Resolves the capability once,
-/// fetches the authoritative detail and optional parent preview, and keeps the
-/// seeded header visible while the request is in flight.
+/// Drives the comment detail and moderation screen. Resolves the moderation
+/// capability once, runs the authoritative detail/parent/reply-count fetches,
+/// and enforces the ordering rules the design requires: no action lands before
+/// the authoritative fetch, the toolbar is disabled while a mutation is in
+/// flight, and an open screen still hears late status changes by subscribing to
+/// coordinator events for its comment ID.
+///
+/// Moderation is pessimistic: the tapped action shows an in-place spinner, the
+/// coordinator emits its change event only after the request succeeds, and a
+/// failure posts an app-wide notice with the screen still on the true
+/// pre-action state.
 @MainActor
 final class CommentDetailViewModel: ObservableObject {
     enum ContentState: Equatable {
@@ -21,44 +30,122 @@ final class CommentDetailViewModel: ObservableObject {
         let status: CommentListItem.Status
     }
 
-    @Published private(set) var header: Header? // nil = seedless, show placeholders
+    /// The confirmation a trash action should present. `numberOfReplies` is
+    /// unknown until the count fetch lands, so an unknown count falls back to a
+    /// generic confirmation rather than silently trashing a thread.
+    enum TrashConfirmation: Equatable {
+        case none // 0 replies: no confirmation needed
+        case generic // reply count unknown
+        case withReplies
+    }
+
     @Published private(set) var content: ContentState = .loading
     @Published private(set) var canModerate: Bool? // nil = resolving
     @Published private(set) var parentPreview: CommentListItem? // "In reply to" strip
+    @Published private(set) var numberOfReplies: Int? // nil = unknown
+    /// The action whose request is in flight, or nil. Drives the per-button
+    /// spinner and gates the toolbar synchronously (the coordinator's
+    /// `isMutating` only flips after the first suspension).
+    @Published private(set) var pendingAction: CommentModerationAction?
+    /// Set by a `.deleted` event (a confirmed delete), which turns the toolbar
+    /// off. Cleared by a successful authoritative fetch or a later status
+    /// change proving the comment exists again.
+    @Published private(set) var isDeleted = false
 
     let commentID: Int64
 
+    /// The fetched detail once it lands, else the list seed, else nil
+    /// (seedless: show placeholders). Derived so the status has one source.
+    var header: Header? {
+        if let detail = loadedDetail { return Header(detail: detail) }
+        return seed.map(Header.init(seed:))
+    }
+
+    var loadedDetail: CommentDetail? {
+        if case .loaded(let detail) = content { return detail }
+        return nil
+    }
+
+    /// Toolbar renders when the user can moderate AND edit context stuck. Once
+    /// the detail lands, a view-context fallback (no edit context) means the
+    /// capability was stale; hide the toolbar for this screen.
+    var showsToolbar: Bool {
+        guard !isDeleted, canModerate == true else { return false }
+        return loadedDetail?.hasEditContext ?? true
+    }
+
+    /// The toolbar's shape for the live header status (the screen's status
+    /// source of truth).
+    var toolbarModel: CommentModerationToolbarModel {
+        .make(status: header?.status, showsToolbar: showsToolbar)
+    }
+
+    /// Enabled only on fetched truth and while no mutation is in flight. The
+    /// local `pendingAction` is the synchronous double-tap guard; the
+    /// coordinator's `isMutating` also covers a mutation started before this
+    /// screen opened.
+    var isToolbarEnabled: Bool {
+        actionableDetail != nil && pendingAction == nil
+    }
+
+    var trashConfirmation: TrashConfirmation {
+        switch numberOfReplies {
+        case .none: .generic
+        case .some(0): .none
+        case .some: .withReplies
+        }
+    }
+
+    /// The fetched detail when the user may act on it: the toolbar shows and no
+    /// mutation is in flight for this comment.
+    private var actionableDetail: CommentDetail? {
+        guard showsToolbar, !coordinator.isMutating(id: commentID) else { return nil }
+        return loadedDetail
+    }
+
+    private let seed: CommentListItem?
     private let service: any CommentsServiceProtocol
     private let capabilities: any CommentsCapabilitiesProtocol
+    private let coordinator: CommentsModerationCoordinator
     private let titleResolver: PostTitleResolver
     /// Fires `.detailViewed` once per screen, on the first successful fetch.
     private let tracker: (any CommentsTracker)?
+    private let noticePresenter: (any NoticePresenting)?
 
-    /// The authoritative fetch has landed successfully at least once.
-    private var hasFetched = false
     /// A load (capability + fetch) is currently running; guards re-entry.
     private var isLoading = false
+
+    private var eventSubscription: AnyCancellable?
 
     init(
         commentID: Int64,
         seed: CommentListItem?,
         service: any CommentsServiceProtocol,
         capabilities: any CommentsCapabilitiesProtocol,
+        coordinator: CommentsModerationCoordinator,
         titleResolver: PostTitleResolver,
-        tracker: (any CommentsTracker)? = nil
+        tracker: (any CommentsTracker)? = nil,
+        noticePresenter: (any NoticePresenting)? = nil
     ) {
         self.commentID = commentID
+        self.seed = seed
         self.service = service
         self.capabilities = capabilities
+        self.coordinator = coordinator
         self.titleResolver = titleResolver
         self.tracker = tracker
-        if let seed {
-            header = Header(seed: seed)
-        }
+        self.noticePresenter = noticePresenter
+        // Deliberately not tied to the view's appearance: pushing a child screen
+        // (e.g. the parent comment) hides this one, and a status change that
+        // lands meanwhile must still correct the header/toolbar. Lives for the
+        // VM's lifetime.
+        eventSubscription = coordinator.events
+            .filter { $0.commentID == commentID }
+            .sink { [weak self] in self?.handle($0) }
     }
 
     func onAppear() async {
-        guard !hasFetched, !isLoading else { return }
+        guard loadedDetail == nil, !isLoading else { return }
         await load()
     }
 
@@ -67,6 +154,26 @@ final class CommentDetailViewModel: ObservableObject {
         content = .loading
         await load()
     }
+
+    /// Runs a moderation action pessimistically: the tapped button shows a
+    /// spinner while the request is in flight, and the UI changes only once the
+    /// coordinator's post-success event has updated the loaded detail. Ignored
+    /// unless the toolbar is enabled (authoritative truth landed and no
+    /// mutation is in flight), so an action can never run before the fetch.
+    func perform(_ action: CommentModerationAction) {
+        guard isToolbarEnabled, let detail = loadedDetail else { return }
+        pendingAction = action
+        Task { [coordinator, noticePresenter, weak self] in
+            do {
+                try await coordinator.perform(action, on: detail)
+            } catch {
+                noticePresenter?.present(title: Strings.moderationFailed)
+            }
+            self?.pendingAction = nil
+        }
+    }
+
+    // MARK: - Loading
 
     private func load() async {
         isLoading = true
@@ -77,29 +184,46 @@ final class CommentDetailViewModel: ObservableObject {
         await runFetch()
     }
 
+    /// Runs the authoritative fetch. Waits for any in-flight mutation to settle
+    /// first, so the fetch reads post-commit state. A mutation cannot start
+    /// mid-fetch from this screen (the toolbar stays disabled until the fetch
+    /// lands), and a success event arriving later corrects the status anyway.
     private func runFetch() async {
         guard let canModerate else { return }
-        guard
-            let detail = try? await service.fetchComment(
-                id: commentID,
-                allowsEditContext: canModerate
-            )
-        else {
+        await coordinator.waitForPendingMutation(id: commentID)
+
+        async let detail = try? service.fetchComment(id: commentID, allowsEditContext: canModerate)
+        // The reply count only feeds the trash confirmation, so skip the
+        // request when the toolbar can never show.
+        async let replies = canModerate ? try? service.numberOfReplies(for: commentID) : nil
+        let (detailResult, repliesResult) = await (detail, replies)
+
+        numberOfReplies = repliesResult
+        if let detail = detailResult {
+            applyLoaded(detail)
+            await loadParentPreview(for: detail)
+        } else {
             content = .failed
-            return
         }
-        applyLoaded(detail)
-        await loadParentPreview(for: detail)
     }
 
     private func applyLoaded(_ detail: CommentDetail) {
-        let isFirstFetch = !hasFetched
-        hasFetched = true
+        let isFirstFetch = loadedDetail == nil
+        // A successful authoritative fetch proves the comment exists at a known
+        // status, so clear any terminal (deleted) state (re-enabling the
+        // toolbar). A genuinely deleted comment never reaches here: its fetch
+        // fails into `.failed`.
+        isDeleted = false
         content = .loaded(detail)
-        header = Header(detail: detail)
         titleResolver.resolve(ids: [detail.postID])
+        // Fire once per screen, on the first successful fetch only.
         if isFirstFetch {
             tracker?.track(.detailViewed(commentID: commentID, postID: detail.postID))
+        }
+        // The list's status can be stale; broadcast the corrected status so any
+        // loaded list tab reconciles without a full refetch.
+        if let seed, seed.status != detail.status {
+            coordinator.noteExternalStatus(id: commentID, to: detail.status)
         }
     }
 
@@ -115,6 +239,27 @@ final class CommentDetailViewModel: ObservableObject {
             return
         }
         parentPreview = CommentListItem(detail: parent)
+    }
+
+    // MARK: - Coordinator events
+
+    private func handle(_ event: CommentChangeEvent) {
+        switch event {
+        case .statusChanged(_, let to):
+            // A status change proves the comment exists at a known status. Clear
+            // any prior terminal state (e.g. a delete that later proved false)
+            // so the toolbar can re-enable, then apply the status. The loaded
+            // detail is the screen's status source of truth (header, pill, and
+            // toolbar model all read it).
+            isDeleted = false
+            if var detail = loadedDetail {
+                detail.status = to
+                content = .loaded(detail)
+            }
+        case .deleted:
+            // The comment is gone: a terminal state that turns the toolbar off.
+            isDeleted = true
+        }
     }
 }
 

--- a/Modules/Sources/WordPressComments/ViewModels/CommentsListViewModel.swift
+++ b/Modules/Sources/WordPressComments/ViewModels/CommentsListViewModel.swift
@@ -1,3 +1,4 @@
+import Combine
 import Foundation
 
 /// One instance per filter tab, alive for the screen's lifetime, so switching
@@ -5,81 +6,222 @@ import Foundation
 /// mode). Pages accumulate in memory; there is no persistence by design.
 @MainActor
 final class CommentsListViewModel: ObservableObject {
+    /// Where the tab stands with page one. Load-more state (`isLoadingMore`,
+    /// `loadMoreFailed`) is an orthogonal axis and stays separate.
+    enum FirstPageState: Equatable {
+        /// Never appeared; no request made yet.
+        case idle
+        /// The initial page-one fetch is in flight. `items` is empty or a
+        /// placeholder subset borrowed from the All tab meanwhile.
+        case loading
+        /// The initial fetch failed: full-screen error with retry.
+        case failed
+        /// Page one landed; `items` reflect the last fetch plus in-place
+        /// event corrections.
+        case loaded
+        /// A change event couldn't be reconciled in place (see `apply(_:)`);
+        /// page one is refetching behind the outdated rows.
+        case reloading
+        /// The rows are outdated and a page-one reload is pending: either
+        /// just scheduled by `markStale`, or deferred to the next appearance
+        /// after a reload attempt failed.
+        case awaitingReload
+    }
+
     let filter: CommentsListFilter
 
     @Published private(set) var items: [CommentListItem] = []
-    // TODO: Consider folding the first-page state (isShowingSeededPlaceholder,
-    // isLoadingFirstPage, firstPageFailed, hasLoaded, showsEmptyState) into a
-    // single ScreenState enum so illegal combinations become unrepresentable.
-    // The load-more state (isLoadingMore, loadMoreFailed) is an orthogonal axis
-    // and would stay separate. Deferred as a non-behavioral cleanup.
-    @Published private(set) var isShowingSeededPlaceholder = false
-    @Published private(set) var isLoadingFirstPage = false
-    @Published private(set) var firstPageFailed = false
+    @Published private(set) var state: FirstPageState = .idle
     @Published private(set) var isLoadingMore = false
     @Published private(set) var loadMoreFailed = false
-
-    private(set) var hasLoaded = false
 
     private let service: any CommentsServiceProtocol
     private let seedItems: (@MainActor () -> [CommentListItem])?
     private let onItemsAppended: (@MainActor ([CommentListItem]) -> Void)?
     private var nextPage: CommentsPageToken?
+    /// The IDs of `items`, for O(1) membership checks.
     private var seenIDs: Set<Int64> = []
+    private var eventSubscription: AnyCancellable?
+    /// Number of `fetchPage` calls currently awaiting the service, so an
+    /// invalidation only bumps `generation` when there is something to discard.
+    private var inFlightFetchCount = 0
     /// Bumped whenever the list is reset to page one (first load or refresh).
     /// A `loadMore` started before a reset carries the old value and discards
     /// its result on completion, so a slow page fetched from an obsolete cursor
     /// can never append onto or overwrite the refreshed list.
     private var generation = 0
 
+    /// Page one has landed at least once: `items` are real rows, if possibly
+    /// outdated.
+    var hasLoaded: Bool {
+        switch state {
+        case .loaded, .reloading, .awaitingReload: true
+        case .idle, .loading, .failed: false
+        }
+    }
+
     var canLoadMore: Bool {
-        hasLoaded && nextPage != nil && !isShowingSeededPlaceholder && !isLoadingMore && !loadMoreFailed
+        hasLoaded && nextPage != nil && !isLoadingMore && !loadMoreFailed
     }
 
     var showsEmptyState: Bool {
-        hasLoaded && items.isEmpty && !firstPageFailed
+        hasLoaded && items.isEmpty
     }
 
     init(
         filter: CommentsListFilter,
         service: any CommentsServiceProtocol,
         seedItems: (@MainActor () -> [CommentListItem])? = nil,
-        onItemsAppended: (@MainActor ([CommentListItem]) -> Void)? = nil
+        onItemsAppended: (@MainActor ([CommentListItem]) -> Void)? = nil,
+        changeEvents: AnyPublisher<CommentChangeEvent, Never>? = nil
     ) {
         self.filter = filter
         self.service = service
         self.seedItems = seedItems
         self.onItemsAppended = onItemsAppended
+        eventSubscription = changeEvents?.sink { [weak self] in self?.apply($0) }
     }
 
     func onAppear() async {
-        guard !hasLoaded, !isLoadingFirstPage else { return }
-        if let seeded = seedItems?(), !seeded.isEmpty {
-            items = seeded
-            isShowingSeededPlaceholder = true
+        switch state {
+        case .loading, .loaded, .reloading:
+            return
+        case .awaitingReload:
+            // A stale reload keeps its real (if outdated) rows; seeding only
+            // applies to the very first load.
+            await loadFirstPage(as: .reloading)
+        case .idle, .failed:
+            if let seeded = seedItems?(), !seeded.isEmpty {
+                items = seeded
+                seenIDs = Set(seeded.map(\.id))
+            }
+            await loadFirstPage(as: .loading)
         }
-        await loadFirstPage()
+    }
+
+    /// Retries a stale reload that failed while the tab was off screen. A no-op
+    /// in every other state, so it never starts a first load.
+    func reloadIfStale() async {
+        guard state == .awaitingReload else { return }
+        await onAppear()
+    }
+
+    /// Applies a moderation change event, keeping this tab's items consistent
+    /// without a full refetch where possible.
+    func apply(_ event: CommentChangeEvent) {
+        switch event {
+        case .statusChanged(let id, let to):
+            if filter.matches(to) {
+                if seenIDs.contains(id), let index = items.firstIndex(where: { $0.id == id }) {
+                    // Correct the row in place, then invalidate in-flight
+                    // fetches: an older page-one fetch (initial or stale reload)
+                    // captured before this correction would otherwise pass its
+                    // generation guard and overwrite the corrected status.
+                    items[index].status = to
+                    invalidateInFlightFetches()
+                } else if hasLoaded {
+                    // The comment now belongs here but a paged list cannot know
+                    // the correct insert position; refetch on next appearance.
+                    // markStale also invalidates any in-flight fetch.
+                    markStale()
+                } else {
+                    // Belongs but absent while an initial (seeded) page-one load
+                    // is still in flight: invalidate it so it re-converges to a
+                    // complete post-mutation page that includes this comment,
+                    // rather than accepting a pre-mutation page that omits it.
+                    invalidateInFlightFetches()
+                }
+            } else {
+                removeItem(id: id)
+            }
+        case .deleted(let id):
+            removeItem(id: id)
+        }
+    }
+
+    private func removeItem(id: Int64) {
+        if seenIDs.remove(id) != nil {
+            items.removeAll { $0.id == id }
+        }
+        // Invalidate even when the row was absent: a page still in flight
+        // captured the pre-removal generation and could still deliver the
+        // comment (as a fresh id) after it was removed elsewhere.
+        invalidateInFlightFetches()
+    }
+
+    /// Marks the tab stale and reloads page one right away, so a visible tab
+    /// doesn't wait for a tab switch. Callers guard `hasLoaded`. A reload
+    /// already in flight keeps its state: its fetch is invalidated below and
+    /// refetches itself, and `onAppear` ignores the extra kick.
+    private func markStale() {
+        if state == .loaded {
+            state = .awaitingReload
+        }
+        invalidateInFlightFetches()
+        Task { await onAppear() }
+    }
+
+    /// Bumps `generation` so any list fetch already in flight (which captured
+    /// the earlier value) discards its result on completion. A no-op when no
+    /// fetch is in flight: there is nothing to discard.
+    private func invalidateInFlightFetches() {
+        if inFlightFetchCount > 0 {
+            generation &+= 1
+        }
+    }
+
+    /// The result of a paged fetch that has already waited for in-flight
+    /// moderation to settle.
+    private enum FetchOutcome {
+        /// A moderation event bumped `generation` while the fetch was in flight,
+        /// so the returned page predates it and must not be treated as
+        /// authoritative.
+        case invalidated
+        case loaded(CommentsPage)
+        case failed
+    }
+
+    /// Fetches a page and reports whether a moderation event invalidated it
+    /// mid-flight. The generation guard catches an event that lands (post-
+    /// success, so describing committed server state) while the request is in
+    /// flight and would otherwise overwrite an in-place correction or restore a
+    /// removed row; the caller decides whether to retry until convergence (page
+    /// one) or drop the page (pagination/refresh).
+    ///
+    /// It's possible that a page requested before a mutation commits is applied
+    /// before that mutation's success event lands, so it briefly shows the
+    /// pre-action state; the success event then corrects membership in place. We
+    /// consider that an edge case and accept the risk.
+    private func fetchPage(nextPage token: CommentsPageToken?) async -> FetchOutcome {
+        let requestGeneration = generation
+        inFlightFetchCount += 1
+        defer { inFlightFetchCount -= 1 }
+        do {
+            let page = try await service.listComments(filter: filter, nextPage: token)
+            guard requestGeneration == generation else { return .invalidated }
+            return .loaded(page)
+        } catch {
+            guard requestGeneration == generation else { return .invalidated }
+            return .failed
+        }
     }
 
     func retryFirstPage() async {
-        guard !isLoadingFirstPage else { return }
-        await loadFirstPage()
+        guard state == .failed else { return }
+        await loadFirstPage(as: .loading)
     }
 
     func loadMore() async {
         guard canLoadMore, let token = nextPage else { return }
-        let requestGeneration = generation
         isLoadingMore = true
         defer { isLoadingMore = false }
-        do {
-            let page = try await service.listComments(filter: filter, nextPage: token)
-            // A refresh or first-load reset that landed while this page was in
-            // flight makes it stale; dropping it avoids appending items fetched
-            // from an obsolete cursor onto the refreshed list.
-            guard requestGeneration == generation else { return }
+        switch await fetchPage(nextPage: token) {
+        case .invalidated:
+            // Fetched from an obsolete cursor or predating a moderation; drop it.
+            break
+        case .loaded(let page):
             append(page: page)
-        } catch {
-            guard requestGeneration == generation else { return }
+        case .failed:
             loadMoreFailed = true
         }
     }
@@ -90,26 +232,50 @@ final class CommentsListViewModel: ObservableObject {
     }
 
     func refresh() async {
-        do {
-            let page = try await service.listComments(filter: filter, nextPage: nil)
-            replace(with: page)
-        } catch {
-            // Keep stale content on refresh failure; the design surfaces no
-            // blocking error here.
+        // On invalidation or error, keep the current content: the in-place
+        // `apply` already reflects moderation, and the user can pull again.
+        guard case .loaded(let page) = await fetchPage(nextPage: nil) else { return }
+        replace(with: page)
+        // A fresh full page is authoritative, so a tab awaiting a stale reload
+        // is no longer stale. A page-one loop still in flight settles its own
+        // state once its (now invalidated) fetch reconverges.
+        switch state {
+        case .loading, .reloading:
+            break
+        case .idle, .failed, .loaded, .awaitingReload:
+            state = .loaded
         }
     }
 
-    private func loadFirstPage() async {
-        isLoadingFirstPage = true
-        firstPageFailed = false
-        defer { isLoadingFirstPage = false }
-        do {
-            let page = try await service.listComments(filter: filter, nextPage: nil)
-            replace(with: page)
-            hasLoaded = true
-            isShowingSeededPlaceholder = false
-        } catch {
-            firstPageFailed = items.isEmpty || isShowingSeededPlaceholder
+    /// Runs the page-one fetch loop from `loadingState` (`.loading` for the
+    /// initial load, `.reloading` for a stale reload) and settles into the
+    /// matching terminal state.
+    private func loadFirstPage(as loadingState: FirstPageState) async {
+        state = loadingState
+        // Loop so a request invalidated mid-flight always converges: a
+        // stale-triggered onAppear can't reschedule while this is running (the
+        // re-entry guard), so a discard-and-return would strand the tab stale
+        // until a lifecycle event. With no further events the next fetch
+        // matches and completes, so this can't spin.
+        while true {
+            switch await fetchPage(nextPage: nil) {
+            case .invalidated:
+                continue
+            case .loaded(let page):
+                replace(with: page)
+                state = .loaded
+                return
+            case .failed:
+                if loadingState == .loading {
+                    // Initial (or seeded) load failure: full-screen error + retry.
+                    state = .failed
+                } else {
+                    // A stale reload fails silently: keep the outdated rows and
+                    // try again on the next appearance.
+                    state = .awaitingReload
+                }
+                return
+            }
         }
     }
 

--- a/Modules/Sources/WordPressComments/Views/CommentsHostingController.swift
+++ b/Modules/Sources/WordPressComments/Views/CommentsHostingController.swift
@@ -33,6 +33,10 @@ public enum CommentsHostingController {
         )
         let host = UIHostingController(rootView: view)
         host.navigationItem.largeTitleDisplayMode = .never
+        // Hides the app tab bar for the list and everything pushed above it
+        // (detail, parent comments): the list has its own status tabs, and the
+        // detail's pinned moderation bar belongs at the screen bottom.
+        host.hidesBottomBarWhenPushed = true
         router.host = host
         return host
     }

--- a/Modules/Sources/WordPressComments/Views/CommentsHostingController.swift
+++ b/Modules/Sources/WordPressComments/Views/CommentsHostingController.swift
@@ -30,12 +30,20 @@ public enum CommentsHostingController {
             makeContentRenderer: makeContentRenderer
         )
 
-        let view = CommentsTabView(
+        let listViewModels = CommentsTabView.makeViewModels(
             service: service,
+            titleResolver: titleResolver,
+            coordinator: coordinator
+        )
+        let view = CommentsTabView(
+            viewModels: listViewModels,
             titleResolver: titleResolver,
             router: router
         )
-        let host = UIHostingController(rootView: view)
+        let host = CommentsRootHostingController(
+            rootView: view,
+            listViewModels: Array(listViewModels.values)
+        )
         host.navigationItem.largeTitleDisplayMode = .never
         // Hides the app tab bar for the list and everything pushed above it
         // (detail, parent comments): the list has its own status tabs, and the
@@ -43,5 +51,33 @@ public enum CommentsHostingController {
         host.hidesBottomBarWhenPushed = true
         router.host = host
         return host
+    }
+}
+
+/// Hosts the tab view and, on each appearance, retries the list tabs whose
+/// stale reload failed while the list was off screen (typically behind a
+/// pushed detail screen). `markStale()` already reloads eagerly at event
+/// time; this is only the retry for when that reload failed. It lives in the
+/// controller because SwiftUI's `onAppear` and `.task` do not re-run when a
+/// UIKit-pushed controller is popped back to this one (verified on a
+/// simulator).
+final class CommentsRootHostingController<Content: View>: UIHostingController<Content> {
+    private let listViewModels: [CommentsListViewModel]
+
+    init(rootView: Content, listViewModels: [CommentsListViewModel]) {
+        self.listViewModels = listViewModels
+        super.init(rootView: rootView)
+    }
+
+    @available(*, unavailable)
+    @MainActor dynamic required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        for viewModel in listViewModels {
+            Task { await viewModel.reloadIfStale() }
+        }
     }
 }

--- a/Modules/Sources/WordPressComments/Views/CommentsHostingController.swift
+++ b/Modules/Sources/WordPressComments/Views/CommentsHostingController.swift
@@ -10,10 +10,12 @@ public enum CommentsHostingController {
     public static func make(
         client: WordPressClient,
         makeContentRenderer: @escaping @MainActor () -> any CommentContentRendering,
-        tracker: any CommentsTracker
+        tracker: any CommentsTracker,
+        noticePresenter: any NoticePresenting
     ) -> UIViewController {
         let service = CommentsService(client: client)
         let titleResolver = PostTitleResolver(fetcher: PostTitleResolver.liveFetcher(client: client))
+        let coordinator = CommentsModerationCoordinator(service: service, tracker: tracker)
 
         // The router builds each detail screen (recursively, so a parent comment
         // pushes onto the same stack). The tab view retains it for the
@@ -21,8 +23,10 @@ public enum CommentsHostingController {
         let router = CommentsDetailRouter(
             service: service,
             capabilities: CommentsCapabilities(client: client),
+            coordinator: coordinator,
             titleResolver: titleResolver,
             tracker: tracker,
+            noticePresenter: noticePresenter,
             makeContentRenderer: makeContentRenderer
         )
 

--- a/Modules/Sources/WordPressComments/Views/CommentsListView.swift
+++ b/Modules/Sources/WordPressComments/Views/CommentsListView.swift
@@ -39,9 +39,9 @@ struct CommentsListView: View {
             await viewModel.refresh()
         }
         .overlay {
-            if viewModel.isLoadingFirstPage && viewModel.items.isEmpty {
+            if viewModel.state == .loading, viewModel.items.isEmpty {
                 ProgressView()
-            } else if viewModel.firstPageFailed {
+            } else if case .failed = viewModel.state {
                 ContentUnavailableView {
                     Label(Strings.errorTitle, systemImage: "exclamationmark.triangle")
                 } actions: {

--- a/Modules/Sources/WordPressComments/Views/CommentsTabView.swift
+++ b/Modules/Sources/WordPressComments/Views/CommentsTabView.swift
@@ -12,18 +12,34 @@ struct CommentsTabView: View {
     private let router: CommentsDetailRouter
 
     init(
-        service: any CommentsServiceProtocol,
+        viewModels: [CommentsListFilter: CommentsListViewModel],
         titleResolver: PostTitleResolver,
         router: CommentsDetailRouter
     ) {
         self.router = router
         _titleResolver = State(initialValue: titleResolver)
+        _viewModels = State(initialValue: viewModels)
+    }
 
-        // The All view model is built first so Pending and Approved can seed
-        // their first appearance from its loaded items. All is a strict
-        // superset of both under the same sort key, so the filtered items are
-        // a true prefix of each tab's list. Spam and Trash can't seed: core's
-        // status=all excludes them.
+    /// Builds one view model per filter tab, all alive for the screen's
+    /// lifetime. The hosting controller keeps the same instances so it can
+    /// retry stale reloads on appearance.
+    ///
+    /// The All view model is built first so Pending and Approved can seed
+    /// their first appearance from its loaded items. All is a strict
+    /// superset of both under the same sort key, so the filtered items are
+    /// a true prefix of each tab's list. Spam and Trash can't seed: core's
+    /// status=all excludes them.
+    /// Every tab subscribes to the coordinator's events so a change made on
+    /// the detail screen reconciles each loaded list in place without a
+    /// refetch.
+    @MainActor
+    static func makeViewModels(
+        service: any CommentsServiceProtocol,
+        titleResolver: PostTitleResolver,
+        coordinator: CommentsModerationCoordinator
+    ) -> [CommentsListFilter: CommentsListViewModel] {
+        let changeEvents = coordinator.events.eraseToAnyPublisher()
         var models: [CommentsListFilter: CommentsListViewModel] = [:]
         let resolve: @MainActor ([CommentListItem]) -> Void = { [titleResolver] items in
             titleResolver.resolve(ids: items.map(\.postID))
@@ -31,29 +47,31 @@ struct CommentsTabView: View {
         let allViewModel = CommentsListViewModel(
             filter: .all,
             service: service,
-            onItemsAppended: resolve
+            onItemsAppended: resolve,
+            changeEvents: changeEvents
         )
         models[.all] = allViewModel
         for filter in [CommentsListFilter.pending, .approved] {
-            let status: CommentListItem.Status = filter == .pending ? .pending : .approved
             models[filter] = CommentsListViewModel(
                 filter: filter,
                 service: service,
                 seedItems: { [weak allViewModel] in
                     guard let allViewModel, allViewModel.hasLoaded else { return [] }
-                    return allViewModel.items.filter { $0.status == status }
+                    return allViewModel.items.filter { filter.matches($0.status) }
                 },
-                onItemsAppended: resolve
+                onItemsAppended: resolve,
+                changeEvents: changeEvents
             )
         }
         for filter in [CommentsListFilter.spam, .trash] {
             models[filter] = CommentsListViewModel(
                 filter: filter,
                 service: service,
-                onItemsAppended: resolve
+                onItemsAppended: resolve,
+                changeEvents: changeEvents
             )
         }
-        _viewModels = State(initialValue: models)
+        return models
     }
 
     var body: some View {

--- a/Modules/Sources/WordPressComments/Views/Detail/CommentDetailView.swift
+++ b/Modules/Sources/WordPressComments/Views/Detail/CommentDetailView.swift
@@ -137,6 +137,13 @@ private final class PreviewCommentsService: CommentsServiceProtocol {
     func fetchComment(id: Int64, allowsEditContext: Bool) async throws -> CommentDetail {
         .preview(id: id, status: .pending)
     }
+
+    func fetchStatus(id: Int64) async throws -> CommentListItem.Status { .pending }
+    func setStatus(id: Int64, _ status: CommentListItem.Status) async throws -> CommentDetail { .preview() }
+    func restore(id: Int64, from bin: CommentListItem.Status) async throws -> CommentDetail { .preview() }
+    func trash(id: Int64) async throws {}
+    func delete(id: Int64) async throws {}
+    func numberOfReplies(for id: Int64) async throws -> Int { 2 }
 }
 
 private struct PreviewCapabilities: CommentsCapabilitiesProtocol {

--- a/Modules/Sources/WordPressComments/Views/Detail/CommentDetailView.swift
+++ b/Modules/Sources/WordPressComments/Views/Detail/CommentDetailView.swift
@@ -17,6 +17,8 @@ struct CommentDetailView: View {
     /// the screen's lifetime.
     private let renderer: any CommentContentRendering
 
+    @Environment(\.dismiss) private var dismiss
+
     init(
         viewModel: CommentDetailViewModel,
         titleResolver: PostTitleResolver,
@@ -35,6 +37,11 @@ struct CommentDetailView: View {
             .toolbar { trailingToolbarItems }
             .navigationBarTitleDisplayMode(.inline)
             .task { await viewModel.onAppear() }
+            // The comment no longer exists, so there is nothing left to show.
+            // `dismiss` pops this screen off the UIKit navigation stack.
+            .onChange(of: viewModel.isDeleted) { _, isDeleted in
+                if isDeleted { dismiss() }
+            }
     }
 
     private var fixedRegions: some View {

--- a/Modules/Sources/WordPressComments/Views/Detail/CommentDetailView.swift
+++ b/Modules/Sources/WordPressComments/Views/Detail/CommentDetailView.swift
@@ -1,9 +1,11 @@
 import SwiftUI
 import UIKit
 
-/// The fixed-region comment detail screen: a pinned status pill
+/// The fixed-region comment detail and moderation screen: a pinned status pill
 /// and author header, an optional "In reply to" strip, the internally
-/// scrolling content region, and the navigation-bar share action.
+/// scrolling content region, and a pinned bottom moderation toolbar hosted via
+/// `.safeAreaInset(edge: .bottom)` (never `.toolbar(placement: .bottomBar)`,
+/// which does not render in a UIKit-hosted `UIHostingController`).
 struct CommentDetailView: View {
     @StateObject private var viewModel: CommentDetailViewModel
     @ObservedObject private var titleResolver: PostTitleResolver
@@ -29,7 +31,8 @@ struct CommentDetailView: View {
 
     var body: some View {
         fixedRegions
-            .toolbar { shareToolbarItem }
+            .safeAreaInset(edge: .bottom, spacing: 0) { bottomToolbar }
+            .toolbar { trailingToolbarItems }
             .navigationBarTitleDisplayMode(.inline)
             .task { await viewModel.onAppear() }
     }
@@ -42,7 +45,7 @@ struct CommentDetailView: View {
                     CommentAuthorHeader(
                         header: header,
                         titleState: titleResolver.titleState(for: header.postID),
-                        detail: loadedDetail
+                        detail: viewModel.loadedDetail
                     )
                 }
                 .padding(.horizontal)
@@ -84,18 +87,48 @@ struct CommentDetailView: View {
         }
     }
 
-    @ToolbarContentBuilder
-    private var shareToolbarItem: some ToolbarContent {
-        if let link = loadedDetail?.link {
-            ToolbarItem(placement: .topBarTrailing) {
-                ShareLink(item: link)
+    @ViewBuilder
+    private var bottomToolbar: some View {
+        let model = viewModel.toolbarModel
+        if model != .hidden {
+            CommentModerationToolbar(
+                model: model,
+                isEnabled: viewModel.isToolbarEnabled,
+                pendingAction: viewModel.pendingAction,
+                trashConfirmation: viewModel.trashConfirmation
+            ) { action in
+                viewModel.perform(action)
             }
         }
     }
 
-    private var loadedDetail: CommentDetail? {
-        if case .loaded(let detail) = viewModel.content { return detail }
-        return nil
+    @ToolbarContentBuilder
+    private var trailingToolbarItems: some ToolbarContent {
+        ToolbarItem(placement: .topBarTrailing) {
+            let link = viewModel.loadedDetail?.link
+            let menuAction = viewModel.toolbarModel.menuAction
+            if link != nil || menuAction != nil {
+                Menu {
+                    if let link {
+                        ShareLink(item: link)
+                    }
+                    // The secondary moderation move shares the toolbar's
+                    // enablement so it can't fire on seed data or during a
+                    // mutation.
+                    if let menuAction {
+                        Section {
+                            Button(menuAction.title, systemImage: menuAction.systemImage, role: menuAction.role) {
+                                viewModel.perform(menuAction)
+                            }
+                            .disabled(!viewModel.isToolbarEnabled)
+                        }
+                    }
+                } label: {
+                    Image(systemName: "ellipsis")
+                }
+                .accessibilityLabel(Strings.detailMoreActions)
+            }
+        }
     }
 }
 
@@ -128,30 +161,9 @@ private final class StubContentRenderer: NSObject, CommentContentRendering {
     }
 }
 
-@MainActor
-private final class PreviewCommentsService: CommentsServiceProtocol {
-    func listComments(filter: CommentsListFilter, nextPage: CommentsPageToken?) async throws -> CommentsPage {
-        CommentsPage(items: [], nextPage: nil)
-    }
-
-    func fetchComment(id: Int64, allowsEditContext: Bool) async throws -> CommentDetail {
-        .preview(id: id, status: .pending)
-    }
-
-    func fetchStatus(id: Int64) async throws -> CommentListItem.Status { .pending }
-    func setStatus(id: Int64, _ status: CommentListItem.Status) async throws -> CommentDetail { .preview() }
-    func restore(id: Int64, from bin: CommentListItem.Status) async throws -> CommentDetail { .preview() }
-    func trash(id: Int64) async throws {}
-    func delete(id: Int64) async throws {}
-    func numberOfReplies(for id: Int64) async throws -> Int { 2 }
-}
-
-private struct PreviewCapabilities: CommentsCapabilitiesProtocol {
-    func canModerateComments() async -> Bool { true }
-}
-
 #Preview {
-    let service = PreviewCommentsService()
+    let service = PreviewCommentsService(fetchedStatus: .pending, numberOfReplies: 2)
+    let coordinator = CommentsModerationCoordinator(service: service)
     let titleResolver = PostTitleResolver(fetcher: { _ in
         PostTitleResolver.FetchResult(titles: [10: "Reviewing the 2027 Upgrade"])
     })
@@ -160,6 +172,7 @@ private struct PreviewCapabilities: CommentsCapabilitiesProtocol {
         seed: nil,
         service: service,
         capabilities: PreviewCapabilities(),
+        coordinator: coordinator,
         titleResolver: titleResolver
     )
     return NavigationStack {

--- a/Modules/Sources/WordPressComments/Views/Detail/CommentModerationToolbar.swift
+++ b/Modules/Sources/WordPressComments/Views/Detail/CommentModerationToolbar.swift
@@ -1,0 +1,190 @@
+import SwiftUI
+
+/// Pure description of the bottom moderation toolbar's shape for a given
+/// comment status. Derived once from the live header status and the view
+/// model's `showsToolbar`, so the toolbar never has to branch on raw status.
+enum CommentModerationToolbarModel: Equatable {
+    case pending // Approve (prominent) over Spam | Trash
+    case approved // Spam | Trash
+    case inBin // Restore over Delete Permanently
+    case hidden // custom status, no capability, or forced off
+
+    static func make(
+        status: CommentListItem.Status?,
+        showsToolbar: Bool
+    ) -> CommentModerationToolbarModel {
+        guard showsToolbar, let status else { return .hidden }
+        return switch status {
+        case .pending: .pending
+        case .approved: .approved
+        case .spam, .trash: .inBin
+        case .other: .hidden
+        }
+    }
+
+    /// The secondary moderation action that lives in the nav bar overflow
+    /// menu rather than the toolbar, so the toolbar shows only the common moves.
+    var menuAction: CommentModerationAction? {
+        switch self {
+        case .approved: .unapprove
+        case .pending, .inBin, .hidden: nil
+        }
+    }
+}
+
+/// How each action presents as a button: shared by the toolbar and the nav
+/// bar overflow menu so a title, symbol, and role are defined once.
+extension CommentModerationAction {
+    var title: String {
+        switch self {
+        case .approve: Strings.approve
+        case .unapprove: Strings.moveToPending
+        case .spam: Strings.spam
+        case .trash: Strings.trash
+        case .restore: Strings.restore
+        case .delete: Strings.deletePermanently
+        }
+    }
+
+    var systemImage: String {
+        switch self {
+        case .approve: "checkmark"
+        case .unapprove: "clock"
+        case .spam: "exclamationmark.bubble"
+        case .trash: "trash"
+        case .restore: "arrow.uturn.backward"
+        case .delete: "trash"
+        }
+    }
+
+    var role: ButtonRole? {
+        switch self {
+        case .spam, .trash, .delete: .destructive
+        case .approve, .unapprove, .restore: nil
+        }
+    }
+}
+
+/// The pinned bottom moderation bar. Hosted via `.safeAreaInset(edge: .bottom)`
+/// so it renders inside the UIKit `UIHostingController`; Trash gates behind a
+/// confirmation dialog when the comment has replies, Delete Permanently always.
+/// Each dialog is attached to its own button so it anchors there when
+/// presented as a popover.
+struct CommentModerationToolbar: View {
+    let model: CommentModerationToolbarModel
+    let isEnabled: Bool
+    /// The action whose request is in flight; its button shows a spinner in
+    /// place of its label while the pessimistic request round-trips.
+    let pendingAction: CommentModerationAction?
+    let trashConfirmation: CommentDetailViewModel.TrashConfirmation
+    let perform: (CommentModerationAction) -> Void
+
+    @State private var isTrashConfirmationPresented = false
+    @State private var isDeleteConfirmationPresented = false
+
+    var body: some View {
+        buttons
+            .controlSize(.large)
+            .disabled(!isEnabled)
+            .padding(.horizontal)
+            .padding(.vertical, 10)
+            .frame(maxWidth: .infinity)
+    }
+
+    @ViewBuilder
+    private var buttons: some View {
+        switch model {
+        case .pending:
+            VStack(spacing: 10) {
+                approveButton
+                spamTrashRow
+            }
+        case .approved:
+            spamTrashRow
+        case .inBin:
+            VStack(spacing: 10) {
+                restoreButton
+                deleteButton
+            }
+        case .hidden:
+            EmptyView()
+        }
+    }
+
+    private var approveButton: some View {
+        button(for: .approve) { perform(.approve) }
+            .buttonStyle(.borderedProminent)
+    }
+
+    private var spamTrashRow: some View {
+        HStack(spacing: 10) {
+            button(for: .spam) { perform(.spam) }
+            button(for: .trash) { requestTrash() }
+                .confirmationDialog(
+                    trashConfirmationTitle,
+                    isPresented: $isTrashConfirmationPresented,
+                    titleVisibility: .visible
+                ) {
+                    Button(Strings.trashConfirmButton, role: .destructive) { perform(.trash) }
+                }
+        }
+        .buttonStyle(.bordered)
+    }
+
+    private var restoreButton: some View {
+        button(for: .restore) { perform(.restore) }
+            .buttonStyle(.bordered)
+    }
+
+    private var deleteButton: some View {
+        button(for: .delete) { isDeleteConfirmationPresented = true }
+            .buttonStyle(.bordered)
+            .confirmationDialog(
+                Strings.deleteConfirmTitle,
+                isPresented: $isDeleteConfirmationPresented,
+                titleVisibility: .visible
+            ) {
+                Button(Strings.deletePermanently, role: .destructive) { perform(.delete) }
+            } message: {
+                Text(Strings.deleteConfirmMessage)
+            }
+    }
+
+    /// A full-width button for `action`, its label overlaid by a spinner while
+    /// its own action is the one in flight. The label stays in the layout
+    /// (hidden) so the button keeps its height, and the spinner keeps the
+    /// action's name so VoiceOver still says which action is running.
+    private func button(for action: CommentModerationAction, tap: @escaping () -> Void) -> some View {
+        let isPending = pendingAction == action
+        return Button(role: action.role, action: tap) {
+            Label(action.title, systemImage: action.systemImage)
+                .opacity(isPending ? 0 : 1)
+                .overlay {
+                    if isPending {
+                        ProgressView()
+                            .controlSize(.regular)
+                            .accessibilityLabel(action.title)
+                    }
+                }
+                .frame(maxWidth: .infinity)
+        }
+    }
+
+    /// Trash confirms only when the comment has replies (known or unknown
+    /// count); a leaf comment trashes without a prompt.
+    private func requestTrash() {
+        switch trashConfirmation {
+        case .none:
+            perform(.trash)
+        case .generic, .withReplies:
+            isTrashConfirmationPresented = true
+        }
+    }
+
+    private var trashConfirmationTitle: String {
+        if case .withReplies = trashConfirmation {
+            return Strings.trashHasReplies
+        }
+        return Strings.trashConfirmGenericTitle
+    }
+}

--- a/Modules/Sources/WordPressComments/Views/Detail/CommentStatusPill.swift
+++ b/Modules/Sources/WordPressComments/Views/Detail/CommentStatusPill.swift
@@ -1,12 +1,13 @@
-import DesignSystem
 import SwiftUI
 
-/// The pinned status pill above the author header.
+/// The pinned status pill above the author header. Reads the live header
+/// status (the screen's status source of truth), so it stays in sync while a
+/// moderation action settles.
 struct CommentStatusPill: View {
     let status: CommentListItem.Status
 
     var body: some View {
-        Text(label)
+        Label(label, systemImage: symbol)
             .font(.footnote.weight(.semibold))
             .foregroundStyle(tint)
             .padding(.horizontal, 10)
@@ -17,11 +18,20 @@ struct CommentStatusPill: View {
 
     private var tint: Color {
         switch status {
-        case .approved: Color(UIAppColor.green(.shade40))
-        case .pending: Color(UIAppColor.yellow(.shade20))
-        case .spam: Color(UIAppColor.orange(.shade40))
-        case .trash: Color(UIAppColor.red(.shade40))
-        case .other: Color(UIAppColor.gray(.shade30))
+        case .approved: .green
+        case .pending: .orange
+        case .spam, .trash: .red
+        case .other: .gray
+        }
+    }
+
+    private var symbol: String {
+        switch status {
+        case .approved: "checkmark.circle"
+        case .pending: "clock"
+        case .spam: "nosign"
+        case .trash: "trash"
+        case .other: "questionmark.circle"
         }
     }
 

--- a/Modules/Sources/WordPressComments/Views/PreviewSupport.swift
+++ b/Modules/Sources/WordPressComments/Views/PreviewSupport.swift
@@ -1,0 +1,36 @@
+#if DEBUG
+import Foundation
+
+/// Canned service for SwiftUI previews. Every fetch resolves to
+/// `CommentDetail.preview`; `fetchedStatus` and `numberOfReplies` shape the
+/// detail screen's toolbar and trash confirmation.
+@MainActor
+final class PreviewCommentsService: CommentsServiceProtocol {
+    private let fetchedStatus: CommentListItem.Status
+    private let replyCount: Int
+
+    init(fetchedStatus: CommentListItem.Status = .pending, numberOfReplies: Int = 0) {
+        self.fetchedStatus = fetchedStatus
+        self.replyCount = numberOfReplies
+    }
+
+    func listComments(filter: CommentsListFilter, nextPage: CommentsPageToken?) async throws -> CommentsPage {
+        CommentsPage(items: [], nextPage: nil)
+    }
+
+    func fetchComment(id: Int64, allowsEditContext: Bool) async throws -> CommentDetail {
+        .preview(id: id, status: fetchedStatus)
+    }
+
+    func fetchStatus(id: Int64) async throws -> CommentListItem.Status { fetchedStatus }
+    func setStatus(id: Int64, _ status: CommentListItem.Status) async throws -> CommentDetail { .preview() }
+    func restore(id: Int64, from bin: CommentListItem.Status) async throws -> CommentDetail { .preview() }
+    func trash(id: Int64) async throws {}
+    func delete(id: Int64) async throws {}
+    func numberOfReplies(for id: Int64) async throws -> Int { replyCount }
+}
+
+struct PreviewCapabilities: CommentsCapabilitiesProtocol {
+    func canModerateComments() async -> Bool { true }
+}
+#endif

--- a/Modules/Tests/WordPressCommentsTests/CommentDetailViewModelTests.swift
+++ b/Modules/Tests/WordPressCommentsTests/CommentDetailViewModelTests.swift
@@ -9,9 +9,10 @@ struct CommentDetailViewModelTests {
         let seed = makeItem(id: 1, authorName: "Ada", post: 42, status: .hold)
         let vm = makeVM(seed: seed, service: FakeCommentsService())
 
-        #expect(vm.header?.authorName == "Ada")
-        #expect(vm.header?.postID == 42)
-        #expect(vm.header?.status == .pending)
+        let header = vm.header
+        #expect(header?.authorName == "Ada")
+        #expect(header?.postID == 42)
+        #expect(header?.status == .pending)
     }
 
     @Test func seedlessHeaderIsNilUntilFetch() async {
@@ -28,16 +29,14 @@ struct CommentDetailViewModelTests {
     @Test func capabilityTrueFetchesEditContext() async {
         let service = FakeCommentsService()
         service.fetchCommentResult = .success(makeDetail(id: 1, editContext: true))
-        let capabilities = FakeCommentsCapabilities()
-        capabilities.canModerate = true
-        let vm = makeVM(service: service, capabilities: capabilities)
+        let vm = makeVM(service: service)
 
         await vm.onAppear()
 
         #expect(service.fetchCommentInvocations.last?.allowsEditContext == true)
     }
 
-    @Test func capabilityFalseFetchesViewContext() async {
+    @Test func capabilityFalseFetchesViewContextAndHidesToolbar() async {
         let service = FakeCommentsService()
         service.fetchCommentResult = .success(makeDetail(id: 1))
         let capabilities = FakeCommentsCapabilities()
@@ -47,44 +46,238 @@ struct CommentDetailViewModelTests {
         await vm.onAppear()
 
         #expect(service.fetchCommentInvocations.last?.allowsEditContext == false)
+        #expect(vm.showsToolbar == false)
     }
 
-    @Test func duplicateAppearanceDoesNotRefetchAfterSuccess() async {
+    @Test func editContextFallbackHidesToolbar() async {
+        // Capability says canModerate, but the fetch fell back to view context
+        // (hasEditContext == false): a stale, demoted capability. The toolbar
+        // must hide for this screen.
         let service = FakeCommentsService()
-        service.fetchCommentResult = .success(makeDetail(id: 1))
+        service.fetchCommentResult = .success(makeDetail(id: 1, editContext: false))
         let vm = makeVM(service: service)
 
         await vm.onAppear()
-        await vm.onAppear()
 
-        #expect(service.fetchCommentInvocations.count == 1)
+        #expect(service.fetchCommentInvocations.last?.allowsEditContext == true)
+        #expect(vm.showsToolbar == false)
     }
 
-    @Test func duplicateAppearanceDoesNotStartConcurrentFetch() async {
+    @Test func toolbarDisabledUntilFetchCompletes() async {
         let service = BlockingCommentsService()
         let vm = makeVM(service: service)
 
-        async let firstAppearance: Void = vm.onAppear()
-        while service.fetchCommentInvocations.isEmpty { await Task.yield() }
-        await vm.onAppear()
+        async let appear: Void = vm.onAppear()
+        await waitUntil { !service.fetchCommentInvocations.isEmpty }
 
-        #expect(service.fetchCommentInvocations.count == 1)
-        service.resolveFetch(callIndex: 0, with: makeDetail(id: 1))
-        await firstAppearance
+        // Capability resolved, fetch still in flight: toolbar renders but is
+        // disabled until authoritative truth lands.
+        #expect(vm.showsToolbar == true)
+        #expect(vm.isToolbarEnabled == false)
+
+        service.resolveFetch(callIndex: 0, with: makeDetail(id: 1, editContext: true))
+        await appear
+
+        #expect(vm.isToolbarEnabled == true)
     }
 
-    @Test func failedFetchShowsFailureAndRetryLoadsDetail() async {
+    // MARK: - Pessimistic moderation
+
+    @Test func performKeepsPreActionStatusWhileRequestInFlight() async {
+        let noticePresenter = FakeNoticePresenter()
+        let coordinatorService = BlockingCommentsService()
+        let coordinator = CommentsModerationCoordinator(service: coordinatorService)
+        let vm = await makeLoadedVM(status: .hold, coordinator: coordinator, noticePresenter: noticePresenter)
+        #expect(vm.header?.status == .pending)
+        #expect(vm.isToolbarEnabled)
+
+        vm.perform(.approve)
+        // The spinner state is set synchronously; the toolbar disables at once.
+        #expect(vm.pendingAction == .approve)
+        #expect(vm.isToolbarEnabled == false)
+
+        await waitUntil { !coordinatorService.setStatusInvocations.isEmpty }
+        // Still blocked on the request: the status stays pre-action (no
+        // optimistic flip) and nothing is emitted yet.
+        #expect(vm.header?.status == .pending)
+        #expect(noticePresenter.presented.isEmpty)
+
+        coordinatorService.resolveSetStatus(callIndex: 0, with: makeDetail(id: 1, status: .approved, editContext: true))
+        await waitUntil { vm.pendingAction == nil }
+
+        // Only after the request succeeds does the status flip and the toolbar
+        // re-enable.
+        #expect(vm.header?.status == .approved)
+        #expect(vm.isToolbarEnabled)
+    }
+
+    @Test func performSuccessUpdatesStatusAndClearsPending() async {
+        let noticePresenter = FakeNoticePresenter()
+        let coordinatorService = FakeCommentsService()
+        coordinatorService.setStatusResult = .success(makeDetail(id: 1, status: .approved))
+        let coordinator = CommentsModerationCoordinator(service: coordinatorService)
+        let vm = await makeLoadedVM(status: .hold, coordinator: coordinator, noticePresenter: noticePresenter)
+        vm.perform(.approve)
+        await waitUntil { vm.pendingAction == nil }
+
+        #expect(vm.header?.status == .approved)
+        #expect(vm.pendingAction == nil)
+        #expect(noticePresenter.presented.isEmpty)
+        #expect(vm.isToolbarEnabled)
+    }
+
+    @Test func performFailureKeepsStatusAndShowsNotice() async {
+        let noticePresenter = FakeNoticePresenter()
+        let coordinatorService = FakeCommentsService()
+        coordinatorService.setStatusResult = .failure(FakeServiceError())
+        let coordinator = CommentsModerationCoordinator(service: coordinatorService)
+        let vm = await makeLoadedVM(status: .hold, coordinator: coordinator, noticePresenter: noticePresenter)
+        vm.perform(.approve)
+        await waitUntil { vm.pendingAction == nil }
+
+        // The action genuinely failed: the screen stays on the pre-action
+        // status, posts the app-wide notice, and re-enables the toolbar.
+        #expect(vm.header?.status == .pending)
+        #expect(noticePresenter.presented == ["That action couldn't be completed. Please try again."])
+        #expect(vm.pendingAction == nil)
+        #expect(vm.isToolbarEnabled)
+    }
+
+    @Test func secondPerformAfterFailurePresentsSecondNotice() async {
+        let noticePresenter = FakeNoticePresenter()
+        let coordinatorService = FakeCommentsService()
+        coordinatorService.setStatusResult = .failure(FakeServiceError())
+        let coordinator = CommentsModerationCoordinator(service: coordinatorService)
+        let vm = await makeLoadedVM(status: .hold, coordinator: coordinator, noticePresenter: noticePresenter)
+        vm.perform(.approve)
+        await waitUntil { vm.pendingAction == nil }
+        #expect(noticePresenter.presented.count == 1)
+
+        vm.perform(.approve)
+        await waitUntil { vm.pendingAction == nil }
+        #expect(
+            noticePresenter.presented == [
+                "That action couldn't be completed. Please try again.",
+                "That action couldn't be completed. Please try again."
+            ]
+        )
+    }
+
+    @Test func actionBeforeFetchIsIgnored() async {
+        let service = BlockingCommentsService()
+        let coordinatorService = FakeCommentsService()
+        let coordinator = CommentsModerationCoordinator(service: coordinatorService)
+        let vm = makeVM(service: service, coordinator: coordinator)
+
+        async let appear: Void = vm.onAppear()
+        await waitUntil { !service.fetchCommentInvocations.isEmpty }
+
+        // Fetch not yet landed: an action must be ignored (no mutation, no
+        // pending state).
+        vm.perform(.spam)
+        #expect(vm.pendingAction == nil)
+        #expect(coordinatorService.setStatusInvocations.isEmpty)
+
+        service.resolveFetch(callIndex: 0, with: makeDetail(id: 1, editContext: true))
+        await appear
+    }
+
+    @Test func toolbarDisabledWhileMutationInFlight() async {
+        let coordinatorService = BlockingCommentsService()
+        let coordinator = CommentsModerationCoordinator(service: coordinatorService)
+        let vm = await makeLoadedVM(status: .approved, coordinator: coordinator)
+        #expect(vm.isToolbarEnabled == true)
+
+        vm.perform(.spam)
+        #expect(vm.pendingAction == .spam)
+        #expect(vm.isToolbarEnabled == false)
+
+        await waitUntil { !coordinatorService.setStatusInvocations.isEmpty }
+        #expect(vm.isToolbarEnabled == false)
+        coordinatorService.resolveSetStatus(callIndex: 0, with: makeDetail(id: 1, status: .spam, editContext: true))
+        await waitUntil { vm.pendingAction == nil }
+
+        #expect(vm.isToolbarEnabled == true)
+    }
+
+    @Test func seedStatusMismatchEmitsEvent() async {
+        let seed = makeItem(id: 1, status: .hold) // list showed pending
         let service = FakeCommentsService()
-        service.fetchCommentResult = .failure(FakeServiceError())
-        let vm = makeVM(service: service)
+        service.fetchCommentResult = .success(makeDetail(id: 1, status: .approved)) // server says approved
+        let coordinator = CommentsModerationCoordinator(service: FakeCommentsService())
+        let recorder = EventRecorder(coordinator)
+        let vm = makeVM(seed: seed, service: service, coordinator: coordinator)
 
         await vm.onAppear()
-        #expect(vm.content == .failed)
 
-        service.fetchCommentResult = .success(makeDetail(id: 1, status: .approved))
-        await vm.retry()
+        #expect(recorder.events == [.statusChanged(id: 1, to: .approved)])
+        #expect(vm.header?.status == .approved)
+    }
 
-        #expect(vm.content == .loaded(makeDetail(id: 1, status: .approved)))
+    @Test func reEntryFetchAwaitsPendingMutation() async {
+        let coordinatorService = BlockingCommentsService()
+        let coordinator = CommentsModerationCoordinator(service: coordinatorService)
+        // A mutation is already in flight for this comment (started elsewhere).
+        let mutation = Task { try? await coordinator.perform(.approve, on: makeDetail(id: 1, status: .hold)) }
+        await waitUntil { !coordinatorService.setStatusInvocations.isEmpty }
+
+        let service = FakeCommentsService()
+        service.fetchCommentResult = .success(makeDetail(id: 1, editContext: true))
+        let vm = makeVM(service: service, coordinator: coordinator)
+
+        async let appear: Void = vm.onAppear()
+        // Let the VM resolve capability and park on the pending-mutation wait.
+        await waitUntil { vm.canModerate != nil }
+        await Task.yield()
+        #expect(service.fetchCommentInvocations.isEmpty)
+
+        coordinatorService.resolveSetStatus(callIndex: 0, with: makeDetail(id: 1, status: .approved))
+        await appear
+        _ = await mutation.value
+
+        #expect(service.fetchCommentInvocations.isEmpty == false)
+    }
+
+    @Test func subscribedEventUpdatesLoadedStatus() async {
+        let service = FakeCommentsService()
+        service.fetchCommentResult = .success(makeDetail(id: 1, status: .approved, editContext: true))
+        let coordinator = CommentsModerationCoordinator(service: FakeCommentsService())
+        let vm = makeVM(service: service, coordinator: coordinator)
+
+        await vm.onAppear()
+        #expect(vm.header?.status == .approved)
+
+        // A late status change for this comment arrives while the screen is open.
+        coordinator.noteExternalStatus(id: 1, to: .spam)
+
+        #expect(vm.header?.status == .spam)
+    }
+
+    @Test func trashConfirmationVariants() async {
+        // nil replies -> generic confirmation.
+        let unknownService = FakeCommentsService()
+        unknownService.fetchCommentResult = .success(makeDetail(id: 1))
+        unknownService.numberOfRepliesResult = .failure(FakeServiceError())
+        let unknownVM = makeVM(service: unknownService)
+        await unknownVM.onAppear()
+        #expect(unknownVM.numberOfReplies == nil)
+        #expect(unknownVM.trashConfirmation == .generic)
+
+        // 0 replies -> no confirmation.
+        let zeroService = FakeCommentsService()
+        zeroService.fetchCommentResult = .success(makeDetail(id: 1))
+        zeroService.numberOfRepliesResult = .success(0)
+        let zeroVM = makeVM(service: zeroService)
+        await zeroVM.onAppear()
+        #expect(zeroVM.trashConfirmation == .none)
+
+        // >0 replies -> reply-count confirmation.
+        let manyService = FakeCommentsService()
+        manyService.fetchCommentResult = .success(makeDetail(id: 1))
+        manyService.numberOfRepliesResult = .success(3)
+        let manyVM = makeVM(service: manyService)
+        await manyVM.onAppear()
+        #expect(manyVM.trashConfirmation == .withReplies)
     }
 
     @Test func parentPreviewLoadedForReply() async {
@@ -98,16 +291,101 @@ struct CommentDetailViewModelTests {
         await vm.onAppear()
 
         #expect(vm.parentPreview?.id == 5)
+        // The parent is fetched with view context regardless of capability.
         #expect(service.fetchCommentInvocations.contains { $0.id == 5 && $0.allowsEditContext == false })
     }
 
     @Test func parentFetchFailureHidesStrip() async {
         let service = FakeCommentsService()
+        service.numberOfRepliesResult = .success(0)
+        // 5 is missing: the parent fetch throws.
         service.fetchCommentResultsByID = [1: .success(makeDetail(id: 1, parent: 5))]
         let vm = makeVM(service: service)
 
         await vm.onAppear()
 
         #expect(vm.parentPreview == nil)
+    }
+
+    @Test func statusChangeWhileHiddenIsAppliedOnReturn() async {
+        let service = FakeCommentsService()
+        service.fetchCommentResult = .success(makeDetail(id: 1, status: .approved, editContext: true))
+        let coordinator = CommentsModerationCoordinator(service: FakeCommentsService())
+        let vm = makeVM(service: service, coordinator: coordinator)
+
+        await vm.onAppear()
+        #expect(vm.header?.status == .approved)
+
+        // The screen is hidden because a parent detail was pushed on top. The
+        // subscription is not torn down on disappearance, so a status change
+        // that lands for this comment while it is hidden is still applied and is
+        // reflected on return.
+        coordinator.noteExternalStatus(id: 1, to: .spam)
+
+        #expect(vm.header?.status == .spam)
+    }
+
+    // MARK: - Terminal (deleted) state
+
+    @Test func deletedEventTerminatesAndLaterStatusChangeReenables() async {
+        let service = FakeCommentsService()
+        service.fetchCommentResult = .success(makeDetail(id: 1, status: .approved, editContext: true))
+        let coordinator = CommentsModerationCoordinator(service: FakeCommentsService())
+        let vm = makeVM(service: service, coordinator: coordinator)
+
+        await vm.onAppear()
+        #expect(vm.showsToolbar == true)
+
+        // A permanent delete succeeds and its `.deleted` event terminates the
+        // screen: the toolbar turns off.
+        try? await coordinator.perform(.delete, on: makeDetail(id: 1, status: .approved))
+        #expect(vm.isDeleted)
+        #expect(vm.showsToolbar == false)
+
+        // A later status change proves the comment exists again, clearing the
+        // terminal state so the toolbar re-enables.
+        coordinator.noteExternalStatus(id: 1, to: .approved)
+        #expect(!vm.isDeleted)
+        #expect(vm.showsToolbar == true)
+    }
+
+    @Test func deletedThenFailedRetryStaysTerminated() async {
+        let service = FakeCommentsService()
+        service.fetchCommentResult = .success(makeDetail(id: 1, status: .approved, editContext: true))
+        let coordinator = CommentsModerationCoordinator(service: FakeCommentsService())
+        let vm = makeVM(service: service, coordinator: coordinator)
+
+        await vm.onAppear()
+        try? await coordinator.perform(.delete, on: makeDetail(id: 1, status: .approved))
+        #expect(vm.isDeleted)
+
+        // The comment is genuinely gone: the retry fetch fails. It must surface
+        // as failed and stay terminal rather than falsely re-enabling the
+        // toolbar.
+        service.fetchCommentResult = .failure(WpApiError.stub(statusCode: 404))
+        await vm.retry()
+        #expect(vm.content == .failed)
+        #expect(vm.isDeleted)
+        #expect(vm.showsToolbar == false)
+    }
+
+    // MARK: - Failure after deallocation
+
+    @Test func failureAfterViewModelDeallocatedStillPresentsNotice() async {
+        let noticePresenter = FakeNoticePresenter()
+        let coordinatorService = BlockingCommentsService()
+        let coordinator = CommentsModerationCoordinator(service: coordinatorService)
+        var vm: CommentDetailViewModel? = await makeLoadedVM(status: .hold, coordinator: coordinator, noticePresenter: noticePresenter)
+        vm!.perform(.approve)
+        await waitUntil { !coordinatorService.setStatusInvocations.isEmpty }
+
+        // The screen is torn down while the request is still in flight.
+        vm = nil
+
+        // The request then fails. The request task retains the app-wide
+        // presenter even though the detail view model is gone.
+        coordinatorService.failSetStatus(callIndex: 0, with: FakeServiceError())
+        await waitUntil { !noticePresenter.presented.isEmpty }
+        #expect(noticePresenter.presented == ["That action couldn't be completed. Please try again."])
     }
 }

--- a/Modules/Tests/WordPressCommentsTests/CommentDetailViewModelTests.swift
+++ b/Modules/Tests/WordPressCommentsTests/CommentDetailViewModelTests.swift
@@ -280,6 +280,31 @@ struct CommentDetailViewModelTests {
         #expect(manyVM.trashConfirmation == .withReplies)
     }
 
+    @Test func actionsWaitForReplyCountAfterDetailRenders() async {
+        let service = BlockingCommentsService()
+        service.numberOfRepliesResult = nil
+        let vm = makeVM(service: service)
+        let detail = makeDetail(id: 1, editContext: true)
+
+        async let appear: Void = vm.onAppear()
+        await waitUntil { !service.fetchCommentInvocations.isEmpty }
+        service.resolveFetch(callIndex: 0, with: detail)
+        await waitUntil { !service.numberOfRepliesInvocations.isEmpty }
+
+        // The comment is on screen while the count is still in flight, but
+        // actions wait for it so a reply can't race a stale count.
+        #expect(vm.content == .loaded(detail))
+        #expect(!vm.isToolbarEnabled)
+        #expect(vm.trashConfirmation == .generic)
+
+        service.resolveNumberOfReplies(callIndex: 0, with: 3)
+        await appear
+
+        #expect(vm.isToolbarEnabled)
+        #expect(vm.numberOfReplies == 3)
+        #expect(vm.trashConfirmation == .withReplies)
+    }
+
     @Test func parentPreviewLoadedForReply() async {
         let service = FakeCommentsService()
         service.fetchCommentResultsByID = [

--- a/Modules/Tests/WordPressCommentsTests/CommentModerationToolbarModelTests.swift
+++ b/Modules/Tests/WordPressCommentsTests/CommentModerationToolbarModelTests.swift
@@ -1,0 +1,58 @@
+import Testing
+@testable import WordPressComments
+
+struct CommentModerationToolbarModelTests {
+    @Test func pendingStatusShowsPendingModel() {
+        #expect(CommentModerationToolbarModel.make(status: .pending, showsToolbar: true) == .pending)
+    }
+
+    @Test func approvedStatusShowsApprovedModel() {
+        #expect(CommentModerationToolbarModel.make(status: .approved, showsToolbar: true) == .approved)
+    }
+
+    @Test func spamStatusShowsBinModelRestoringFromSpam() {
+        #expect(
+            CommentModerationToolbarModel.make(status: .spam, showsToolbar: true)
+                == .inBin
+        )
+    }
+
+    @Test func trashStatusShowsBinModelRestoringFromTrash() {
+        #expect(
+            CommentModerationToolbarModel.make(status: .trash, showsToolbar: true)
+                == .inBin
+        )
+    }
+
+    @Test func otherStatusIsHiddenEvenWhenToolbarShows() {
+        #expect(CommentModerationToolbarModel.make(status: .other("archived"), showsToolbar: true) == .hidden)
+    }
+
+    @Test func nilStatusIsHidden() {
+        #expect(CommentModerationToolbarModel.make(status: nil, showsToolbar: true) == .hidden)
+    }
+
+    @Test(arguments: [
+        CommentListItem.Status.pending,
+        .approved,
+        .spam,
+        .trash,
+        .other("archived")
+    ])
+    func toolbarOffForcesHidden(_ status: CommentListItem.Status) {
+        #expect(CommentModerationToolbarModel.make(status: status, showsToolbar: false) == .hidden)
+    }
+
+    @Test func nilStatusWithToolbarOffIsHidden() {
+        #expect(CommentModerationToolbarModel.make(status: nil, showsToolbar: false) == .hidden)
+    }
+
+    @Test func approvedModelMovesUnapproveToTheMenu() {
+        #expect(CommentModerationToolbarModel.approved.menuAction == .unapprove)
+    }
+
+    @Test(arguments: [CommentModerationToolbarModel.pending, .inBin, .hidden])
+    func pendingBinAndHiddenModelsHaveNoMenuAction(_ model: CommentModerationToolbarModel) {
+        #expect(model.menuAction == nil)
+    }
+}

--- a/Modules/Tests/WordPressCommentsTests/CommentsAnalyticsTests.swift
+++ b/Modules/Tests/WordPressCommentsTests/CommentsAnalyticsTests.swift
@@ -5,9 +5,12 @@ import WordPressAPI
 
 @MainActor
 struct CommentsAnalyticsTests {
+    // MARK: - detailViewed
+
     @Test func detailViewedFiresOnceOnFirstSuccessfulFetch() async {
         let service = FakeCommentsService()
         service.fetchCommentResult = .success(makeDetail(id: 7, post: 42))
+        service.numberOfRepliesResult = .success(0)
         let spy = SpyCommentsTracker()
         let vm = makeVM(commentID: 7, service: service, tracker: spy)
 
@@ -26,6 +29,75 @@ struct CommentsAnalyticsTests {
         let vm = makeVM(commentID: 7, service: service, tracker: spy)
 
         await vm.onAppear()
+
+        #expect(spy.trackedEvents.isEmpty)
+    }
+
+    // MARK: - action events
+
+    @Test(arguments: [
+        (CommentModerationAction.approve, CommentStatus.approved, CommentsTrackedEvent.approved(commentID: 1, postID: 10)),
+        (.unapprove, .hold, .unapproved(commentID: 1, postID: 10)),
+        (.spam, .spam, .spammed(commentID: 1, postID: 10))
+    ])
+    func statusWriteTracksItsEventOnSuccess(
+        action: CommentModerationAction,
+        landed: CommentStatus,
+        expected: CommentsTrackedEvent
+    ) async {
+        let spy = SpyCommentsTracker()
+        let service = FakeCommentsService()
+        service.setStatusResult = .success(makeDetail(id: 1, post: 10, status: landed))
+        let coordinator = CommentsModerationCoordinator(service: service, tracker: spy)
+
+        try? await coordinator.perform(action, on: makeDetail(id: 1, post: 10))
+
+        #expect(spy.trackedEvents == [expected])
+    }
+
+    @Test func trashTracksTrashedOnSuccess() async {
+        let spy = SpyCommentsTracker()
+        let service = FakeCommentsService()
+        // trash() succeeds when no error is queued.
+        let coordinator = CommentsModerationCoordinator(service: service, tracker: spy)
+
+        try? await coordinator.perform(.trash, on: makeDetail(id: 1, post: 10, status: .approved))
+
+        #expect(spy.trackedEvents == [.trashed(commentID: 1, postID: 10)])
+    }
+
+    @Test func restoreIsNotTracked() async {
+        let spy = SpyCommentsTracker()
+        let service = FakeCommentsService()
+        // Restore probes first; the comment is still in the bin, so it issues.
+        service.fetchStatusResults = [.success(.spam)]
+        service.setStatusResult = .success(makeDetail(id: 1, post: 10, status: .approved))
+        let coordinator = CommentsModerationCoordinator(service: service, tracker: spy)
+
+        try? await coordinator.perform(.restore, on: makeDetail(id: 1, post: 10, status: .spam))
+
+        #expect(spy.trackedEvents.isEmpty)
+    }
+
+    @Test func deleteIsNotTracked() async {
+        let spy = SpyCommentsTracker()
+        let service = FakeCommentsService()
+        let coordinator = CommentsModerationCoordinator(service: service, tracker: spy)
+
+        try? await coordinator.perform(.delete, on: makeDetail(id: 1, post: 10, status: .trash))
+
+        #expect(spy.trackedEvents.isEmpty)
+    }
+
+    @Test func failedActionIsNotTracked() async {
+        let spy = SpyCommentsTracker()
+        let service = FakeCommentsService()
+        // A genuine failure (no error code and no 404): the action definitively
+        // did not succeed, so nothing is tracked.
+        service.setStatusResult = .failure(FakeServiceError())
+        let coordinator = CommentsModerationCoordinator(service: service, tracker: spy)
+
+        try? await coordinator.perform(.approve, on: makeDetail(id: 1, post: 10, status: .hold))
 
         #expect(spy.trackedEvents.isEmpty)
     }

--- a/Modules/Tests/WordPressCommentsTests/CommentsDetailRouterTests.swift
+++ b/Modules/Tests/WordPressCommentsTests/CommentsDetailRouterTests.swift
@@ -11,8 +11,10 @@ struct CommentsDetailRouterTests {
         let router = CommentsDetailRouter(
             service: FakeCommentsService(),
             capabilities: FakeCommentsCapabilities(),
+            coordinator: CommentsModerationCoordinator(service: FakeCommentsService()),
             titleResolver: PostTitleResolver(fetcher: { _ in .init(titles: [:]) }),
             tracker: nil,
+            noticePresenter: FakeNoticePresenter(),
             makeContentRenderer: { FakeContentRenderer() }
         )
         router.host = host

--- a/Modules/Tests/WordPressCommentsTests/CommentsHostingControllerTests.swift
+++ b/Modules/Tests/WordPressCommentsTests/CommentsHostingControllerTests.swift
@@ -1,0 +1,35 @@
+import SwiftUI
+import Testing
+@testable import WordPressComments
+
+@MainActor
+struct CommentsHostingControllerTests {
+    @Test func viewWillAppearReloadsOnlyTabsAwaitingStaleReload() async {
+        let service = FakeCommentsService()
+        service.queuedResults = [
+            .success(makePage(items: [makeItem(id: 1)], hasNext: false)),
+            .failure(FakeServiceError()),
+            .success(makePage(items: [makeItem(id: 2)], hasNext: false))
+        ]
+        let staleTab = CommentsListViewModel(filter: .all, service: service)
+        await staleTab.onAppear()
+        // A change event stales the tab and its eager reload fails while the
+        // list is off screen.
+        staleTab.apply(.statusChanged(id: 99, to: .pending))
+        await staleTab.onAppear()
+        #expect(staleTab.state == .awaitingReload)
+        let neverLoadedTab = CommentsListViewModel(filter: .pending, service: service)
+
+        let controller = CommentsRootHostingController(
+            rootView: EmptyView(),
+            listViewModels: [staleTab, neverLoadedTab]
+        )
+        controller.beginAppearanceTransition(true, animated: false)
+        controller.endAppearanceTransition()
+        await waitUntil { staleTab.state == .loaded }
+
+        #expect(staleTab.items.map(\.id) == [2])
+        // The never-loaded tab is left to its own first appearance.
+        #expect(service.requests.map(\.filter) == [.all, .all, .all])
+    }
+}

--- a/Modules/Tests/WordPressCommentsTests/CommentsListFilterMembershipTests.swift
+++ b/Modules/Tests/WordPressCommentsTests/CommentsListFilterMembershipTests.swift
@@ -1,0 +1,26 @@
+import Testing
+@testable import WordPressComments
+
+struct CommentsListFilterMembershipTests {
+    @Test func allMatchesOnlyPendingAndApproved() {
+        #expect(CommentsListFilter.all.matches(.pending))
+        #expect(CommentsListFilter.all.matches(.approved))
+        #expect(!CommentsListFilter.all.matches(.spam))
+        #expect(!CommentsListFilter.all.matches(.trash))
+        #expect(!CommentsListFilter.all.matches(.other("post-trashed")))
+    }
+
+    @Test func exactFiltersMatchOnlyTheirStatus() {
+        #expect(CommentsListFilter.pending.matches(.pending))
+        #expect(!CommentsListFilter.pending.matches(.approved))
+        #expect(CommentsListFilter.approved.matches(.approved))
+        #expect(CommentsListFilter.spam.matches(.spam))
+        #expect(CommentsListFilter.trash.matches(.trash))
+    }
+
+    @Test func customStatusMatchesNoFilter() {
+        for filter in CommentsListFilter.allCases {
+            #expect(!filter.matches(.other("weird")))
+        }
+    }
+}

--- a/Modules/Tests/WordPressCommentsTests/CommentsListViewModelConcurrencyTests.swift
+++ b/Modules/Tests/WordPressCommentsTests/CommentsListViewModelConcurrencyTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Testing
+import WordPressAPI
 @testable import WordPressComments
 
 @MainActor
@@ -10,19 +11,19 @@ struct CommentsListViewModelConcurrencyTests {
 
         // First load (call 0).
         async let firstLoad: Void = viewModel.onAppear()
-        while service.callCount < 1 { await Task.yield() }
+        await waitUntil { service.callCount >= 1 }
         service.resolve(callIndex: 0, with: makePage(items: [makeItem(id: 1)], hasNext: true))
         await firstLoad
         #expect(viewModel.items.map(\.id) == [1])
 
         // Start load-more (call 1); it suspends before appending.
         async let more: Void = viewModel.loadMore()
-        while service.callCount < 2 { await Task.yield() }
+        await waitUntil { service.callCount >= 2 }
 
         // A refresh (call 2) lands and completes while load-more is still in
         // flight.
         async let refresh: Void = viewModel.refresh()
-        while service.callCount < 3 { await Task.yield() }
+        await waitUntil { service.callCount >= 3 }
         service.resolve(callIndex: 2, with: makePage(items: [makeItem(id: 9)], hasNext: false))
         await refresh
         #expect(viewModel.items.map(\.id) == [9])
@@ -32,5 +33,135 @@ struct CommentsListViewModelConcurrencyTests {
         service.resolve(callIndex: 1, with: makePage(items: [makeItem(id: 5)], hasNext: true))
         await more
         #expect(viewModel.items.map(\.id) == [9])
+    }
+
+    @Test func inFlightLoadMoreDoesNotResurrectModeratedRow() async {
+        let service = BlockingCommentsService()
+        let viewModel = CommentsListViewModel(filter: .all, service: service)
+
+        // First load (call 0): rows 1 and 5.
+        async let firstLoad: Void = viewModel.onAppear()
+        await waitUntil { service.callCount >= 1 }
+        service.resolve(callIndex: 0, with: makePage(items: [makeItem(id: 1), makeItem(id: 5)], hasNext: true))
+        await firstLoad
+        #expect(viewModel.items.map(\.id) == [1, 5])
+
+        // Start load-more (call 1); it suspends before appending.
+        async let more: Void = viewModel.loadMore()
+        await waitUntil { service.callCount >= 2 }
+
+        // A moderation removes row 5 while the page is in flight.
+        viewModel.apply(.deleted(id: 5))
+        #expect(viewModel.items.map(\.id) == [1])
+
+        // The in-flight page still contains row 5 (offset paging re-served it).
+        // The removal invalidated this fetch, so it must be discarded rather
+        // than re-adding row 5 as "fresh" (no longer in seenIDs).
+        service.resolve(callIndex: 1, with: makePage(items: [makeItem(id: 5), makeItem(id: 2)], hasNext: false))
+        await more
+        #expect(viewModel.items.map(\.id) == [1])
+    }
+
+    @Test func normalLoadMoreStillAppends() async {
+        let service = BlockingCommentsService()
+        let viewModel = CommentsListViewModel(filter: .all, service: service)
+
+        async let firstLoad: Void = viewModel.onAppear()
+        await waitUntil { service.callCount >= 1 }
+        service.resolve(callIndex: 0, with: makePage(items: [makeItem(id: 1)], hasNext: true))
+        await firstLoad
+
+        // A load-more with no intervening moderation appends normally.
+        async let more: Void = viewModel.loadMore()
+        await waitUntil { service.callCount >= 2 }
+        service.resolve(callIndex: 1, with: makePage(items: [makeItem(id: 2)], hasNext: false))
+        await more
+
+        #expect(viewModel.items.map(\.id) == [1, 2])
+    }
+
+    @Test func inFlightRefreshDoesNotResurrectModeratedRow() async {
+        let service = BlockingCommentsService()
+        let viewModel = CommentsListViewModel(filter: .all, service: service)
+
+        // First load (call 0): rows 1 and 5.
+        async let firstLoad: Void = viewModel.onAppear()
+        await waitUntil { service.callCount >= 1 }
+        service.resolve(callIndex: 0, with: makePage(items: [makeItem(id: 1), makeItem(id: 5)], hasNext: false))
+        await firstLoad
+        #expect(viewModel.items.map(\.id) == [1, 5])
+
+        // Start a refresh (call 1); it suspends before replacing the list.
+        async let refreshing: Void = viewModel.refresh()
+        await waitUntil { service.callCount >= 2 }
+
+        // A moderation removes row 5 while the refresh is in flight.
+        viewModel.apply(.deleted(id: 5))
+        #expect(viewModel.items.map(\.id) == [1])
+
+        // The in-flight refresh page still contains row 5 (pre-mutation). It must
+        // be discarded rather than replacing the list and resurrecting the row.
+        service.resolve(callIndex: 1, with: makePage(items: [makeItem(id: 1), makeItem(id: 5)], hasNext: false))
+        await refreshing
+        #expect(viewModel.items.map(\.id) == [1])
+    }
+
+    @Test func inFlightPageOneDoesNotOverwriteInPlaceStatusUpdate() async {
+        let service = BlockingCommentsService()
+        let viewModel = CommentsListViewModel(filter: .all, service: service)
+
+        // First load (call 0): row 1 pending.
+        async let firstLoad: Void = viewModel.onAppear()
+        await waitUntil { service.callCount >= 1 }
+        service.resolve(callIndex: 0, with: makePage(items: [makeItem(id: 1, status: .hold)], hasNext: false))
+        await firstLoad
+        #expect(viewModel.items.first?.status == .pending)
+
+        // Mark the tab stale (an approved comment that belongs here but is
+        // absent can't be placed in a paged list); the tab schedules its own
+        // page-one reload (call 1), which suspends.
+        viewModel.apply(.statusChanged(id: 99, to: .approved))
+        await waitUntil { service.callCount >= 2 }
+
+        // An approve reconciles the row in place while the reload is in flight,
+        // invalidating the in-flight page.
+        viewModel.apply(.statusChanged(id: 1, to: .approved))
+        #expect(viewModel.items.first?.status == .approved)
+
+        // The invalidated page must NOT overwrite the corrected status. Instead
+        // the reload refetches (exactly one more request) and converges on fresh
+        // authoritative data, without a manual refresh.
+        service.resolve(callIndex: 1, with: makePage(items: [makeItem(id: 1, status: .hold)], hasNext: false))
+        await waitUntil { service.callCount >= 3 }
+        service.resolve(callIndex: 2, with: makePage(items: [makeItem(id: 1, status: .approved)], hasNext: false))
+        await waitUntil { viewModel.state == .loaded }
+        #expect(viewModel.items.first?.status == .approved)
+        #expect(viewModel.state == .loaded)
+        #expect(service.callCount == 3)
+    }
+
+    @Test func inFlightInitialLoadInvalidationConvergesWithoutManualRefresh() async {
+        let service = BlockingCommentsService()
+        let viewModel = CommentsListViewModel(filter: .all, service: service)
+
+        // Initial load (call 0) is in flight.
+        async let load: Void = viewModel.onAppear()
+        await waitUntil { service.callCount >= 1 }
+
+        // A moderation event bumps generation mid-flight (invalidating the
+        // request) without marking the tab stale or bumping the reload counter,
+        // so nothing external would reschedule a reload.
+        viewModel.apply(.deleted(id: 99))
+
+        // The invalidated page is discarded, but loading converges on its own
+        // (exactly one more fetch) with no manual refresh or lifecycle event.
+        service.resolve(callIndex: 0, with: makePage(items: [makeItem(id: 1)], hasNext: false))
+        await waitUntil { service.callCount >= 2 }
+        service.resolve(callIndex: 1, with: makePage(items: [makeItem(id: 2)], hasNext: false))
+        await load
+
+        #expect(viewModel.items.map(\.id) == [2])
+        #expect(viewModel.state == .loaded)
+        #expect(service.callCount == 2)
     }
 }

--- a/Modules/Tests/WordPressCommentsTests/CommentsListViewModelEventTests.swift
+++ b/Modules/Tests/WordPressCommentsTests/CommentsListViewModelEventTests.swift
@@ -1,0 +1,453 @@
+import Foundation
+import Testing
+@testable import WordPressComments
+
+@MainActor
+struct CommentsListViewModelEventTests {
+    // MARK: - Approve (pending -> approved)
+
+    @Test func approveEventRemovesFromPendingTabAndDropsSeenID() async {
+        let service = FakeCommentsService()
+        service.queuedResults = [
+            .success(makePage(items: [makeItem(id: 1, status: .hold)], hasNext: true)),
+            .success(makePage(items: [makeItem(id: 1, status: .hold)], hasNext: false))
+        ]
+        let viewModel = CommentsListViewModel(filter: .pending, service: service)
+        await viewModel.onAppear()
+        #expect(viewModel.items.map(\.id) == [1])
+
+        viewModel.apply(.statusChanged(id: 1, to: .approved))
+        #expect(viewModel.items.isEmpty)
+        #expect(viewModel.state == .loaded)
+
+        // If seenIDs still contained the removed ID, loadMore's dedupe would
+        // silently drop this page and items would stay empty.
+        await viewModel.loadMore()
+        #expect(viewModel.items.map(\.id) == [1])
+    }
+
+    @Test func approveEventUpdatesRowInPlaceInAllTab() async {
+        let service = FakeCommentsService()
+        service.queuedResults = [.success(makePage(items: [makeItem(id: 1, status: .hold)], hasNext: false))]
+        let viewModel = CommentsListViewModel(filter: .all, service: service)
+        await viewModel.onAppear()
+
+        viewModel.apply(.statusChanged(id: 1, to: .approved))
+
+        #expect(viewModel.items.map(\.id) == [1])
+        #expect(viewModel.items[0].status == .approved)
+        #expect(viewModel.state == .loaded)
+    }
+
+    @Test func approveEventMarksApprovedTabStaleWhenMissingAndReloadsOnNextAppear() async {
+        let service = FakeCommentsService()
+        service.queuedResults = [
+            .success(makePage(items: [makeItem(id: 2, status: .approved)], hasNext: false)),
+            .success(
+                makePage(
+                    items: [makeItem(id: 1, status: .approved), makeItem(id: 2, status: .approved)],
+                    hasNext: false
+                )
+            )
+        ]
+        let viewModel = CommentsListViewModel(filter: .approved, service: service)
+        await viewModel.onAppear()
+        #expect(viewModel.items.map(\.id) == [2])
+
+        viewModel.apply(.statusChanged(id: 1, to: .approved))
+        #expect(viewModel.state == .awaitingReload)
+        #expect(viewModel.items.map(\.id) == [2])
+
+        await viewModel.onAppear()
+        #expect(viewModel.state == .loaded)
+        #expect(viewModel.items.map(\.id) == [1, 2])
+        #expect(service.requests.count == 2)
+    }
+
+    // MARK: - Unapprove (approved -> pending), mirror of approve
+
+    @Test func unapproveEventRemovesFromApprovedTabAndDropsSeenID() async {
+        let service = FakeCommentsService()
+        service.queuedResults = [
+            .success(makePage(items: [makeItem(id: 1, status: .approved)], hasNext: true)),
+            .success(makePage(items: [makeItem(id: 1, status: .approved)], hasNext: false))
+        ]
+        let viewModel = CommentsListViewModel(filter: .approved, service: service)
+        await viewModel.onAppear()
+        #expect(viewModel.items.map(\.id) == [1])
+
+        viewModel.apply(.statusChanged(id: 1, to: .pending))
+        #expect(viewModel.items.isEmpty)
+        #expect(viewModel.state == .loaded)
+
+        await viewModel.loadMore()
+        #expect(viewModel.items.map(\.id) == [1])
+    }
+
+    @Test func unapproveEventUpdatesRowInPlaceInAllTab() async {
+        let service = FakeCommentsService()
+        service.queuedResults = [.success(makePage(items: [makeItem(id: 1, status: .approved)], hasNext: false))]
+        let viewModel = CommentsListViewModel(filter: .all, service: service)
+        await viewModel.onAppear()
+
+        viewModel.apply(.statusChanged(id: 1, to: .pending))
+
+        #expect(viewModel.items.map(\.id) == [1])
+        #expect(viewModel.items[0].status == .pending)
+        #expect(viewModel.state == .loaded)
+    }
+
+    @Test func unapproveEventMarksPendingTabStaleWhenMissingAndReloadsOnNextAppear() async {
+        let service = FakeCommentsService()
+        service.queuedResults = [
+            .success(makePage(items: [makeItem(id: 2, status: .hold)], hasNext: false)),
+            .success(makePage(items: [makeItem(id: 1, status: .hold), makeItem(id: 2, status: .hold)], hasNext: false))
+        ]
+        let viewModel = CommentsListViewModel(filter: .pending, service: service)
+        await viewModel.onAppear()
+        #expect(viewModel.items.map(\.id) == [2])
+
+        viewModel.apply(.statusChanged(id: 1, to: .pending))
+        #expect(viewModel.state == .awaitingReload)
+        #expect(viewModel.items.map(\.id) == [2])
+
+        await viewModel.onAppear()
+        #expect(viewModel.state == .loaded)
+        #expect(viewModel.items.map(\.id) == [1, 2])
+        #expect(service.requests.count == 2)
+    }
+
+    // MARK: - Spam / trash: removed from All/Pending/Approved, lands tab goes stale
+
+    @Test(arguments: [CommentsListFilter.all, .pending, .approved])
+    func spamEventRemovesFromNonSpamLoadedTabs(filter: CommentsListFilter) async {
+        let service = FakeCommentsService()
+        service.queuedResults = [.success(makePage(items: [makeItem(id: 1)], hasNext: false))]
+        let viewModel = CommentsListViewModel(filter: filter, service: service)
+        await viewModel.onAppear()
+
+        viewModel.apply(.statusChanged(id: 1, to: .spam))
+
+        #expect(viewModel.items.isEmpty)
+        #expect(viewModel.state == .loaded)
+    }
+
+    @Test func spamEventMarksSpamTabStaleWhenMissingAndReloadsOnNextAppear() async {
+        let service = FakeCommentsService()
+        service.queuedResults = [
+            .success(makePage(items: [], hasNext: false)),
+            .success(makePage(items: [makeItem(id: 1, status: .spam)], hasNext: false))
+        ]
+        let viewModel = CommentsListViewModel(filter: .spam, service: service)
+        await viewModel.onAppear()
+        #expect(viewModel.items.isEmpty)
+
+        viewModel.apply(.statusChanged(id: 1, to: .spam))
+        #expect(viewModel.state == .awaitingReload)
+
+        await viewModel.onAppear()
+        #expect(viewModel.state == .loaded)
+        #expect(viewModel.items.map(\.id) == [1])
+        #expect(service.requests.count == 2)
+    }
+
+    @Test(arguments: [CommentsListFilter.all, .pending, .approved])
+    func trashEventRemovesFromNonTrashLoadedTabs(filter: CommentsListFilter) async {
+        let service = FakeCommentsService()
+        service.queuedResults = [.success(makePage(items: [makeItem(id: 1)], hasNext: false))]
+        let viewModel = CommentsListViewModel(filter: filter, service: service)
+        await viewModel.onAppear()
+
+        viewModel.apply(.statusChanged(id: 1, to: .trash))
+
+        #expect(viewModel.items.isEmpty)
+        #expect(viewModel.state == .loaded)
+    }
+
+    @Test func trashEventMarksTrashTabStaleWhenMissingAndReloadsOnNextAppear() async {
+        let service = FakeCommentsService()
+        service.queuedResults = [
+            .success(makePage(items: [], hasNext: false)),
+            .success(makePage(items: [makeItem(id: 1, status: .trash)], hasNext: false))
+        ]
+        let viewModel = CommentsListViewModel(filter: .trash, service: service)
+        await viewModel.onAppear()
+        #expect(viewModel.items.isEmpty)
+
+        viewModel.apply(.statusChanged(id: 1, to: .trash))
+        #expect(viewModel.state == .awaitingReload)
+
+        await viewModel.onAppear()
+        #expect(viewModel.state == .loaded)
+        #expect(viewModel.items.map(\.id) == [1])
+        #expect(service.requests.count == 2)
+    }
+
+    // MARK: - Restore landing on pending vs approved: only the landing tab + All go stale
+
+    @Test func restoreToPendingRemovesFromSpamAndOnlyMarksPendingAndAllStale() async {
+        let spamService = FakeCommentsService()
+        spamService.queuedResults = [.success(makePage(items: [makeItem(id: 1, status: .spam)], hasNext: false))]
+        let spamViewModel = CommentsListViewModel(filter: .spam, service: spamService)
+        await spamViewModel.onAppear()
+        spamViewModel.apply(.statusChanged(id: 1, to: .pending))
+        #expect(spamViewModel.items.isEmpty)
+        #expect(spamViewModel.state == .loaded)
+
+        let pendingService = FakeCommentsService()
+        pendingService.queuedResults = [.success(makePage(items: [], hasNext: false))]
+        let pendingViewModel = CommentsListViewModel(filter: .pending, service: pendingService)
+        await pendingViewModel.onAppear()
+        pendingViewModel.apply(.statusChanged(id: 1, to: .pending))
+        #expect(pendingViewModel.state == .awaitingReload)
+
+        let allService = FakeCommentsService()
+        allService.queuedResults = [.success(makePage(items: [], hasNext: false))]
+        let allViewModel = CommentsListViewModel(filter: .all, service: allService)
+        await allViewModel.onAppear()
+        allViewModel.apply(.statusChanged(id: 1, to: .pending))
+        #expect(allViewModel.state == .awaitingReload)
+
+        let approvedService = FakeCommentsService()
+        approvedService.queuedResults = [.success(makePage(items: [], hasNext: false))]
+        let approvedViewModel = CommentsListViewModel(filter: .approved, service: approvedService)
+        await approvedViewModel.onAppear()
+        approvedViewModel.apply(.statusChanged(id: 1, to: .pending))
+        #expect(approvedViewModel.state == .loaded)
+        #expect(approvedViewModel.items.isEmpty)
+    }
+
+    @Test func restoreToApprovedRemovesFromTrashAndOnlyMarksApprovedAndAllStale() async {
+        let trashService = FakeCommentsService()
+        trashService.queuedResults = [.success(makePage(items: [makeItem(id: 1, status: .trash)], hasNext: false))]
+        let trashViewModel = CommentsListViewModel(filter: .trash, service: trashService)
+        await trashViewModel.onAppear()
+        trashViewModel.apply(.statusChanged(id: 1, to: .approved))
+        #expect(trashViewModel.items.isEmpty)
+        #expect(trashViewModel.state == .loaded)
+
+        let approvedService = FakeCommentsService()
+        approvedService.queuedResults = [.success(makePage(items: [], hasNext: false))]
+        let approvedViewModel = CommentsListViewModel(filter: .approved, service: approvedService)
+        await approvedViewModel.onAppear()
+        approvedViewModel.apply(.statusChanged(id: 1, to: .approved))
+        #expect(approvedViewModel.state == .awaitingReload)
+
+        let allService = FakeCommentsService()
+        allService.queuedResults = [.success(makePage(items: [], hasNext: false))]
+        let allViewModel = CommentsListViewModel(filter: .all, service: allService)
+        await allViewModel.onAppear()
+        allViewModel.apply(.statusChanged(id: 1, to: .approved))
+        #expect(allViewModel.state == .awaitingReload)
+
+        let pendingService = FakeCommentsService()
+        pendingService.queuedResults = [.success(makePage(items: [], hasNext: false))]
+        let pendingViewModel = CommentsListViewModel(filter: .pending, service: pendingService)
+        await pendingViewModel.onAppear()
+        pendingViewModel.apply(.statusChanged(id: 1, to: .approved))
+        #expect(pendingViewModel.state == .loaded)
+        #expect(pendingViewModel.items.isEmpty)
+    }
+
+    // MARK: - Custom status (e.g. post-trashed): removed everywhere, never stale
+
+    @Test(arguments: CommentsListFilter.allCases)
+    func otherStatusEventRemovesFromEveryLoadedTabWithoutMarkingStale(filter: CommentsListFilter) async {
+        let service = FakeCommentsService()
+        service.queuedResults = [.success(makePage(items: [makeItem(id: 1)], hasNext: false))]
+        let viewModel = CommentsListViewModel(filter: filter, service: service)
+        await viewModel.onAppear()
+
+        viewModel.apply(.statusChanged(id: 1, to: .other("post-trashed")))
+
+        #expect(viewModel.items.isEmpty)
+        #expect(viewModel.state == .loaded)
+    }
+
+    // MARK: - Deleted: removed everywhere
+
+    @Test(arguments: CommentsListFilter.allCases)
+    func deletedEventRemovesFromEveryLoadedTab(filter: CommentsListFilter) async {
+        let service = FakeCommentsService()
+        service.queuedResults = [.success(makePage(items: [makeItem(id: 1)], hasNext: false))]
+        let viewModel = CommentsListViewModel(filter: filter, service: service)
+        await viewModel.onAppear()
+
+        viewModel.apply(.deleted(id: 1))
+
+        #expect(viewModel.items.isEmpty)
+        #expect(viewModel.state == .loaded)
+    }
+
+    // MARK: - Stale reload resets
+
+    @Test func staleReloadReplacesItemsClearsStaleAndResetsPaging() async {
+        let service = FakeCommentsService()
+        service.queuedResults = [
+            .success(makePage(items: [makeItem(id: 1)], hasNext: false)),
+            .success(makePage(items: [makeItem(id: 2)], hasNext: true)),
+            .success(makePage(items: [makeItem(id: 3)], hasNext: false))
+        ]
+        let viewModel = CommentsListViewModel(filter: .all, service: service)
+        await viewModel.onAppear()
+        #expect(viewModel.items.map(\.id) == [1])
+
+        viewModel.apply(.statusChanged(id: 99, to: .pending))
+        #expect(viewModel.state == .awaitingReload)
+
+        await viewModel.onAppear()
+        #expect(viewModel.state == .loaded)
+        #expect(viewModel.items.map(\.id) == [2])
+        #expect(viewModel.canLoadMore)
+
+        await viewModel.loadMore()
+        #expect(viewModel.items.map(\.id) == [2, 3])
+    }
+
+    @Test func staleReloadFailureKeepsStaleAndRetriesOnNextOnAppear() async {
+        let service = FakeCommentsService()
+        service.queuedResults = [
+            .success(makePage(items: [makeItem(id: 1)], hasNext: false)),
+            .failure(FakeServiceError()),
+            .success(makePage(items: [makeItem(id: 2)], hasNext: false))
+        ]
+        let viewModel = CommentsListViewModel(filter: .all, service: service)
+        await viewModel.onAppear()
+        #expect(viewModel.items.map(\.id) == [1])
+
+        viewModel.apply(.statusChanged(id: 99, to: .pending))
+        #expect(viewModel.state == .awaitingReload)
+
+        // The reload attempt fails: the tab must stay awaiting a reload (not
+        // silently settle as loaded) so it keeps retrying rather than freezing
+        // on outdated items with no error state and no path back to fresh data.
+        await viewModel.onAppear()
+        #expect(viewModel.state == .awaitingReload)
+        #expect(viewModel.items.map(\.id) == [1])
+
+        await viewModel.onAppear()
+        #expect(viewModel.state == .loaded)
+        #expect(viewModel.items.map(\.id) == [2])
+        #expect(service.requests.count == 3)
+    }
+
+    @Test func staleReloadWithSeedItemsReplacesFetchedItemsAndClearsStale() async {
+        let service = FakeCommentsService()
+        service.queuedResults = [
+            .success(makePage(items: [makeItem(id: 1)], hasNext: false)),
+            .success(makePage(items: [makeItem(id: 2)], hasNext: false))
+        ]
+        var seedCallCount = 0
+        let viewModel = CommentsListViewModel(
+            filter: .pending,
+            service: service,
+            seedItems: {
+                seedCallCount += 1
+                return [makeItem(id: 99)]
+            }
+        )
+        await viewModel.onAppear()
+        #expect(viewModel.items.map(\.id) == [1])
+        #expect(seedCallCount == 1)
+
+        viewModel.apply(.statusChanged(id: 99, to: .pending))
+        #expect(viewModel.state == .awaitingReload)
+
+        // A stale reload must fetch and replace with the real page, not
+        // re-seed a placeholder subset over already-loaded (if outdated)
+        // items.
+        await viewModel.onAppear()
+        #expect(viewModel.state == .loaded)
+        #expect(viewModel.items.map(\.id) == [2])
+        #expect(seedCallCount == 1)
+    }
+
+    // MARK: - Visible-tab stale reload (FIX-L)
+
+    @Test func staleFlagIsObservableAndClearedByReload() async {
+        let service = FakeCommentsService()
+        service.queuedResults = [
+            .success(makePage(items: [makeItem(id: 1)], hasNext: false)),
+            .success(makePage(items: [makeItem(id: 2)], hasNext: false))
+        ]
+        let viewModel = CommentsListViewModel(filter: .all, service: service)
+        await viewModel.onAppear()
+        #expect(viewModel.state == .loaded)
+
+        // A status change for a comment that belongs here but is absent marks
+        // the (visible) tab stale; the view observes this published flag and
+        // triggers a reload.
+        viewModel.apply(.statusChanged(id: 99, to: .pending))
+        #expect(viewModel.state == .awaitingReload)
+
+        // The reload refetches page one and clears the flag (so the view's
+        // onChange won't loop).
+        await viewModel.onAppear()
+        #expect(viewModel.state == .loaded)
+        #expect(viewModel.items.map(\.id) == [2])
+    }
+
+    @Test func successfulRefreshClearsStale() async {
+        let service = FakeCommentsService()
+        service.queuedResults = [
+            .success(makePage(items: [makeItem(id: 1)], hasNext: false)),
+            .success(makePage(items: [makeItem(id: 2)], hasNext: false))
+        ]
+        let viewModel = CommentsListViewModel(filter: .all, service: service)
+        await viewModel.onAppear()
+        viewModel.apply(.statusChanged(id: 99, to: .pending))
+        #expect(viewModel.state == .awaitingReload)
+
+        // A fresh full page from pull-to-refresh is authoritative: the tab is no
+        // longer stale.
+        await viewModel.refresh()
+        #expect(viewModel.state == .loaded)
+        #expect(viewModel.items.map(\.id) == [2])
+    }
+
+    @Test func markingStaleReloadsPageOneWithoutReappearing() async {
+        let service = FakeCommentsService()
+        service.queuedResults = [
+            .success(makePage(items: [makeItem(id: 1)], hasNext: false)),
+            .success(makePage(items: [makeItem(id: 1), makeItem(id: 99)], hasNext: false))
+        ]
+        let viewModel = CommentsListViewModel(filter: .all, service: service)
+        await viewModel.onAppear()
+
+        // A comment that belongs here but is absent can't be placed in a paged
+        // list; the tab reloads on its own rather than waiting for a tab switch.
+        viewModel.apply(.statusChanged(id: 99, to: .pending))
+        #expect(viewModel.state == .awaitingReload)
+
+        await waitUntil { viewModel.state == .loaded }
+        #expect(viewModel.items.map(\.id) == [1, 99])
+    }
+
+    @Test func failedStaleReloadOnEmptyTabKeepsEmptyStateAndIgnoresRetry() async {
+        let service = FakeCommentsService()
+        service.queuedResults = [
+            .success(makePage(items: [], hasNext: false)),
+            .failure(FakeServiceError()),
+            .success(makePage(items: [makeItem(id: 1, status: .spam)], hasNext: false))
+        ]
+        let viewModel = CommentsListViewModel(filter: .spam, service: service)
+        await viewModel.onAppear()
+        #expect(viewModel.showsEmptyState)
+
+        // A stale reload is app-triggered, so its failure is silent even with
+        // no rows to keep: the empty state stays rather than the full-screen
+        // error, and retry (the error state's action) is a no-op.
+        viewModel.apply(.statusChanged(id: 1, to: .spam))
+        await viewModel.onAppear()
+        #expect(viewModel.state == .awaitingReload)
+        #expect(viewModel.showsEmptyState)
+        await viewModel.retryFirstPage()
+        #expect(viewModel.state == .awaitingReload)
+        #expect(service.requests.count == 2)
+
+        // The next appearance retries.
+        await viewModel.onAppear()
+        #expect(viewModel.state == .loaded)
+        #expect(viewModel.items.map(\.id) == [1])
+    }
+}

--- a/Modules/Tests/WordPressCommentsTests/CommentsListViewModelStateTests.swift
+++ b/Modules/Tests/WordPressCommentsTests/CommentsListViewModelStateTests.swift
@@ -11,7 +11,7 @@ struct CommentsListViewModelStateTests {
 
         await viewModel.onAppear()
 
-        #expect(viewModel.firstPageFailed)
+        #expect(viewModel.state == .failed)
         #expect(!viewModel.showsEmptyState)
         #expect(viewModel.items.isEmpty)
     }
@@ -27,9 +27,8 @@ struct CommentsListViewModelStateTests {
         await viewModel.onAppear()
         await viewModel.retryFirstPage()
 
-        #expect(!viewModel.firstPageFailed)
+        #expect(viewModel.state == .loaded)
         #expect(viewModel.items.map(\.id) == [1])
-        #expect(viewModel.hasLoaded)
     }
 
     @Test func emptyResultShowsEmptyState() async {
@@ -88,7 +87,7 @@ struct CommentsListViewModelStateTests {
         await viewModel.refresh()
 
         #expect(viewModel.items.map(\.id) == [1])
-        #expect(!viewModel.firstPageFailed)
+        #expect(viewModel.state == .loaded)
     }
 
     @Test func seededItemsShowWhilePlaceholderThenReplaced() async {
@@ -102,7 +101,7 @@ struct CommentsListViewModelStateTests {
         // transition through a mid-flight check below.
         await viewModel.onAppear()
 
-        #expect(!viewModel.isShowingSeededPlaceholder)
+        #expect(viewModel.state == .loaded)
         #expect(viewModel.items.map(\.id) == [3, 4])
     }
 
@@ -113,9 +112,9 @@ struct CommentsListViewModelStateTests {
 
         await viewModel.onAppear()
 
-        #expect(viewModel.isShowingSeededPlaceholder)
+        #expect(viewModel.state == .failed)
+        #expect(viewModel.items.map(\.id) == [3])
         #expect(!viewModel.canLoadMore)
-        #expect(viewModel.firstPageFailed)
     }
 
     @Test func emptySeedDoesNotEnablePlaceholder() async {

--- a/Modules/Tests/WordPressCommentsTests/CommentsListViewModelTests.swift
+++ b/Modules/Tests/WordPressCommentsTests/CommentsListViewModelTests.swift
@@ -12,8 +12,7 @@ struct CommentsListViewModelTests {
         await viewModel.onAppear()
 
         #expect(viewModel.items.map(\.id) == [1, 2])
-        #expect(viewModel.hasLoaded)
-        #expect(!viewModel.isLoadingFirstPage)
+        #expect(viewModel.state == .loaded)
         #expect(viewModel.canLoadMore)
     }
 

--- a/Modules/Tests/WordPressCommentsTests/CommentsModerationCoordinatorTests.swift
+++ b/Modules/Tests/WordPressCommentsTests/CommentsModerationCoordinatorTests.swift
@@ -1,0 +1,273 @@
+import Foundation
+import Testing
+import WordPressAPI
+import WordPressAPIInternal
+@testable import WordPressComments
+
+@MainActor
+struct CommentsModerationCoordinatorTests {
+    @Test func noEventEmittedBeforeRequestResolves() async {
+        let service = BlockingCommentsService()
+        let coordinator = CommentsModerationCoordinator(service: service)
+        let recorder = EventRecorder(coordinator)
+
+        async let performed: Void = coordinator.perform(.approve, on: makeDetail(id: 1, status: .hold))
+        await waitUntil { !service.setStatusInvocations.isEmpty }
+
+        // Still blocked on the continuation: nothing emitted until it resolves.
+        #expect(recorder.events.isEmpty)
+
+        service.resolveSetStatus(callIndex: 0, with: makeDetail(id: 1, status: .approved))
+        _ = try? await performed
+        #expect(recorder.events == [.statusChanged(id: 1, to: .approved)])
+    }
+
+    @Test func successEmitsLandedStatusFromResponse() async {
+        let service = FakeCommentsService()
+        // Restore probes first and finds the comment still in the bin, so it
+        // issues the restore; it lands back on approved (the saved pre-trash
+        // status), not the pending stand-in.
+        service.fetchStatusResults = [.success(.spam)]
+        service.setStatusResult = .success(makeDetail(id: 1, status: .approved))
+        let coordinator = CommentsModerationCoordinator(service: service)
+        let recorder = EventRecorder(coordinator)
+
+        try? await coordinator.perform(.restore, on: makeDetail(id: 1, status: .spam))
+
+        #expect(recorder.events == [.statusChanged(id: 1, to: .approved)])
+        #expect(service.restoreInvocations.map(\.from) == [.spam])
+    }
+
+    @Test func trashSuccessEmitsTrashEvent() async {
+        let service = FakeCommentsService() // trash() succeeds when no error queued
+        let coordinator = CommentsModerationCoordinator(service: service)
+        let recorder = EventRecorder(coordinator)
+
+        try? await coordinator.perform(.trash, on: makeDetail(id: 1, status: .approved))
+
+        #expect(recorder.events == [.statusChanged(id: 1, to: .trash)])
+    }
+
+    @Test func deleteSuccessEmitsDeletedEvent() async {
+        let service = FakeCommentsService() // delete() succeeds when no error queued
+        let coordinator = CommentsModerationCoordinator(service: service)
+        let recorder = EventRecorder(coordinator)
+
+        try? await coordinator.perform(.delete, on: makeDetail(id: 1, status: .approved))
+
+        #expect(recorder.events == [.deleted(id: 1)])
+    }
+
+    @Test func genuineFailureThrowsAndEmitsNothing() async {
+        let service = FakeCommentsService()
+        service.setStatusResult = .failure(FakeServiceError())
+        let coordinator = CommentsModerationCoordinator(service: service)
+        let recorder = EventRecorder(coordinator)
+
+        await #expect(throws: (any Error).self) {
+            try await coordinator.perform(.approve, on: makeDetail(id: 1, status: .hold))
+        }
+        #expect(recorder.events.isEmpty)
+    }
+
+    @Test func commentFailedEditProbeMatchIsSuccess() async {
+        let service = FakeCommentsService()
+        service.setStatusResult = .failure(WpApiError.stub(code: .CommentFailedEdit))
+        // The probe finds the comment already approved (an earlier timed-out
+        // attempt landed, or another moderator made the same change).
+        service.fetchStatusResults = [.success(.approved)]
+        let coordinator = CommentsModerationCoordinator(service: service)
+        let recorder = EventRecorder(coordinator)
+
+        await #expect(throws: Never.self) {
+            try await coordinator.perform(.approve, on: makeDetail(id: 1, status: .hold))
+        }
+        #expect(recorder.events == [.statusChanged(id: 1, to: .approved)])
+    }
+
+    @Test func commentFailedEditProbeMismatchThrowsWithoutEvent() async {
+        let service = FakeCommentsService()
+        service.setStatusResult = .failure(WpApiError.stub(code: .CommentFailedEdit))
+        // The probe finds a different status: the action genuinely failed.
+        service.fetchStatusResults = [.success(.spam)]
+        let coordinator = CommentsModerationCoordinator(service: service)
+        let recorder = EventRecorder(coordinator)
+
+        await #expect(throws: (any Error).self) {
+            try await coordinator.perform(.approve, on: makeDetail(id: 1, status: .hold))
+        }
+        #expect(recorder.events.isEmpty)
+    }
+
+    @Test func commentFailedEditProbeFailureThrowsOriginalError() async {
+        let service = FakeCommentsService()
+        service.setStatusResult = .failure(WpApiError.stub(code: .CommentFailedEdit))
+        // The probe itself fails: fall through to the original error, no event.
+        service.fetchStatusResults = [.failure(FakeServiceError())]
+        let coordinator = CommentsModerationCoordinator(service: service)
+        let recorder = EventRecorder(coordinator)
+
+        var caught: Error?
+        do {
+            try await coordinator.perform(.approve, on: makeDetail(id: 1, status: .hold))
+        } catch {
+            caught = error
+        }
+
+        #expect((caught as? WpApiError)?.wpErrorCode == .CommentFailedEdit)
+        #expect(recorder.events.isEmpty)
+    }
+
+    @Test func restoreProbeAlreadyActiveSkipsRequest() async {
+        let service = FakeCommentsService()
+        // The pre-restore probe finds the comment already active: an earlier
+        // attempt landed (its response was lost). Restore is non-idempotent, so
+        // it must NOT be reissued; the probed status is the outcome and no
+        // restore request goes out.
+        service.fetchStatusResults = [.success(.approved)]
+        let coordinator = CommentsModerationCoordinator(service: service)
+        let recorder = EventRecorder(coordinator)
+
+        await #expect(throws: Never.self) {
+            try await coordinator.perform(.restore, on: makeDetail(id: 1, status: .spam))
+        }
+        #expect(recorder.events == [.statusChanged(id: 1, to: .approved)])
+        #expect(service.fetchStatusInvocations == [1])
+        #expect(service.restoreInvocations.isEmpty)
+    }
+
+    @Test func restoreProbeStillInBinIssuesRestore() async {
+        let service = FakeCommentsService()
+        // The probe proves the comment is still in the bin, so the restore is
+        // safe to issue; it lands back on its saved pre-trash status.
+        service.fetchStatusResults = [.success(.trash)]
+        service.setStatusResult = .success(makeDetail(id: 1, status: .approved))
+        let coordinator = CommentsModerationCoordinator(service: service)
+        let recorder = EventRecorder(coordinator)
+
+        await #expect(throws: Never.self) {
+            try await coordinator.perform(.restore, on: makeDetail(id: 1, status: .trash))
+        }
+        #expect(recorder.events == [.statusChanged(id: 1, to: .approved)])
+        #expect(service.restoreInvocations.map(\.from) == [.trash])
+    }
+
+    @Test func restoreUsesProbedBinNotStaleHeader() async {
+        let service = FakeCommentsService()
+        // The tap captured spam, but the comment was moved to trash meanwhile.
+        // The restore must target the probed bin (untrash), not the stale
+        // header (unspam), so the right restore hooks run.
+        service.fetchStatusResults = [.success(.trash)]
+        service.setStatusResult = .success(makeDetail(id: 1, status: .approved))
+        let coordinator = CommentsModerationCoordinator(service: service)
+
+        try? await coordinator.perform(.restore, on: makeDetail(id: 1, status: .spam))
+
+        #expect(service.restoreInvocations.map(\.from) == [.trash])
+    }
+
+    @Test func restoreProbeFailureDoesNotIssueRestore() async {
+        let service = FakeCommentsService()
+        // The pre-restore probe fails, so the comment's state is unconfirmed.
+        // Issuing the restore anyway could downgrade an already-restored
+        // comment, so it must not go out: the action fails instead.
+        service.fetchStatusResults = [.failure(FakeServiceError())]
+        let coordinator = CommentsModerationCoordinator(service: service)
+        let recorder = EventRecorder(coordinator)
+
+        await #expect(throws: (any Error).self) {
+            try await coordinator.perform(.restore, on: makeDetail(id: 1, status: .trash))
+        }
+        #expect(recorder.events.isEmpty)
+        #expect(service.restoreInvocations.isEmpty)
+    }
+
+    @Test func trashAlreadyTrashedIsSuccess() async {
+        let service = FakeCommentsService()
+        service.trashError = WpApiError.stub(code: .AlreadyTrashed)
+        let coordinator = CommentsModerationCoordinator(service: service)
+        let recorder = EventRecorder(coordinator)
+
+        await #expect(throws: Never.self) {
+            try await coordinator.perform(.trash, on: makeDetail(id: 1, status: .approved))
+        }
+        #expect(recorder.events == [.statusChanged(id: 1, to: .trash)])
+    }
+
+    @Test func notFoundOnDeleteIsSuccessWithDeletedEvent() async {
+        let service = FakeCommentsService()
+        service.deleteError = WpApiError.stub(statusCode: 404)
+        let coordinator = CommentsModerationCoordinator(service: service)
+        let recorder = EventRecorder(coordinator)
+
+        await #expect(throws: Never.self) {
+            try await coordinator.perform(.delete, on: makeDetail(id: 1, status: .approved))
+        }
+        #expect(recorder.events == [.deleted(id: 1)])
+    }
+
+    @Test func notFoundOnNonDeleteThrowsWithDeletedEvent() async {
+        let service = FakeCommentsService()
+        service.setStatusResult = .failure(WpApiError.stub(statusCode: 404))
+        let coordinator = CommentsModerationCoordinator(service: service)
+        let recorder = EventRecorder(coordinator)
+
+        await #expect(throws: (any Error).self) {
+            try await coordinator.perform(.approve, on: makeDetail(id: 1, status: .hold))
+        }
+        #expect(recorder.events == [.deleted(id: 1)])
+    }
+
+    @Test func secondPerformWhileInFlightIsIgnored() async {
+        let service = BlockingCommentsService()
+        let coordinator = CommentsModerationCoordinator(service: service)
+        let recorder = EventRecorder(coordinator)
+
+        async let first: Void = coordinator.perform(.approve, on: makeDetail(id: 1, status: .hold))
+        await waitUntil { !service.setStatusInvocations.isEmpty }
+
+        // A second action while the first is in flight returns without a request.
+        try? await coordinator.perform(.spam, on: makeDetail(id: 1, status: .hold))
+        #expect(service.setStatusInvocations.count == 1)
+
+        service.resolveSetStatus(callIndex: 0, with: makeDetail(id: 1, status: .approved))
+        _ = try? await first
+        #expect(recorder.events == [.statusChanged(id: 1, to: .approved)])
+    }
+
+    @Test func waitForPendingMutationSuspendsUntilSettled() async {
+        let service = BlockingCommentsService()
+        let coordinator = CommentsModerationCoordinator(service: service)
+
+        async let performed: Void = coordinator.perform(.approve, on: makeDetail(id: 1, status: .hold))
+        await waitUntil { !service.setStatusInvocations.isEmpty }
+
+        async let waiterResumed: Bool = {
+            await coordinator.waitForPendingMutation(id: 1)
+            return true
+        }()
+
+        // Let the waiter reach its suspension point; the mutation is still in
+        // flight, so it must not have resumed yet.
+        await Task.yield()
+        #expect(coordinator.isMutating(id: 1))
+
+        service.resolveSetStatus(callIndex: 0, with: makeDetail(id: 1, status: .approved))
+        #expect(await waiterResumed)
+        _ = try? await performed
+        #expect(!coordinator.isMutating(id: 1))
+    }
+
+    @Test func mappedSuccessStillFiresAnalytics() async {
+        let spy = SpyCommentsTracker()
+        let service = FakeCommentsService()
+        service.setStatusResult = .failure(WpApiError.stub(code: .CommentFailedEdit))
+        service.fetchStatusResults = [.success(.approved)]
+        let coordinator = CommentsModerationCoordinator(service: service, tracker: spy)
+
+        try? await coordinator.perform(.approve, on: makeDetail(id: 1, status: .hold))
+
+        // A mapped success fires the same analytics event as a plain success.
+        #expect(spy.trackedEvents == [.approved(commentID: 1, postID: 10)])
+    }
+}

--- a/Modules/Tests/WordPressCommentsTests/CommentsServiceStatusMappingTests.swift
+++ b/Modules/Tests/WordPressCommentsTests/CommentsServiceStatusMappingTests.swift
@@ -1,0 +1,18 @@
+import Testing
+import WordPressAPI
+@testable import WordPressComments
+
+struct CommentsServiceStatusMappingTests {
+    @Test func updateStatusValues() {
+        #expect(CommentsService.updateStatus(for: .approved).description == "approved")
+        #expect(CommentsService.updateStatus(for: .pending).description == "hold")
+        #expect(CommentsService.updateStatus(for: .spam).description == "spam")
+        #expect(CommentsService.updateStatus(for: .trash).description == "trash")
+        #expect(CommentsService.updateStatus(for: .other("weird")).description == "weird")
+    }
+
+    @Test func restoreStatusValues() {
+        #expect(CommentsService.restoreStatus(from: .spam).description == "unspam")
+        #expect(CommentsService.restoreStatus(from: .trash).description == "untrash")
+    }
+}

--- a/Modules/Tests/WordPressCommentsTests/Support/BlockingCommentsService.swift
+++ b/Modules/Tests/WordPressCommentsTests/Support/BlockingCommentsService.swift
@@ -14,7 +14,10 @@ final class BlockingCommentsService: CommentsServiceProtocol {
     private(set) var setStatusInvocations: [(id: Int64, status: CommentListItem.Status)] = []
     private(set) var callCount = 0
     private(set) var fetchCommentInvocations: [(id: Int64, allowsEditContext: Bool)] = []
-    var numberOfRepliesResult: Result<Int, Error> = .success(0)
+    /// When nil, `numberOfReplies` blocks like the other calls.
+    var numberOfRepliesResult: Result<Int, Error>? = .success(0)
+    private var numberOfRepliesContinuations: [CheckedContinuation<Int, Error>] = []
+    private(set) var numberOfRepliesInvocations: [Int64] = []
 
     func listComments(filter: CommentsListFilter, nextPage: CommentsPageToken?) async throws -> CommentsPage {
         callCount += 1
@@ -60,7 +63,13 @@ final class BlockingCommentsService: CommentsServiceProtocol {
     }
 
     func numberOfReplies(for id: Int64) async throws -> Int {
-        try numberOfRepliesResult.get()
+        numberOfRepliesInvocations.append(id)
+        if let numberOfRepliesResult { return try numberOfRepliesResult.get() }
+        return try await withCheckedThrowingContinuation { numberOfRepliesContinuations.append($0) }
+    }
+
+    func resolveNumberOfReplies(callIndex: Int, with count: Int) {
+        numberOfRepliesContinuations[callIndex].resume(returning: count)
     }
 
     func resolveFetch(callIndex: Int, with detail: CommentDetail) {

--- a/Modules/Tests/WordPressCommentsTests/Support/BlockingCommentsService.swift
+++ b/Modules/Tests/WordPressCommentsTests/Support/BlockingCommentsService.swift
@@ -2,19 +2,27 @@ import Foundation
 import WordPressAPI
 @testable import WordPressComments
 
-/// A service whose calls suspend until the test resolves them by index, so a
-/// test can interleave in-flight calls deterministically (for example a
-/// `loadMore` with a `refresh`, or two detail appearances).
+/// A service whose list, fetch, and status calls suspend until the test
+/// resolves them by index, so a test can interleave in-flight calls
+/// deterministically (for example a `loadMore` with a `refresh`, two detail
+/// appearances, or a moderation request still in flight).
 @MainActor
 final class BlockingCommentsService: CommentsServiceProtocol {
     private var continuations: [CheckedContinuation<CommentsPage, Error>] = []
     private var fetchContinuations: [CheckedContinuation<CommentDetail, Error>] = []
+    private var setStatusContinuations: [CheckedContinuation<CommentDetail, Error>] = []
+    private(set) var setStatusInvocations: [(id: Int64, status: CommentListItem.Status)] = []
     private(set) var callCount = 0
     private(set) var fetchCommentInvocations: [(id: Int64, allowsEditContext: Bool)] = []
+    var numberOfRepliesResult: Result<Int, Error> = .success(0)
 
     func listComments(filter: CommentsListFilter, nextPage: CommentsPageToken?) async throws -> CommentsPage {
         callCount += 1
         return try await withCheckedThrowingContinuation { continuations.append($0) }
+    }
+
+    func resolve(callIndex: Int, with page: CommentsPage) {
+        continuations[callIndex].resume(returning: page)
     }
 
     func fetchComment(id: Int64, allowsEditContext: Bool) async throws -> CommentDetail {
@@ -22,8 +30,37 @@ final class BlockingCommentsService: CommentsServiceProtocol {
         return try await withCheckedThrowingContinuation { fetchContinuations.append($0) }
     }
 
-    func resolve(callIndex: Int, with page: CommentsPage) {
-        continuations[callIndex].resume(returning: page)
+    func fetchStatus(id: Int64) async throws -> CommentListItem.Status {
+        throw FakeServiceError()
+    }
+
+    func setStatus(id: Int64, _ status: CommentListItem.Status) async throws -> CommentDetail {
+        setStatusInvocations.append((id, status))
+        return try await withCheckedThrowingContinuation { setStatusContinuations.append($0) }
+    }
+
+    func restore(id: Int64, from bin: CommentListItem.Status) async throws -> CommentDetail {
+        throw FakeServiceError()
+    }
+
+    func resolveSetStatus(callIndex: Int, with detail: CommentDetail) {
+        setStatusContinuations[callIndex].resume(returning: detail)
+    }
+
+    func failSetStatus(callIndex: Int, with error: Error) {
+        setStatusContinuations[callIndex].resume(throwing: error)
+    }
+
+    func trash(id: Int64) async throws {
+        throw FakeServiceError()
+    }
+
+    func delete(id: Int64) async throws {
+        throw FakeServiceError()
+    }
+
+    func numberOfReplies(for id: Int64) async throws -> Int {
+        try numberOfRepliesResult.get()
     }
 
     func resolveFetch(callIndex: Int, with detail: CommentDetail) {

--- a/Modules/Tests/WordPressCommentsTests/Support/CommentDetailTestHelpers.swift
+++ b/Modules/Tests/WordPressCommentsTests/Support/CommentDetailTestHelpers.swift
@@ -26,14 +26,33 @@ func makeVM(
     seed: CommentListItem? = nil,
     service: any CommentsServiceProtocol,
     capabilities: FakeCommentsCapabilities = FakeCommentsCapabilities(),
-    tracker: (any CommentsTracker)? = nil
+    coordinator: CommentsModerationCoordinator? = nil,
+    tracker: (any CommentsTracker)? = nil,
+    noticePresenter: (any NoticePresenting)? = nil
 ) -> CommentDetailViewModel {
     CommentDetailViewModel(
         commentID: commentID,
         seed: seed,
         service: service,
         capabilities: capabilities,
+        coordinator: coordinator ?? CommentsModerationCoordinator(service: FakeCommentsService()),
         titleResolver: makeResolver(),
-        tracker: tracker
+        tracker: tracker,
+        noticePresenter: noticePresenter
     )
+}
+
+/// A view model whose authoritative fetch has landed with edit context at
+/// `status`, so the toolbar is enabled and actions run through `coordinator`.
+@MainActor
+func makeLoadedVM(
+    status: CommentStatus = .hold,
+    coordinator: CommentsModerationCoordinator,
+    noticePresenter: (any NoticePresenting)? = nil
+) async -> CommentDetailViewModel {
+    let service = FakeCommentsService()
+    service.fetchCommentResult = .success(makeDetail(id: 1, status: status, editContext: true))
+    let vm = makeVM(service: service, coordinator: coordinator, noticePresenter: noticePresenter)
+    await vm.onAppear()
+    return vm
 }

--- a/Modules/Tests/WordPressCommentsTests/Support/CoordinatorTestHelpers.swift
+++ b/Modules/Tests/WordPressCommentsTests/Support/CoordinatorTestHelpers.swift
@@ -1,0 +1,26 @@
+import Combine
+import Foundation
+@testable import WordPressComments
+
+/// Records every event the coordinator publishes, in order.
+@MainActor
+final class EventRecorder {
+    private(set) var events: [CommentChangeEvent] = []
+    private var subscription: AnyCancellable?
+
+    init(_ coordinator: CommentsModerationCoordinator) {
+        subscription = coordinator.events.sink { [weak self] in self?.events.append($0) }
+    }
+}
+
+/// Polls until `condition` holds or a generous bound is reached, letting a
+/// detached task (a view model's `perform`, a coordinator chain) run up to
+/// the point the test wants to observe. Bounded so a regression fails the
+/// test instead of hanging the suite.
+@MainActor
+func waitUntil(_ condition: () -> Bool) async {
+    for _ in 0..<1000 {
+        if condition() { return }
+        await Task.yield()
+    }
+}

--- a/Modules/Tests/WordPressCommentsTests/Support/FakeCommentsService.swift
+++ b/Modules/Tests/WordPressCommentsTests/Support/FakeCommentsService.swift
@@ -14,6 +14,22 @@ final class FakeCommentsService: CommentsServiceProtocol {
     var fetchCommentResult: Result<CommentDetail, Error>?
     private(set) var fetchCommentInvocations: [(id: Int64, allowsEditContext: Bool)] = []
 
+    var fetchStatusResults: [Result<CommentListItem.Status, Error>] = []
+    private(set) var fetchStatusInvocations: [Int64] = []
+
+    var setStatusResult: Result<CommentDetail, Error>?
+    private(set) var setStatusInvocations: [(id: Int64, status: CommentListItem.Status)] = []
+    private(set) var restoreInvocations: [(id: Int64, from: CommentListItem.Status)] = []
+
+    var trashError: Error?
+    private(set) var trashInvocations: [Int64] = []
+
+    var deleteError: Error?
+    private(set) var deleteInvocations: [Int64] = []
+
+    var numberOfRepliesResult: Result<Int, Error>?
+    private(set) var numberOfRepliesInvocations: [Int64] = []
+
     func listComments(filter: CommentsListFilter, nextPage: CommentsPageToken?) async throws -> CommentsPage {
         requests.append((filter, nextPage))
         guard !queuedResults.isEmpty else {
@@ -26,6 +42,41 @@ final class FakeCommentsService: CommentsServiceProtocol {
         fetchCommentInvocations.append((id, allowsEditContext))
         guard let result = fetchCommentResultsByID[id] ?? fetchCommentResult else { throw FakeServiceError() }
         return try result.get()
+    }
+
+    func fetchStatus(id: Int64) async throws -> CommentListItem.Status {
+        fetchStatusInvocations.append(id)
+        guard !fetchStatusResults.isEmpty else { throw FakeServiceError() }
+        return try fetchStatusResults.removeFirst().get()
+    }
+
+    func setStatus(id: Int64, _ status: CommentListItem.Status) async throws -> CommentDetail {
+        setStatusInvocations.append((id, status))
+        guard let setStatusResult else { throw FakeServiceError() }
+        return try setStatusResult.get()
+    }
+
+    /// Shares `setStatusResult`: restore is the same update call on the wire.
+    func restore(id: Int64, from bin: CommentListItem.Status) async throws -> CommentDetail {
+        restoreInvocations.append((id, bin))
+        guard let setStatusResult else { throw FakeServiceError() }
+        return try setStatusResult.get()
+    }
+
+    func trash(id: Int64) async throws {
+        trashInvocations.append(id)
+        if let trashError { throw trashError }
+    }
+
+    func delete(id: Int64) async throws {
+        deleteInvocations.append(id)
+        if let deleteError { throw deleteError }
+    }
+
+    func numberOfReplies(for id: Int64) async throws -> Int {
+        numberOfRepliesInvocations.append(id)
+        guard let numberOfRepliesResult else { throw FakeServiceError() }
+        return try numberOfRepliesResult.get()
     }
 }
 

--- a/Modules/Tests/WordPressCommentsTests/Support/FakeNoticePresenter.swift
+++ b/Modules/Tests/WordPressCommentsTests/Support/FakeNoticePresenter.swift
@@ -1,0 +1,11 @@
+@testable import WordPressComments
+
+@MainActor
+final class FakeNoticePresenter: NoticePresenting {
+    /// The titles presented, in order.
+    private(set) var presented: [String] = []
+
+    func present(title: String) {
+        presented.append(title)
+    }
+}

--- a/Modules/Tests/WordPressCommentsTests/Support/FakeRenderingTracking.swift
+++ b/Modules/Tests/WordPressCommentsTests/Support/FakeRenderingTracking.swift
@@ -12,9 +12,10 @@ final class FakeContentRenderer: NSObject, CommentContentRendering {
     }
 }
 
-// `CommentsTracker` is non-isolated, so this spy can't be `@MainActor` like the
-// other fakes. `NSLock` enforces (rather than just documents) that concurrent
-// `track(_:)` writes and `trackedEvents` reads are race-free.
+// `CommentsTracker` is a non-isolated protocol, so this spy can't be
+// `@MainActor` like the other fakes. `NSLock` enforces (rather than just
+// documents) that concurrent `track(_:)` writes and `trackedEvents` reads
+// are race-free.
 final class SpyCommentsTracker: CommentsTracker, @unchecked Sendable {
     private let lock = NSLock()
     private var events: [CommentsTrackedEvent] = []

--- a/Modules/Tests/WordPressCommentsTests/Support/WpApiError+Stub.swift
+++ b/Modules/Tests/WordPressCommentsTests/Support/WpApiError+Stub.swift
@@ -1,0 +1,17 @@
+import WordPressAPI
+import WordPressAPIInternal
+
+extension WpApiError {
+    /// A REST error carrying only the fields the comments code reads: the WP
+    /// error code and the HTTP status.
+    static func stub(code: WpErrorCode = .CustomError("stub"), statusCode: UInt32 = 400) -> WpApiError {
+        .WpError(
+            errorCode: code,
+            errorMessage: "",
+            statusCode: statusCode,
+            response: "{}",
+            requestUrl: "https://example.com",
+            requestMethod: .get
+        )
+    }
+}

--- a/WordPress/Classes/ViewRelated/Comments/CommentsRouting.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentsRouting.swift
@@ -30,7 +30,8 @@ enum CommentsRouting {
         return CommentsHostingController.make(
             client: client,
             makeContentRenderer: { CommentsWebContentRendererAdapter() },
-            tracker: CommentsTrackerAdapter(blogProperties: blog.analyticsProperties)
+            tracker: CommentsTrackerAdapter(blogProperties: blog.analyticsProperties),
+            noticePresenter: NoticePresenterAdapter()
         )
     }
 }

--- a/WordPress/Classes/ViewRelated/Comments/V2/CommentsTrackerAdapter.swift
+++ b/WordPress/Classes/ViewRelated/Comments/V2/CommentsTrackerAdapter.swift
@@ -5,7 +5,8 @@ import WordPressShared
 /// site segmentation (blog_id, site_type) that legacy `CommentAnalytics` adds via
 /// the blog-associated track overload.
 struct CommentsTrackerAdapter: CommentsTracker {
-    /// Captured once at construction as a `Sendable` snapshot.
+    /// Captured once at construction as a `Sendable` snapshot: `track(_:)`
+    /// is a non-isolated protocol requirement.
     private let blogProperties: BlogAnalyticsProperties
 
     init(blogProperties: BlogAnalyticsProperties) {
@@ -15,7 +16,11 @@ struct CommentsTrackerAdapter: CommentsTracker {
     func track(_ event: CommentsTrackedEvent) {
         let (analyticsEvent, commentID, postID): (WPAnalyticsEvent, Int64, Int64) =
             switch event {
-            case .detailViewed(let commentID, let postID): (.commentViewed, commentID, postID)
+            case .detailViewed(let c, let p): (.commentViewed, c, p)
+            case .approved(let c, let p): (.commentApproved, c, p)
+            case .unapproved(let c, let p): (.commentUnApproved, c, p)
+            case .spammed(let c, let p): (.commentSpammed, c, p)
+            case .trashed(let c, let p): (.commentTrashed, c, p)
             }
         WPAnalytics.track(
             analyticsEvent,

--- a/WordPress/Classes/ViewRelated/Comments/V2/NoticePresenterAdapter.swift
+++ b/WordPress/Classes/ViewRelated/Comments/V2/NoticePresenterAdapter.swift
@@ -1,0 +1,8 @@
+import WordPressComments
+
+@MainActor
+struct NoticePresenterAdapter: NoticePresenting {
+    func present(title: String) {
+        Notice(title: title).post()
+    }
+}


### PR DESCRIPTION
## Description

Moderation actions are intentionally pessimistic. The UI keeps its current state until the server confirms the change, and shows a notice if the request fails.

1. Add approve, move to pending, spam, trash, restore, and permanent delete actions to the comment detail screen.
2. Keep open comment lists and detail screens in sync after moderation. Deleted comments are removed, and their detail screens are dismissed.
3. Confirm destructive actions. Trash warns when the comment has replies or the reply count is unknown. Permanent deletion always requires confirmation.
4. Hide the app tab bar on Comments v2 screens.

https://github.com/user-attachments/assets/a18c131b-3483-4512-b6b6-4d9210ae840e

## Testing instructions

- Test every available action from the Pending, Approved, Spam, and Trash tabs.
- Confirm each action updates the relevant list tabs and the open detail screen.
- Confirm trash and permanent delete show the expected confirmations.
- Confirm permanent delete dismisses the detail screen and removes the comment from the lists.
- Take the app offline and confirm a failed action keeps the previous status and shows an error notice.
- Confirm the app tab bar is hidden on Comments v2 screens and returns after leaving them.

<!-- Consider listing specific testing steps for helping reviewers evaluate the efficacy of the changes -->

<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., VoiceOver)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->
