### PR TITLE
Retry the Unit Tests job once on failure

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -99,6 +99,10 @@ steps:
               api-token-env-name: BUILDKITE_ANALYTICS_TOKEN_UNIT_TESTS
         artifact_paths:
           - "build/results/*"
+        retry:
+          automatic:
+            - exit_status: "*"
+              limit: 1
         notify:
           - github_commit_status:
               context: "Unit Tests"


### PR DESCRIPTION
Retry once on any failure. The suite occasionally hits a Core Data crash when parallel Swift Testing suites touch the test stack at the same time. The existing retry mechanism in the test plan only works on XCTest, not Swift Testing tests.