### PR TITLE
Fix #25595: Locations details show all level

### DIFF
--- a/Modules/Sources/JetpackStats/Cards/TopListCard.swift
+++ b/Modules/Sources/JetpackStats/Cards/TopListCard.swift
@@ -191,7 +191,7 @@ struct TopListCard: View {
         .environment(\.context, context)
         .environment(\.router, router)
 
-        router.navigate(to: screen, title: viewModel.selection.item.localizedTitle)
+        router.navigate(to: screen, title: viewModel.selection.localizedScreenTitle)
     }
 
     private var itemTypePicker: some View {

--- a/Modules/Sources/JetpackStats/Cards/TopListCard.swift
+++ b/Modules/Sources/JetpackStats/Cards/TopListCard.swift
@@ -203,7 +203,8 @@ struct TopListCard: View {
                         selection.item = item
                         let supportedMetric = getSupportedMetrics(for: item)
                         if !supportedMetric.contains(selection.metric),
-                           let metric = supportedMetric.first {
+                            let metric = supportedMetric.first
+                        {
                             selection.metric = metric
                         }
                         viewModel.selection = selection
@@ -262,10 +263,14 @@ struct TopListCard: View {
                 viewModel.selection.options.locationLevel = level
 
                 // Track location level change
-                viewModel.tracker?.send(.locationLevelChanged, properties: [
-                    "from_level": previousLevel.analyticsName,
-                    "to_level": level.analyticsName
-                ])
+                viewModel.tracker?
+                    .send(
+                        .locationLevelChanged,
+                        properties: [
+                            "from_level": previousLevel.analyticsName,
+                            "to_level": level.analyticsName
+                        ]
+                    )
             } label: {
                 Label(level.localizedTitle, systemImage: level.systemImage)
             }
@@ -280,10 +285,14 @@ struct TopListCard: View {
                 viewModel.selection.options.deviceBreakdown = breakdown
 
                 // Track device breakdown change
-                viewModel.tracker?.send(.deviceBreakdownChanged, properties: [
-                    "from_breakdown": previousBreakdown.analyticsName,
-                    "to_breakdown": breakdown.analyticsName
-                ])
+                viewModel.tracker?
+                    .send(
+                        .deviceBreakdownChanged,
+                        properties: [
+                            "from_breakdown": previousBreakdown.analyticsName,
+                            "to_breakdown": breakdown.analyticsName
+                        ]
+                    )
             } label: {
                 Label(breakdown.localizedTitle, systemImage: breakdown.systemImage)
             }
@@ -300,10 +309,14 @@ struct TopListCard: View {
                         viewModel.selection.options.utmParamGrouping = grouping
 
                         // Track UTM parameter grouping change
-                        viewModel.tracker?.send(.utmParamGroupingChanged, properties: [
-                            "from_grouping": previousGrouping.analyticsName,
-                            "to_grouping": grouping.analyticsName
-                        ])
+                        viewModel.tracker?
+                            .send(
+                                .utmParamGroupingChanged,
+                                properties: [
+                                    "from_grouping": previousGrouping.analyticsName,
+                                    "to_grouping": grouping.analyticsName
+                                ]
+                            )
                     } label: {
                         Text(grouping.localizedTitle)
                     }
@@ -449,15 +462,17 @@ private struct TopListCardPreview: View {
 
     init(item: TopListItemType) {
         self.item = item
-        self._viewModel = StateObject(wrappedValue: TopListViewModel(
-            configuration: TopListCardConfiguration(
-                item: item,
-                metric: item == .fileDownloads ? .downloads : .views
-            ),
-            dateRange: Calendar.demo.makeDateRange(for: .last28Days),
-            service: MockStatsService(),
-            tracker: MockStatsTracker.shared
-        ))
+        self._viewModel = StateObject(
+            wrappedValue: TopListViewModel(
+                configuration: TopListCardConfiguration(
+                    item: item,
+                    metric: item == .fileDownloads ? .downloads : .views
+                ),
+                dateRange: Calendar.demo.makeDateRange(for: .last28Days),
+                service: MockStatsService(),
+                tracker: MockStatsTracker.shared
+            )
+        )
     }
 
     var body: some View {

--- a/Modules/Sources/JetpackStats/Cards/TopListViewModel.swift
+++ b/Modules/Sources/JetpackStats/Cards/TopListViewModel.swift
@@ -91,9 +91,11 @@ final class TopListViewModel: ObservableObject, TrafficCardViewModel {
             TopListItemType.contentItems,
             TopListItemType.trafficSourceItems,
             TopListItemType.audienceEngagementItems
-        ].map {
+        ]
+        .map {
             $0.filter(supportedItems.contains)
-        }.filter {
+        }
+        .filter {
             !$0.isEmpty
         }
     }
@@ -111,12 +113,16 @@ final class TopListViewModel: ObservableObject, TrafficCardViewModel {
         isFirstAppear = false
 
         // Track card shown event
-        tracker?.send(.cardShown, properties: [
-            "card_type": CardType.topList.rawValue,
-            "configuration": "\(selection.item.analyticsName)_\(selection.metric.analyticsName)",
-            "item_type": selection.item.analyticsName,
-            "metric": selection.metric.analyticsName
-        ])
+        tracker?
+            .send(
+                .cardShown,
+                properties: [
+                    "card_type": CardType.topList.rawValue,
+                    "configuration": "\(selection.item.analyticsName)_\(selection.metric.analyticsName)",
+                    "item_type": selection.item.analyticsName,
+                    "metric": selection.metric.analyticsName
+                ]
+            )
 
         loadData()
     }
@@ -291,14 +297,16 @@ final class TopListViewModel: ObservableObject, TrafficCardViewModel {
         case .author(let userId):
             let authors = items.lazy.compactMap { $0 as? TopListItem.Author }
             if let author = authors.first(where: { $0.userId == userId }),
-               let posts = author.posts {
+                let posts = author.posts
+            {
                 return posts
             }
             return []
         case .utmMetric(let values):
             let utmMetrics = items.lazy.compactMap { $0 as? TopListItem.UTMMetric }
             if let metric = utmMetrics.first(where: { $0.values == values }),
-               let posts = metric.posts {
+                let posts = metric.posts
+            {
                 return posts
             }
             return []
@@ -315,4 +323,4 @@ final class TopListViewModel: ObservableObject, TrafficCardViewModel {
             previousLocations: previousLocations
         )
     }
- }
+}

--- a/Modules/Sources/JetpackStats/Cards/TopListViewModel.swift
+++ b/Modules/Sources/JetpackStats/Cards/TopListViewModel.swift
@@ -67,6 +67,7 @@ final class TopListViewModel: ObservableObject, TrafficCardViewModel {
 
     init(
         configuration: TopListCardConfiguration,
+        options: TopListItemOptions = TopListItemOptions(),
         dateRange: StatsDateRange,
         service: any StatsServiceProtocol,
         tracker: (any StatsTracker)? = nil,
@@ -76,7 +77,7 @@ final class TopListViewModel: ObservableObject, TrafficCardViewModel {
         initialData: TopListData? = nil
     ) {
         self.configuration = configuration
-        self.selection = Selection(item: configuration.item, metric: configuration.metric)
+        self.selection = Selection(item: configuration.item, metric: configuration.metric, options: options)
         self.items = items ?? service.supportedItems
         self.dateRange = StatsDateRangeSelection(range: dateRange)
         self.service = service

--- a/Modules/Sources/JetpackStats/Cards/TopListViewModel.swift
+++ b/Modules/Sources/JetpackStats/Cards/TopListViewModel.swift
@@ -54,6 +54,15 @@ final class TopListViewModel: ObservableObject, TrafficCardViewModel {
         var item: TopListItemType
         var metric: SiteMetric
         var options = TopListItemOptions()
+
+        /// Title of the screen listing every item in this selection.
+        var localizedScreenTitle: String {
+            if item == .locations {
+                options.locationLevel.localizedTitle
+            } else {
+                item.localizedTitle
+            }
+        }
     }
 
     enum Filter: Equatable {

--- a/Modules/Sources/JetpackStats/Screens/TopListScreenView.swift
+++ b/Modules/Sources/JetpackStats/Screens/TopListScreenView.swift
@@ -27,15 +27,17 @@ struct TopListScreenView: View {
             item: selection.item,
             metric: selection.metric
         )
-        self._viewModel = StateObject(wrappedValue: TopListViewModel(
-            configuration: configuration,
-            dateRange: dateRange,
-            service: service,
-            tracker: context.tracker,
-            fetchLimit: nil, // Get all items
-            filter: filter,
-            initialData: initialData
-        ))
+        self._viewModel = StateObject(
+            wrappedValue: TopListViewModel(
+                configuration: configuration,
+                dateRange: dateRange,
+                service: service,
+                tracker: context.tracker,
+                fetchLimit: nil, // Get all items
+                filter: filter,
+                initialData: initialData
+            )
+        )
     }
 
     var body: some View {
@@ -61,7 +63,9 @@ struct TopListScreenView: View {
                             listContent(data: data)
                         }
                     } else {
-                        makeEmptyStateView(message: viewModel.loadingError?.localizedDescription ?? Strings.Errors.generic)
+                        makeEmptyStateView(
+                            message: viewModel.loadingError?.localizedDescription ?? Strings.Errors.generic
+                        )
                     }
                 }
                 .padding(.horizontal, Constants.cardHorizontalInset(for: horizontalSizeClass))
@@ -211,7 +215,14 @@ struct TopListScreenView: View {
             .padding(.horizontal, Constants.step1)
         } else {
             listHeaderView(title: section.title)
-                .padding(EdgeInsets(top: Constants.step3, leading: Constants.step1, bottom: Constants.step0_5, trailing: Constants.step1))
+                .padding(
+                    EdgeInsets(
+                        top: Constants.step3,
+                        leading: Constants.step1,
+                        bottom: Constants.step0_5,
+                        trailing: Constants.step1
+                    )
+                )
                 .dynamicTypeSize(...DynamicTypeSize.xLarge)
         }
         listForEach(for: section, data: data)

--- a/Modules/Sources/JetpackStats/Screens/TopListScreenView.swift
+++ b/Modules/Sources/JetpackStats/Screens/TopListScreenView.swift
@@ -78,7 +78,7 @@ struct TopListScreenView: View {
         .animation(.default, value: viewModel.data.map(ObjectIdentifier.init))
         .listStyle(.plain)
         .environment(\.defaultMinListRowHeight, 1)
-        .navigationTitle(viewModel.selection.item.localizedTitle)
+        .navigationTitle(viewModel.selection.localizedScreenTitle)
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
             ToolbarItemGroup(placement: .navigationBarTrailing) {
@@ -329,7 +329,7 @@ struct TopListScreenView: View {
         dateFormatter.dateFormat = "yyyy-MM-dd"
         let dateString = dateFormatter.string(from: Date())
 
-        let itemName = viewModel.selection.item.localizedTitle
+        let itemName = viewModel.selection.localizedScreenTitle
             .replacingOccurrences(of: " ", with: "_")
             .replacingOccurrences(of: "&", with: "and")
 

--- a/Modules/Sources/JetpackStats/Screens/TopListScreenView.swift
+++ b/Modules/Sources/JetpackStats/Screens/TopListScreenView.swift
@@ -30,6 +30,7 @@ struct TopListScreenView: View {
         self._viewModel = StateObject(
             wrappedValue: TopListViewModel(
                 configuration: configuration,
+                options: selection.options,
                 dateRange: dateRange,
                 service: service,
                 tracker: context.tracker,

--- a/Modules/Tests/JetpackStatsTests/TopListViewModelTests.swift
+++ b/Modules/Tests/JetpackStatsTests/TopListViewModelTests.swift
@@ -40,6 +40,32 @@ struct TopListViewModelTests {
         try await waitUntil { viewModel.data?.items.isEmpty == true && !viewModel.isLoading }
     }
 
+    @Test("Loads data with the item options provided at initialization")
+    func loadsDataWithProvidedItemOptions() async throws {
+        let service = RecordingStatsService()
+        let calendar = Calendar.mock()
+        let dateRange = StatsDateRange(
+            interval: calendar.makeDateInterval(for: .today),
+            component: .day,
+            comparison: .off,
+            calendar: calendar
+        )
+        let viewModel = TopListViewModel(
+            configuration: TopListCardConfiguration(item: .locations, metric: .views),
+            options: TopListItemOptions(locationLevel: .regions),
+            dateRange: dateRange,
+            service: service
+        )
+
+        viewModel.onAppear()
+        try await waitUntil { viewModel.data != nil && !viewModel.isLoading }
+
+        #expect(viewModel.selection.options.locationLevel == .regions)
+        // The first fetch is the list itself; a second country-level fetch
+        // follows for the map.
+        #expect(await service.requestedLocationLevels.first == .regions)
+    }
+
     private func waitUntil(_ condition: () -> Bool) async throws {
         let clock = ContinuousClock()
         let deadline = clock.now + .seconds(2)
@@ -54,6 +80,65 @@ struct TopListViewModelTests {
 
 private enum TestError: Error {
     case timedOut
+}
+
+private actor RecordingStatsService: StatsServiceProtocol {
+    nonisolated let supportedMetrics: [SiteMetric] = [.views]
+    nonisolated let supportedItems: [TopListItemType] = [.locations]
+
+    private(set) var requestedLocationLevels: [LocationLevel] = []
+
+    nonisolated func getSupportedMetrics(for item: TopListItemType) -> [SiteMetric] {
+        [.views]
+    }
+
+    func invalidateTopListData(for item: TopListItemType) async {
+        // Do nothing
+    }
+
+    func getTopListData(
+        _ item: TopListItemType,
+        metric: SiteMetric,
+        interval: DateInterval,
+        granularity: DateRangeGranularity,
+        limit: Int?,
+        options: TopListItemOptions
+    ) async throws -> TopListResponse {
+        requestedLocationLevels.append(options.locationLevel)
+        return TopListResponse(items: [])
+    }
+
+    func getSiteStats(interval: DateInterval, granularity: DateRangeGranularity) async throws -> SiteMetricsResponse {
+        fatalError("Unused")
+    }
+
+    func getWordAdsStats(date: Date, granularity: DateRangeGranularity) async throws -> WordAdsMetricsResponse {
+        fatalError("Unused")
+    }
+
+    func getWordAdsEarnings() async throws -> WordPressKit.StatsWordAdsEarningsResponse {
+        fatalError("Unused")
+    }
+
+    func getRealtimeTopListData(_ item: TopListItemType) async throws -> TopListResponse {
+        fatalError("Unused")
+    }
+
+    func getPostDetails(for postID: Int) async throws -> StatsPostDetails {
+        fatalError("Unused")
+    }
+
+    func getPostLikes(for postID: Int, count: Int) async throws -> PostLikesData {
+        fatalError("Unused")
+    }
+
+    func getEmailOpens(for postID: Int) async throws -> StatsEmailOpensData {
+        fatalError("Unused")
+    }
+
+    func toggleSpamState(for referrerDomain: String, currentValue: Bool) async throws {
+        fatalError("Unused")
+    }
 }
 
 private actor CachingStatsService: StatsServiceProtocol {

--- a/Modules/Tests/JetpackStatsTests/TopListViewModelTests.swift
+++ b/Modules/Tests/JetpackStatsTests/TopListViewModelTests.swift
@@ -66,6 +66,19 @@ struct TopListViewModelTests {
         #expect(await service.requestedLocationLevels.first == .regions)
     }
 
+    @Test("Screen title names the location level for locations and the item otherwise")
+    func screenTitleReflectsLocationLevel() {
+        let locations = TopListViewModel.Selection(
+            item: .locations,
+            metric: .views,
+            options: TopListItemOptions(locationLevel: .regions)
+        )
+        #expect(locations.localizedScreenTitle == "Regions")
+
+        let referrers = TopListViewModel.Selection(item: .referrers, metric: .views)
+        #expect(referrers.localizedScreenTitle == "Referrers")
+    }
+
     private func waitUntil(_ condition: () -> Bool) async throws {
         let clock = ContinuousClock()
         let deadline = clock.now + .seconds(2)


### PR DESCRIPTION
## Description

Switch to "Regions" and view all:

| Before | After |
| - | - |
| <img width="1206" height="2622" alt="before-locations-title" src="https://github.com/user-attachments/assets/0ff476af-35b1-4f84-934e-9cc22e418ec0" /> | <img width="1206" height="2622" alt="regions-title" src="https://github.com/user-attachments/assets/96c7b925-a8b0-408e-8818-a77d53920978" /> |
