### PR TITLE
De-flake EditorConfiguration and WPAccountRestApi tests by isolating the keychain

### DIFF
--- a/Tests/KeystoneTests/Helpers/BlogBuilder.swift
+++ b/Tests/KeystoneTests/Helpers/BlogBuilder.swift
@@ -106,6 +106,9 @@ final class BlogBuilder {
         // Add Account
         let account =
             NSEntityDescription.insertNewObject(forEntityName: WPAccount.entityName(), into: context) as! WPAccount
+        // Isolate the keychain before writing `username`/`authToken`: both route through
+        // the real, process-global keychain otherwise, which leaks state across tests.
+        account.mockKeychain()
         account.displayName = "displayName"
         account.username = username
         account.authToken = authToken

--- a/Tests/KeystoneTests/Helpers/MockAuthKeyMigration.swift
+++ b/Tests/KeystoneTests/Helpers/MockAuthKeyMigration.swift
@@ -1,0 +1,9 @@
+import WordPressData
+
+final class MockAuthKeyMigration: AuthKeyMigrationProtocol {
+    var migrateCalledWithUsernames: [String] = []
+
+    func migrateIfNeeded(username: String) {
+        migrateCalledWithUsernames.append(username)
+    }
+}

--- a/Tests/KeystoneTests/Tests/Models/WPAccount+Fixture.swift
+++ b/Tests/KeystoneTests/Tests/Models/WPAccount+Fixture.swift
@@ -1,5 +1,5 @@
 import CoreData
-import WordPressData
+@testable import WordPressData
 @testable import WordPress
 
 /// Centralized utility to generate preconfigured WPAccount instances
@@ -15,10 +15,21 @@ extension WPAccount {
         authToken: String = "authToken"
     ) -> WPAccount {
         let account = WPAccount(context: context)
+        // Isolate the keychain before writing `username`/`authToken`: both route through
+        // the real, process-global keychain otherwise, which leaks state across tests.
+        account.mockKeychain()
         account.userID = NSNumber(value: userID)
         account.username = username
         account.authToken = authToken
         account.uuid = uuid.uuidString
         return account
+    }
+
+    @discardableResult
+    func mockKeychain() -> WPAccount {
+        keychain = TestKeychain()
+        keychainServiceName = "test-service"
+        keychainMigration = MockAuthKeyMigration()
+        return self
     }
 }


### PR DESCRIPTION
## Summary

- `EditorConfigurationTests` (the Atomic and self-hosted-Jetpack "uses WP.com REST API" cases) and `WPAccountRestApiTests.testAccessingAPIWithTokenDoesNotPostsNotification` are flaky on CI — ~84–98% reliability.
- Both trace to the **same** root cause: `WPAccount.authToken` reads and writes the real, process-global keychain, so tests that share an account username race on a single keychain slot.
- Mock the keychain in the `WPAccount` test fixture and `BlogBuilder` so each account is isolated.

## Root Cause

`WPAccount.authToken` isn't a Core Data attribute — it round-trips through the real iOS keychain (`AppKeychain`), keyed only by `username` plus a constant service name, with no teardown between tests. The Keystone `WPAccount` fixture — unlike its `WordPressDataTests` twin, which already mocks the keychain — left this pointing at the shared system keychain.

When two tests use the same username, one test's account setup transiently clears the shared slot: the `username` setter does `authToken = nil` then restores it. A concurrent `isAccessibleThroughWPCom` read landing in that window sees an empty token, so `wordPressComRestApi` returns `nil`. That surfaces two ways:

- **EditorConfigurationTests**: `shouldUseWPComRestApi` becomes `false`, so `config.siteApiNamespace` comes back empty (`EditorConfigurationTests.swift:113` — "Should include site ID namespace").
- **WPAccountRestApiTests**: the empty read makes `wordPressComRestApi` post `.wpAccountRequiresShowingSigninForWPComFixingAuthToken`, tripping the inverted "does not post" expectation.

## Fix

Add `mockKeychain()` to the Keystone `WPAccount` fixture and call it from both the fixture and `BlogBuilder` **before** any `username`/`authToken` write, injecting an in-memory keychain and a no-op auth-key migration. This matches the already-fixed `WordPressDataTests` fixture.

`MockAuthKeyMigration` is duplicated here because the two test targets can't share test helpers today. Consolidating the in-memory keychain fake (and this migration mock) into a single low-level type is a planned follow-up.

## Test plan

- [x] `EditorConfigurationTests` — 6/6 green, including "Atomic site uses WP.com REST API" and "Self-hosted site with Jetpack connection uses WP.com REST API" (iOS 26.5, Xcode 26.6)
- [x] `WPAccountRestApiTests` — 2/2 green
- [ ] CI green
