### PR TITLE
Return empty arrays from TaxonomyServiceRemoteREST tag/category mapping

### DIFF
--- a/Modules/Sources/WordPressKitObjC/TaxonomyServiceRemoteREST.m
+++ b/Modules/Sources/WordPressKitObjC/TaxonomyServiceRemoteREST.m
@@ -287,7 +287,7 @@ static NSUInteger const TaxonomyRESTNumberMaxValue = 1000;
 {
     return [jsonArray wp_map:^id(NSDictionary *jsonCategory) {
         return [self remoteCategoryWithJSONDictionary:jsonCategory];
-    }];
+    }] ?: @[];
 }
 
 - (RemotePostCategory *)remoteCategoryWithJSONDictionary:(NSDictionary *)jsonCategory
@@ -303,7 +303,7 @@ static NSUInteger const TaxonomyRESTNumberMaxValue = 1000;
 {
     return [jsonArray wp_map:^id(NSDictionary *jsonTag) {
         return [self remoteTagWithJSONDictionary:jsonTag];
-    }];
+    }] ?: @[];
 }
 
 - (RemotePostTag *)remoteTagWithJSONDictionary:(NSDictionary *)jsonTag

--- a/Tests/WordPressKitTests/WordPressKitTests/Tests/TaxonomyServiceRemoteRESTTests.m
+++ b/Tests/WordPressKitTests/WordPressKitTests/Tests/TaxonomyServiceRemoteRESTTests.m
@@ -200,6 +200,32 @@
                                    failure:^(NSError * __unused error) {}];
 }
 
+/// A response missing the `categories` key must yield an empty array, not `nil`
+/// (a `nil` `NSArray` traps when bridged to a non-optional Swift array).
+- (void)testThatGetCategoriesWithMissingCategoriesKeyReturnsEmptyArray
+{
+    NSString *url = [self GETtaxonomyURLWithType:@"categories"];
+
+    id<WordPressComRESTAPIInterfacing> api = self.service.wordPressComRESTAPI;
+    NSDictionary *json = @{ @"found": @0 };
+    NSHTTPURLResponse *response = OCMStrictClassMock([NSHTTPURLResponse class]);
+    OCMStub([api get:[OCMArg isEqual:url]
+          parameters:[OCMArg any]
+             success:([OCMArg invokeBlockWithArgs:json, response, nil])
+             failure:[OCMArg isNotNil]]);
+
+    XCTestExpectation *gotEmptyArray = [self expectationWithDescription:@"categories should be empty"];
+    id success = ^(NSArray<RemotePostCategory *> * _Nonnull categories) {
+        XCTAssertNotNil(categories);
+        XCTAssertEqualObjects(categories, @[]);
+        [gotEmptyArray fulfill];
+    };
+    [self.service getCategoriesWithSuccess:success
+                                   failure:^(NSError * __unused error) { XCTFail(@"should not fail"); }];
+
+    [self waitForExpectations:@[gotEmptyArray] timeout:0.1];
+}
+
 #pragma mark - Tags
 
 - (void)testThatCreateTagWorks
@@ -313,6 +339,32 @@
     [self.service searchTagsWithName:searchName
                              success:^(NSArray<RemotePostTag *> * __unused tags) {}
                              failure:^(NSError * __unused error) {}];
+}
+
+/// A response missing the `tags` key must yield an empty array, not `nil`
+/// (a `nil` `NSArray` traps when bridged to a non-optional Swift array).
+- (void)testThatGetTagsWithMissingTagsKeyReturnsEmptyArray
+{
+    NSString *url = [self GETtaxonomyURLWithType:@"tags"];
+
+    id<WordPressComRESTAPIInterfacing> api = self.service.wordPressComRESTAPI;
+    NSDictionary *json = @{ @"found": @0 };
+    NSHTTPURLResponse *response = OCMStrictClassMock([NSHTTPURLResponse class]);
+    OCMStub([api get:[OCMArg isEqual:url]
+          parameters:[OCMArg any]
+             success:([OCMArg invokeBlockWithArgs:json, response, nil])
+             failure:[OCMArg isNotNil]]);
+
+    XCTestExpectation *gotEmptyArray = [self expectationWithDescription:@"tags should be empty"];
+    id success = ^(NSArray<RemotePostTag *> * _Nonnull tags) {
+        XCTAssertNotNil(tags);
+        XCTAssertEqualObjects(tags, @[]);
+        [gotEmptyArray fulfill];
+    };
+    [self.service getTagsWithSuccess:success
+                            failure:^(NSError * __unused error) { XCTFail(@"should not fail"); }];
+
+    [self waitForExpectations:@[gotEmptyArray] timeout:0.1];
 }
 
 @end


### PR DESCRIPTION
Follows the pattern from #25964.

## Summary
- `TaxonomyServiceRemoteREST`'s tag/category fetches call their success blocks — declared `NSArray<RemotePostTag *> * _Nonnull` / `NSArray<RemotePostCategory *> * _Nonnull` — with `[self remoteTagsWithJSONArray:[responseObject arrayForKey:…]]`.
- `arrayForKey:` returns `nil` when the key is absent or JSON-null, and `[nil wp_map:…]` is `nil`, so a malformed 200 response leaks `nil` into the `_Nonnull` block.
- The Swift caller (`TagsService`, for `.com` sites) bridges that to non-optional `[RemotePostTag]` and traps at the closure boundary.

## Fix
- Coalesce the two map helpers to `@[]` (`… ?: @[]`). A missing tag/category list semantically **is** empty, so the `_Nonnull` block contract stays true for every current and future caller. This covers all six tag/category fetch entry points at once (`getTags*`, `searchTagsWithName:`, `getCategories*`, `searchCategoriesWithName:`).

## Test plan
- [x] The `WordPressKitObjC` module builds via the `WordPress` app build (generic iOS Simulator).
- [ ] Tag and category lists still load for a `.com` site.

Part of the Objective-C non-null nullability audit; see #25964.
