### PR TITLE
Guard against nil reply in createReplyForComment callback

### DIFF
--- a/WordPress/Classes/Services/CommentService.h
+++ b/WordPress/Classes/Services/CommentService.h
@@ -32,7 +32,7 @@ extern NSUInteger const WPTopLevelHierarchicalCommentsPerPage;
 - (instancetype)init NS_UNAVAILABLE;
 
 // Create reply
-- (void)createReplyForComment:(Comment *)comment content:(NSString *)content completion:(void (^)(Comment *reply))completion;
+- (void)createReplyForComment:(Comment *)comment content:(NSString *)content completion:(void (^)(Comment * _Nullable reply))completion;
 
 // Sync comments
 - (void)syncCommentsForBlog:(Blog *)blog

--- a/WordPress/Classes/Services/CommentService.m
+++ b/WordPress/Classes/Services/CommentService.m
@@ -100,7 +100,7 @@ static NSTimeInterval const CommentsRefreshTimeoutInSeconds = 60 * 5; // 5 minut
 }
 
 // Create reply
-- (void)createReplyForComment:(Comment *)comment content:(NSString *)content completion:(void (^)(Comment *reply))completion
+- (void)createReplyForComment:(Comment *)comment content:(NSString *)content completion:(void (^)(Comment * _Nullable reply))completion
 {
     NSManagedObjectID *parentCommentID = comment.objectID;
     NSManagedObjectID * __block replyID = nil;

--- a/WordPress/Classes/ViewRelated/Comments/Controllers/CommentDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Comments/Controllers/CommentDetailViewController.swift
@@ -1014,6 +1014,7 @@ private extension CommentDetailViewController {
         try await withUnsafeThrowingContinuation { (continuation: UnsafeContinuation<Void, Error>) in
             commentService.createReply(for: comment, content: content) { reply in
                 guard let reply else {
+                    DDLogError("Failed creating comment reply: reply was nil after save")
                     continuation.resume(throwing: URLError(.unknown))
                     return
                 }

--- a/WordPress/Classes/ViewRelated/Comments/Controllers/CommentDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Comments/Controllers/CommentDetailViewController.swift
@@ -1011,8 +1011,12 @@ private extension CommentDetailViewController {
             return
         }
 
-        try await withUnsafeThrowingContinuation { continuation in
+        try await withUnsafeThrowingContinuation { (continuation: UnsafeContinuation<Void, Error>) in
             commentService.createReply(for: comment, content: content) { reply in
+                guard let reply else {
+                    continuation.resume(throwing: URLError(.unknown))
+                    return
+                }
                 self.commentService.uploadComment(reply, success: { [weak self] in
                     self?.refreshCommentReplyIfNeeded()
                     continuation.resume()


### PR DESCRIPTION
## Summary

- `createReplyForComment`'s completion is annotated non-null, but its implementation can hand back `nil` — the reply is re-resolved on the main context via `existingObjectWithID:error:`, which returns `nil` when the just-created optimistic comment can't be resolved again (a rare Core Data race).
- Annotate the callback `_Nullable` so the type tells the truth, and guard the single caller so a `nil` reply reports a clean failure instead of silently forwarding `nil` to `uploadComment`.

## Root Cause

The completion resolves its value via `[self.coreDataStack.mainContext existingObjectWithID:replyID error:nil]` (`CommentService.m:119`), which returns `nil` if the optimistic comment can't be re-resolved. The header (`CommentService.h`) sits inside `NS_ASSUME_NONNULL_BEGIN`, so the unannotated `Comment *` has imported into Swift as a non-optional `Comment` since the method was refactored into this shape in 2023 (`63aa79dedd`). Callers therefore couldn't guard the value even though the implementation can produce `nil`.

It's been harmless so far because the one caller only forwards `reply` to `uploadComment(reply, …)` — Objective-C, where messaging `nil` is a safe no-op. It has never been dereferenced in Swift.

## Fix

- `_Nullable` on the callback in `CommentService.h` / `.m`, so it imports into Swift as `Comment?`.
- `guard let reply` in `CommentDetailViewController.createReply` — a `nil` reply resumes the continuation with `URLError(.unknown)` (the error the method's existing failure branch already uses) rather than messaging `nil`. `uploadComment` takes a non-null `Comment`, so the guard is required once `reply` is optional.
- Adding the guard turns that completion into a multi-statement closure, which stops `withUnsafeThrowingContinuation`'s `T` from being inferred from the nested `continuation.resume()`. Pin it explicitly with `UnsafeContinuation<Void, Error>` — the same idiom already used in `BlogService+Settings` and `JetpackConnectionViewModel`.

## Test plan

- [x] Builds — the `guard let` only compiles once `_Nullable` makes `reply` import as `Comment?`, so a green build confirms the annotation and the guard are consistent.
- [ ] Replying to a comment from the comment detail / a notification still posts normally.

There are no existing tests over `createReplyForComment` (a thin Core Data + callback wrapper), so this contract fix doesn't add one.

## Related

Splits a correctness fix out of #25945, which adds the first Swift dereference of this callback (`TaggedManagedObjectID(reply)`) and would otherwise turn this latent inaccuracy into a reachable crash. Landing this first lets #25945 rebase onto an already-`_Nullable` callback with the guard in place.
