### PR TITLE
Fix a crash generating thumbnails for self-hosted videos

### DIFF
--- a/WordPress/Classes/Utility/Media/MediaExporter.swift
+++ b/WordPress/Classes/Utility/Media/MediaExporter.swift
@@ -123,10 +123,46 @@ extension MediaExporter {
     }
 
     func export() async throws -> MediaExport {
-        try await withUnsafeThrowingContinuation { continuation in
-            export(onCompletion: { continuation.resume(returning: $0) },
-                   onError: { continuation.resume(throwing: $0) })
+        try await withCheckedThrowingContinuation { continuation in
+            let once = ResumeOnce(continuation)
+            export(onCompletion: { once.resume(returning: $0) },
+                   onError: { once.resume(throwing: $0) })
         }
+    }
+}
+
+/// A thread-safe wrapper that guarantees a `CheckedContinuation` is resumed at
+/// most once, degrading any subsequent resume to a no-op.
+///
+/// The callback-based media export APIs can, on a cancellation race, deliver a
+/// second terminal callback (e.g. a stray `.cancelled` after a success). Bridging
+/// them to `async` with a raw continuation would make that second resume undefined
+/// behavior — a hard crash. Routing every resume through this type keeps the
+/// bridge safe regardless of how many times the callback fires.
+final class ResumeOnce<T> {
+    private let lock = NSLock()
+    private var continuation: CheckedContinuation<T, Error>?
+
+    init(_ continuation: CheckedContinuation<T, Error>) {
+        self.continuation = continuation
+    }
+
+    func resume(returning value: T) {
+        take()?.resume(returning: value)
+    }
+
+    func resume(throwing error: Error) {
+        take()?.resume(throwing: error)
+    }
+
+    /// Atomically hands out the continuation exactly once, niling it so any
+    /// later call returns `nil`.
+    private func take() -> CheckedContinuation<T, Error>? {
+        lock.lock()
+        defer { lock.unlock() }
+        let continuation = self.continuation
+        self.continuation = nil
+        return continuation
     }
 }
 

--- a/WordPress/Classes/Utility/Media/MediaThumbnailExporter.swift
+++ b/WordPress/Classes/Utility/Media/MediaThumbnailExporter.swift
@@ -267,11 +267,12 @@ extension MediaThumbnailExporter {
     func exportThumbnail(forFileURL fileURL: URL) async throws -> (ThumbnailIdentifier, MediaExport) {
         let token = MediaExportCancelationToken()
         return try await withTaskCancellationHandler {
-            try await withUnsafeThrowingContinuation { continuation in
+            try await withCheckedThrowingContinuation { continuation in
+                let once = ResumeOnce(continuation)
                 token.progress = exportThumbnail(forFile: fileURL, onCompletion: {
-                    continuation.resume(returning: ($0, $1))
+                    once.resume(returning: ($0, $1))
                 }, onError: {
-                    continuation.resume(throwing: $0)
+                    once.resume(throwing: $0)
                 })
             }
         } onCancel: {
@@ -282,11 +283,12 @@ extension MediaThumbnailExporter {
     func exportThumbnail(forVideoURL url: URL) async throws -> (ThumbnailIdentifier, MediaExport) {
         let token = MediaExportCancelationToken()
         return try await withTaskCancellationHandler {
-            try await withUnsafeThrowingContinuation { continuation in
+            try await withCheckedThrowingContinuation { continuation in
+                let once = ResumeOnce(continuation)
                 token.progress = exportThumbnail(forVideoURL: url, onCompletion: {
-                    continuation.resume(returning: ($0, $1))
+                    once.resume(returning: ($0, $1))
                 }, onError: {
-                    continuation.resume(throwing: $0)
+                    once.resume(throwing: $0)
                 })
             }
         } onCancel: {

--- a/WordPress/Classes/Utility/Media/MediaVideoExporter.swift
+++ b/WordPress/Classes/Utility/Media/MediaVideoExporter.swift
@@ -221,10 +221,18 @@ class MediaVideoExporter: MediaExporter {
                                                         exporter.options = imageOptions
                                                     }
                                                     exporter.mediaDirectoryType = self.mediaDirectoryType
-                                                    let imageProgress = exporter.export(
-                                                                         onCompletion: onCompletion,
-                                                                         onError: onError)
-                                                    progress.addChild(imageProgress, withPendingUnitCount: MediaExportProgressUnits.halfDone)
+                                                    // The image export is synchronous and resumes the awaiting task via
+                                                    // `onCompletion`/`onError`, so finish all `progress` bookkeeping *before*
+                                                    // those callbacks fire. Mutating the `progress` object graph afterwards
+                                                    // would race the resumed task, which can cancel `progress` from another
+                                                    // thread (see the cancellation handler above).
+                                                    exporter.export(onCompletion: { export in
+                                                        progress.completedUnitCount = MediaExportProgressUnits.done
+                                                        onCompletion(export)
+                                                    }, onError: { error in
+                                                        progress.completedUnitCount = MediaExportProgressUnits.done
+                                                        onError(error)
+                                                    })
         })
         return progress
     }


### PR DESCRIPTION
## Summary

- Fixes an intermittent `SIGSEGV` in the video-thumbnail `async` bridge. It surfaces as a hard crash of `MediaImageServiceTests.testSmallThumbnailForRemoteSelfHostedVideo`, and this bridge runs in production every time the app generates a thumbnail for a self-hosted video — so it is a shipping bug, not just a test artifact.
- The test is **retained deliberately** as the regression guard: it exercises the real `AVFoundation` path and is the only thing that caught this.

## Root Cause

Self-hosted videos have no `remoteThumbnailURL`, so the app generates the thumbnail from the video itself via live `AVFoundation`: `MediaImageService.generateThumbnailForVideo` → `MediaThumbnailExporter.exportThumbnail(forVideoURL:)` → `MediaVideoExporter.exportPreviewImageForVideo`.

The callback-to-`async` bridge was unsafe in two compounding ways:

1. **Unsafe continuation, resumed more than once.** The bridge used `withUnsafeThrowingContinuation`. `AVAssetImageGenerator.generateCGImagesAsynchronously` can invoke its completion handler a second time (a `.cancelled` callback on teardown, or racing the cancellation handler), resuming the same continuation twice. A double-resume of an **unsafe** continuation is undefined behavior — a raw `SIGSEGV` — instead of the deterministic trap a checked continuation gives.
2. **`Progress` mutated after the resume.** In `exportPreviewImageForVideo` the image export is synchronous, so `exporter.export(onCompletion:onError:)` resumes the continuation inline. The next line — `progress.addChild(imageProgress, …)` — then mutated the `Progress` object graph on `AVFoundation`'s queue **after** the awaiting task had resumed and could be racing forward on another thread.

## Fix

### 1. Make the async bridges resume-once and checked

`MediaExporter.export()`, `MediaThumbnailExporter.exportThumbnail(forFileURL:)` and `exportThumbnail(forVideoURL:)` now use `withCheckedThrowingContinuation` routed through a small `NSLock`-backed `ResumeOnce<T>` that nils the continuation on first resume. A stray second callback degrades to a **no-op**. The checked variant stays permanently — the unsafe one buys nothing here and hides exactly this class of bug.

### 2. Stop mutating `progress` after the resume

`exportPreviewImageForVideo` finalizes `progress.completedUnitCount = .done` **inside** the inner export's `onCompletion`/`onError`, before the resuming callback fires. The post-resume `addChild` is removed. Because the image export is synchronous and returns an already-complete `Progress`, this is equivalent for progress reporting while removing the cross-thread mutation.

## What We Explored

- **Reproducing the SEGV locally.** Ran the pre-fix binary 200× with per-iteration relaunch on an iOS 26 simulator: 200/200 passed, 0 crashes. The crash does **not** reproduce in an isolated local loop — it needs CI-level executor contention (the test runs alongside hundreds of others). The test never cancels, so the operative mechanism is the double-resume (1), which is **not** a `TSan`-detectable data race — so `TSan` is clean on this path and adds nothing here. Part 1 makes the crash impossible regardless of the exact micro-mechanism.

## Test Plan

- [x] `rake lint` clean on all changed files.
- [x] `WordPressUnitTests` builds; `testSmallThumbnailForRemoteSelfHostedVideo` green across 121 executions of the real `AVFoundation` path (0 crashes / 0 failures).
- [x] Pre-fix SEGV confirmed not locally reproducible (200/200 clean) — documented above.
- [ ] Full `WordPressUnitTests` suite on CI (running the pipeline repeatedly to confirm the flake is gone).

## Related

- The sibling `testSmallThumbnailForRemoteVideo` ~3% flake is a separate `MemoryCache.shared` / `ImageDownloader.shared` test-isolation issue, out of scope here.
