### PR TITLE
Remove unused wordpress-rs dependency from the stats widget

### DIFF
--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -640,8 +640,7 @@ enum XcodeSupport {
                     //  "_OBJC_CLASS_$_DDLog", referenced from:
                     //       in AppExtensionsService.o
                     .product(name: "CocoaLumberjack", package: "CocoaLumberjack"),
-                    .product(name: "CocoaLumberjackSwift", package: "CocoaLumberjack"),
-                    .product(name: "WordPressAPI", package: "wordpress-rs")
+                    .product(name: "CocoaLumberjackSwift", package: "CocoaLumberjack")
                 ]
             )
         ]


### PR DESCRIPTION
Removes a stray dependency that linked the entire `wordpress-rs` static library into the stats widget, which never used it.

## Summary
- `XcodeTarget_StatsWidget` (the SPM product backing `JetpackStatsWidgets.appex`) declared `.product(name: "WordPressAPI", package: "wordpress-rs")`, but nothing in the widget references it.
- `wordpress-rs` ships as a **static** library (`libwp_mobile.a`), so it was copied into the widget binary as dead code — duplicating what the main app already carries.
- Dropping the one line removes **~26.6 MB of loaded code** from the widget (arm64/Release).

## Root Cause
The widget target imports only `JetpackStatsWidgetsCore`, `WidgetKit`, and `Foundation`. `JetpackStatsWidgetsCore` depends solely on `BuildSettingsKit`, and none of the widget's other declared dependencies (`WordPressKit`, `WordPressShared`, `WordPressUI`, `TracksMini`) pull in `wordpress-rs`. The `WordPressAPI` product was the sole path linking it in, and it was unreferenced — grepping the widget target and its core module for any `WordPressAPI` / `uniffi` / `wp_api` symbol returns nothing.

Dead code stripping doesn't cover this: `DEAD_CODE_STRIPPING` is already on for Release, but linking the `WordPressAPI` Swift module pins its metadata → the uniffi FFI thunks → the Rust archive, so the linker retains the whole thing even though the widget's own code never calls it. The fix is to not link it. The main app is `wordpress-rs`'s only genuine consumer and is **unchanged**.

## Impact
Measured on the arm64 device slice, Release configuration, `JetpackStatsWidgets.appex`:

| Metric | Before | After | Delta |
|---|--:|--:|--:|
| `__TEXT` (code) | 32.96 MB | 7.98 MB | −25.0 MB |
| `__DATA_CONST` + `__DATA` | 2.60 MB | 1.00 MB | −1.6 MB |
| **Loaded code total** | **35.57 MB** | **8.98 MB** | **−26.6 MB** |
| `wordpress-rs` / uniffi / `WordPressAPI` symbols | 146,506 | 0 | — |

Figures are uncompressed — the App Store download delta will be smaller after compression, but the on-device install footprint drops by the full amount.

## Test Plan
- [x] `JetpackStatsWidgets` builds and links in Release (arm64) with the dependency removed
- [x] Confirmed zero `wordpress-rs` / `uniffi` / `WordPressAPI` symbols remain in the widget binary
- [ ] Stats widgets still render and refresh on device (Small / Medium / Large)
