### PR TITLE
Prioritise release jobs ahead of feature builds

### DIFF
--- a/.buildkite/release-builds.yml
+++ b/.buildkite/release-builds.yml
@@ -5,6 +5,8 @@ agents:
 env:
   IMAGE_ID: $IMAGE_ID
 
+priority: 1
+
 steps:
 
   - label: ":wordpress: :testflight: WordPress Release Build (App Store Connect)"

--- a/.buildkite/release-pipelines/code-freeze.yml
+++ b/.buildkite/release-pipelines/code-freeze.yml
@@ -7,6 +7,8 @@ env:
 agents:
   queue: mac
 
+priority: 1
+
 steps:
   - label: Code Freeze
     plugins:

--- a/.buildkite/release-pipelines/complete-code-freeze.yml
+++ b/.buildkite/release-pipelines/complete-code-freeze.yml
@@ -8,6 +8,8 @@ env:
 agents:
   queue: mac
 
+priority: 1
+
 steps:
   - label: Complete Code Freeze
     key: complete_code_freeze

--- a/.buildkite/release-pipelines/finalize-hotfix.yml
+++ b/.buildkite/release-pipelines/finalize-hotfix.yml
@@ -8,6 +8,8 @@ env:
 agents:
   queue: mac
 
+priority: 1
+
 steps:
   - label: Finalize Hotfix
     plugins:

--- a/.buildkite/release-pipelines/finalize-release.yml
+++ b/.buildkite/release-pipelines/finalize-release.yml
@@ -8,6 +8,8 @@ env:
 agents:
   queue: mac
 
+priority: 1
+
 steps:
   - label: Finalize Release
     plugins:

--- a/.buildkite/release-pipelines/new-beta-release.yml
+++ b/.buildkite/release-pipelines/new-beta-release.yml
@@ -8,6 +8,8 @@ env:
 agents:
   queue: mac
 
+priority: 1
+
 steps:
   - label: New Beta Deployment
     plugins:

--- a/.buildkite/release-pipelines/new-hotfix.yml
+++ b/.buildkite/release-pipelines/new-hotfix.yml
@@ -8,6 +8,8 @@ env:
 agents:
   queue: mac
 
+priority: 1
+
 steps:
   - label: New Hotfix Deployment
     plugins:

--- a/.buildkite/release-pipelines/publish-release.yml
+++ b/.buildkite/release-pipelines/publish-release.yml
@@ -7,6 +7,8 @@ env:
 agents:
   queue: mac
 
+priority: 1
+
 steps:
   - label: Publish Release
     plugins: [$CI_TOOLKIT_PLUGIN]

--- a/.buildkite/release-pipelines/update-app-store-strings.yml
+++ b/.buildkite/release-pipelines/update-app-store-strings.yml
@@ -7,6 +7,8 @@ env:
 agents:
   queue: mac
 
+priority: 1
+
 steps:
   - label: Update App Store Strings
     plugins:


### PR DESCRIPTION
Adds `priority: 1` on all the release pipelines to ensure they run ASAP so the release trains runs with less chances of delays.

Closes [AINFRA-3039](https://linear.app/a8c/issue/AINFRA-3039).

<details>
<summary>AI-generated details.</summary>

## Description

Release builds and the Releases V2 tasks run on the `wordpress-ios` pipeline, in the same `mac` queue as every PR build, so a release manager waits behind queued feature work. This sets `priority: 1` on the nine release pipeline files.

Set pipeline-wide rather than per step so that steps added later inherit it — missing per-step values are how this gap appeared.

Part of [AINFRA-3038](https://linear.app/a8c/issue/AINFRA-3038) (this repo: [AINFRA-3039](https://linear.app/a8c/issue/AINFRA-3039)); audit in [AINFRA-3032](https://linear.app/a8c/issue/AINFRA-3032).

## Testing instructions

CI here does not exercise these files — the upload step only uploads `pipeline.yml`. Locally, all nine parse and all 10 steps resolve to priority `1`.

Real confirmation is the next release: the code freeze or beta job should show **Priority** `1` in Buildkite, against `0` for a PR build.


</details>