### PR TITLE
Guard against nil account in createOrUpdateAccountWithAuthToken callback

### DIFF
--- a/WordPress/Classes/Services/AccountService.h
+++ b/WordPress/Classes/Services/AccountService.h
@@ -85,7 +85,7 @@ extern NSNotificationName const WPAccountEmailAndDefaultBlogUpdatedNotification;
  @param failure A failure block.
  */
 - (void)createOrUpdateAccountWithAuthToken:(NSString *)authToken
-                                   success:(void (^)(WPAccount * _Nonnull))success
+                                   success:(void (^)(WPAccount * _Nullable))success
                                    failure:(void (^)(NSError * _Nonnull))failure;
 
 - (NSManagedObjectID *)createOrUpdateAccountWithUserDetails:(RemoteUser *)remoteUser authToken:(NSString *)authToken;

--- a/WordPress/Classes/Services/AccountService.m
+++ b/WordPress/Classes/Services/AccountService.m
@@ -180,7 +180,7 @@ NSString * const WPAccountEmailAndDefaultBlogUpdatedNotification = @"WPAccountEm
 }
 
 - (void)createOrUpdateAccountWithAuthToken:(NSString *)authToken
-                                   success:(void (^)(WPAccount * _Nonnull))success
+                                   success:(void (^)(WPAccount * _Nullable))success
                                    failure:(void (^)(NSError * _Nonnull))failure
 {
     WordPressComRestApi *api = [WordPressComRestApi defaultApiWithOAuthToken:authToken userAgent:[WPUserAgent wordPressUserAgent] localeKey:[WordPressComRestApi LocaleKeyDefault]];

--- a/WordPress/Classes/Services/WordPressComSyncService.swift
+++ b/WordPress/Classes/Services/WordPressComSyncService.swift
@@ -24,6 +24,10 @@ class WordPressComSyncService {
     func syncWPCom(authToken: String, isJetpackLogin: Bool, onSuccess: @escaping (WPAccount) -> Void, onFailure: @escaping (Error) -> Void) {
         let accountService = AccountService(coreDataStack: coreDataStack)
         accountService.createOrUpdateAccount(withAuthToken: authToken, success: { account in
+            guard let account else {
+                onFailure(URLError(.unknown))
+                return
+            }
             self.syncOrAssociateBlogs(account: account, isJetpackLogin: isJetpackLogin, onSuccess: onSuccess, onFailure: onFailure)
         }, failure: { error in
             onFailure(error)


### PR DESCRIPTION
Follows the same pattern as #25964.

## Summary
- `AccountService.createOrUpdateAccountWithAuthToken:success:failure:` declares its success block parameter `WPAccount * _Nonnull`, but the implementation resolves the account via `existingObjectWithID:error:`, which can return `nil`.
- Swift imports the callback as non-optional `WPAccount`, so the single caller (`WordPressComSyncService`) cannot guard it.

## Root Cause
`AccountService.m` passes the result of `existingObjectWithID:error:` straight into the `_Nonnull` success block. If the object can't be re-resolved on the main context (a Core Data race), `account` is `nil`. `WordPressComSyncService.syncOrAssociateBlogs(account:)` then reads the Swift-native `isDefaultWordPressComAccount` on it — risking a trap or wrong-account behavior in the login/sync path.

## Fix
- Mark the success block parameter `WPAccount * _Nullable` in `AccountService.h`/`.m` so the annotation is honest. The implementation body already passes `nil` legally.
- Guard the account in `WordPressComSyncService.syncWPCom(...)`; on `nil`, fail through the existing `onFailure` path.

## Test plan
- [x] `WordPress` app builds (generic iOS Simulator).
- [x] SwiftLint clean.
- [ ] Signing in to a WordPress.com account still syncs the account and its blogs.

Part of an audit of Objective-C non-null declarations whose implementations can return `nil`; see #25964 for the first fix in the series.
