### PR TITLE
Harden RichContentFormatter sanitization + add a comprehensive test suite

### DIFF
--- a/Modules/Sources/WordPressShared/Utility/RichContentFormatter.swift
+++ b/Modules/Sources/WordPressShared/Utility/RichContentFormatter.swift
@@ -50,17 +50,17 @@ import Foundation
 
         content = RegEx.styleTags.stringByReplacingMatches(in: content,
                                                            options: .reportCompletion,
-                                                           range: NSRange(location: 0, length: content.count),
+                                                           range: NSRange(location: 0, length: content.utf16.count),
                                                            withTemplate: "")
 
         content = RegEx.scriptTags.stringByReplacingMatches(in: content,
                                                             options: .reportCompletion,
-                                                            range: NSRange(location: 0, length: content.count),
+                                                            range: NSRange(location: 0, length: content.utf16.count),
                                                             withTemplate: "")
 
         content = RegEx.gutenbergComments.stringByReplacingMatches(in: content,
                                                                    options: .reportCompletion,
-                                                                   range: NSRange(location: 0, length: content.count),
+                                                                   range: NSRange(location: 0, length: content.utf16.count),
                                                                    withTemplate: "")
 
         return content
@@ -84,23 +84,23 @@ import Foundation
         // Convert div tags to p tags
         content = RegEx.divTagsStart.stringByReplacingMatches(in: content,
                                                               options: .reportCompletion,
-                                                              range: NSRange(location: 0, length: content.count),
+                                                              range: NSRange(location: 0, length: content.utf16.count),
                                                               withTemplate: openPTag)
 
         content = RegEx.divTagsEnd.stringByReplacingMatches(in: content,
                                                             options: .reportCompletion,
-                                                            range: NSRange(location: 0, length: content.count),
+                                                            range: NSRange(location: 0, length: content.utf16.count),
                                                             withTemplate: closePTag)
 
         // Remove duplicate/redundant p tags.
         content = RegEx.pTagsStart.stringByReplacingMatches(in: content,
                                                             options: .reportCompletion,
-                                                            range: NSRange(location: 0, length: content.count),
+                                                            range: NSRange(location: 0, length: content.utf16.count),
                                                             withTemplate: openPTag)
 
         content = RegEx.pTagsEnd.stringByReplacingMatches(in: content,
                                                           options: .reportCompletion,
-                                                          range: NSRange(location: 0, length: content.count),
+                                                          range: NSRange(location: 0, length: content.utf16.count),
                                                           withTemplate: closePTag)
 
         content = filterNewLines(content)
@@ -114,11 +114,11 @@ import Foundation
         var ranges = [NSRange]()
         // We don't want to remove new lines from preformatted tag blocks,
         // so get the ranges of such blocks.
-        let matches = RegEx.preTags.matches(in: content, options: .reportCompletion, range: NSRange(location: 0, length: content.count))
+        let matches = RegEx.preTags.matches(in: content, options: .reportCompletion, range: NSRange(location: 0, length: content.utf16.count))
         if matches.isEmpty {
 
             // No blocks found, so we'll parse the whole string.
-            ranges.append(NSRange(location: 0, length: content.count))
+            ranges.append(NSRange(location: 0, length: content.utf16.count))
         } else {
 
             // One or more preformatted blocks found, we don't want to remove new lines
@@ -133,7 +133,7 @@ import Foundation
                 location = match.range.location + match.range.length
             }
 
-            length = content.count - location
+            length = content.utf16.count - location
             ranges.append(NSRange(location: location, length: length))
         }
 
@@ -163,7 +163,7 @@ import Foundation
 
         content = RegEx.styleAttr.stringByReplacingMatches(in: content,
                                                            options: .reportCompletion,
-                                                           range: NSRange(location: 0, length: content.count),
+                                                           range: NSRange(location: 0, length: content.utf16.count),
                                                            withTemplate: "")
 
         return content
@@ -206,10 +206,9 @@ import Foundation
         }
 
         var content = string.trim()
-        let matches = RegEx.trailingBRTags.matches(in: content, options: .reportCompletion, range: NSRange(location: 0, length: content.count))
-        if let match = matches.first {
-            let index = content.index(content.startIndex, offsetBy: match.range.location)
-            content = String(content.prefix(upTo: index))
+        let matches = RegEx.trailingBRTags.matches(in: content, options: .reportCompletion, range: NSRange(location: 0, length: content.utf16.count))
+        if let match = matches.first, let matchRange = Range(match.range, in: content) {
+            content = String(content[..<matchRange.lowerBound])
         }
 
         return content

--- a/Modules/Sources/WordPressShared/Utility/RichContentFormatter.swift
+++ b/Modules/Sources/WordPressShared/Utility/RichContentFormatter.swift
@@ -8,8 +8,8 @@ import Foundation
     ///
     public struct RegEx {
         // Forbidden tags
-        static let styleTags = try! NSRegularExpression(pattern: "<style[^>]*?>[\\s\\S]*?</style>", options: .caseInsensitive)
-        static let scriptTags = try! NSRegularExpression(pattern: "<script[^>]*?>[\\s\\S]*?</script>", options: .caseInsensitive)
+        static let styleTags = try! NSRegularExpression(pattern: "<style[^>]*?>[\\s\\S]*?(?:</style>|$)", options: .caseInsensitive)
+        static let scriptTags = try! NSRegularExpression(pattern: "<script[^>]*?>[\\s\\S]*?(?:</script>|$)", options: .caseInsensitive)
         static let gutenbergComments = try! NSRegularExpression(pattern: "<p><!-- /?wp:.+? /?--></p>[\\n]?", options: .caseInsensitive)
 
         // Normalizaing Paragraphs
@@ -19,10 +19,10 @@ import Foundation
         static let pTagsEnd = try! NSRegularExpression(pattern: "</p>\\s*</p>", options: .caseInsensitive)
         static let newLines = try! NSRegularExpression(pattern: "\\n", options: .caseInsensitive)
         static let preTags = try! NSRegularExpression(pattern: "<pre[^>]*>[\\s\\S]*?</pre>", options: .caseInsensitive)
-        static let videoTags = try! NSRegularExpression(pattern: "<video[^>]*>", options: .caseInsensitive)
+        static let videoTags = try! NSRegularExpression(pattern: "<video(\\s[^>]*)?>", options: .caseInsensitive)
 
         // Inline Styles
-        static let styleAttr = try! NSRegularExpression(pattern: "\\s*style=\"[^\"]*\"", options: .caseInsensitive)
+        static let styleAttr = try! NSRegularExpression(pattern: "\\s+style=(?:\"[^\"]*\"|'[^']*')", options: .caseInsensitive)
 
         // Gallery Images
         public static let galleryImgTags = try! NSRegularExpression(pattern: "<img[^>]*data-orig-file[^>]*/>", options: .caseInsensitive)
@@ -178,21 +178,20 @@ import Foundation
     /// - Returns: The value for the attribute or an empty string..
     ///
     @objc public class func parseValueForAttribute(_ attribute: String, inElement element: String) -> String {
-        let elementStr = element as NSString
-        var value = ""
-        let attrStr = "\(attribute)=\""
-        let attrRange = elementStr.range(of: attrStr)
-
-        if attrRange.location != NSNotFound {
-            let location = attrRange.location + attrRange.length
-            let length = elementStr.length - location
-            let ending = elementStr.range(of: "\"", options: .caseInsensitive, range: NSRange(location: location, length: length))
-            if ending.location != NSNotFound {
-                value = elementStr.substring(with: NSRange(location: location, length: ending.location - location))
-            }
+        // Match the attribute name on a word boundary (so "rc" does not match inside "src")
+        // and capture its double-quoted value. A missing closing quote fails to match, so there
+        // is no out-of-bounds range to crash on.
+        let escaped = NSRegularExpression.escapedPattern(for: attribute)
+        guard let regex = try? NSRegularExpression(pattern: "(?<![\\w-])\(escaped)=\"([^\"]*)\"") else {
+            return ""
         }
-
-        return value
+        let range = NSRange(element.startIndex..., in: element)
+        guard let match = regex.firstMatch(in: element, range: range),
+            let valueRange = Range(match.range(at: 1), in: element)
+        else {
+            return ""
+        }
+        return String(element[valueRange])
     }
 
     /// Removes any trailing BR tags from the end of the specified string.
@@ -264,10 +263,10 @@ import Foundation
         // For each video tag, check for controls attribute
         for match in matches.reversed() {
             let tag = mString.substring(with: match.range) as NSString
-            if !tag.contains("controls") {
-                // Add the controls attribute.
-                let range = NSRange(location: match.range.location, length: 6)
-                mString.replaceCharacters(in: range, with: "<video controls")
+            let controls = "\\scontrols(?![\\w-])"
+            if tag.range(of: controls, options: [.regularExpression, .caseInsensitive]).location == NSNotFound {
+                // Insert `controls` after the `<video` opening, preserving the tag's casing.
+                mString.insert(" controls", at: match.range.location + 6)
             }
         }
 

--- a/Modules/Sources/WordPressShared/Utility/RichContentFormatter.swift
+++ b/Modules/Sources/WordPressShared/Utility/RichContentFormatter.swift
@@ -187,7 +187,9 @@ import Foundation
             let location = attrRange.location + attrRange.length
             let length = elementStr.length - location
             let ending = elementStr.range(of: "\"", options: .caseInsensitive, range: NSRange(location: location, length: length))
-            value = elementStr.substring(with: NSRange(location: location, length: ending.location - location))
+            if ending.location != NSNotFound {
+                value = elementStr.substring(with: NSRange(location: location, length: ending.location - location))
+            }
         }
 
         return value

--- a/Modules/Sources/WordPressSharedUI/RichContentFormatter+DisplayPipeline.swift
+++ b/Modules/Sources/WordPressSharedUI/RichContentFormatter+DisplayPipeline.swift
@@ -86,7 +86,7 @@ extension RichContentFormatter {
                 of: srcImgURLStr,
                 with: modifiedURL.absoluteString,
                 options: .literal,
-                range: NSRange(location: 0, length: imgElementStr.count)
+                range: NSRange(location: 0, length: imgElementStr.utf16.count)
             )
 
             mContent.replaceCharacters(in: match.range, with: mImageStr as String)

--- a/Modules/Sources/WordPressSharedUI/RichContentFormatter+DisplayPipeline.swift
+++ b/Modules/Sources/WordPressSharedUI/RichContentFormatter+DisplayPipeline.swift
@@ -83,8 +83,8 @@ extension RichContentFormatter {
 
             let mImageStr = NSMutableString(string: imgElementStr)
             mImageStr.replaceOccurrences(
-                of: srcImgURLStr,
-                with: modifiedURL.absoluteString,
+                of: "src=\"\(srcImgURLStr)\"",
+                with: "src=\"\(modifiedURL.absoluteString)\"",
                 options: .literal,
                 range: NSRange(location: 0, length: imgElementStr.utf16.count)
             )

--- a/Modules/Tests/WordPressSharedTests/RichContentFormatterSanitizationTests.swift
+++ b/Modules/Tests/WordPressSharedTests/RichContentFormatterSanitizationTests.swift
@@ -1,0 +1,292 @@
+import Foundation
+import Testing
+
+@testable import WordPressShared
+
+/// Behavioural coverage for `RichContentFormatter`'s platform-independent text
+/// transformations — the regex-driven sanitisation that runs over untrusted
+/// remote post and comment HTML.
+///
+/// These methods live in `WordPressShared`, so this suite runs under `swift test`
+/// on macOS with no simulator.
+@Suite("RichContentFormatter sanitization")
+struct RichContentFormatterSanitizationTests {
+
+    // MARK: - removeForbiddenTags
+
+    @Suite("removeForbiddenTags")
+    struct RemoveForbiddenTags {
+        @Test(
+            "strips script, style, and Gutenberg-comment paragraphs",
+            arguments: [
+                // Basic script/style removal.
+                ("<script>alert(1)</script>Hello", "Hello"),
+                ("<style>body{color:#000}</style>Hello", "Hello"),
+                // Case-insensitive.
+                ("<SCRIPT>alert(1)</SCRIPT>Hello", "Hello"),
+                ("<STYLE type=\"text/css\">a{}</STYLE>Hello", "Hello"),
+                // Attributes on the opening tag.
+                ("<script src=\"evil.js\">x</script>Hi", "Hi"),
+                // Newlines inside the element body.
+                ("<script>\n  alert(1)\n</script>Hi", "Hi"),
+                // Multiple occurrences.
+                ("a<script>1</script>b<script>2</script>c", "abc"),
+                ("a<style>1</style>b<style>2</style>c", "abc"),
+                // Gutenberg block comments wrapped in <p>, with and without trailing newline.
+                ("<p><!-- wp:paragraph --></p>\nHi", "Hi"),
+                ("<p><!-- /wp:paragraph --></p>Hi", "Hi"),
+                ("<p><!-- wp:self-closing-tag /--></p>Hi", "Hi"),
+                // An unclosed forbidden tag is stripped through the end of the input.
+                ("<script>alert(1)", ""),
+                ("Hello <script>alert(1)", "Hello "),
+                ("<style>body{}", ""),
+                // Non-BMP prefix must not shrink the UTF-16 search range.
+                ("😀😀😀😀😀<script>alert(1)</script>", "😀😀😀😀😀"),
+                // No-ops.
+                ("<p>plain paragraph</p>", "<p>plain paragraph</p>"),
+                ("", "")
+            ]
+        )
+        func strips(input: String, expected: String) {
+            #expect(RichContentFormatter.removeForbiddenTags(input) == expected)
+        }
+    }
+
+    // MARK: - removeInlineStyles
+
+    @Suite("removeInlineStyles")
+    struct RemoveInlineStyles {
+        @Test(
+            "strips double-quoted style attributes and the whitespace before them",
+            arguments: [
+                ("<p style=\"color:red\">x</p>", "<p>x</p>"),
+                ("<p STYLE=\"color:red\">x</p>", "<p>x</p>"),
+                ("<p style=\"\">x</p>", "<p>x</p>"),
+                // Leading whitespace is consumed with the attribute.
+                ("<a href=\"x\" style=\"color:red\">y</a>", "<a href=\"x\">y</a>"),
+                // Multiple styled elements.
+                ("<p style=\"a\">1</p><p style=\"b\">2</p>", "<p>1</p><p>2</p>"),
+                // Single-quoted styles are stripped too, leaving other attributes intact.
+                ("<p style='color:red'>x</p>", "<p>x</p>"),
+                ("<a style='a' title=\"t\">y</a>", "<a title=\"t\">y</a>"),
+                // Attribute names ending in `style` are NOT corrupted (left boundary).
+                ("<img data-style=\"x\" src=\"y\">", "<img data-style=\"x\" src=\"y\">"),
+                ("<div data-mce-style='z'>t</div>", "<div data-mce-style='z'>t</div>"),
+                // Non-BMP prefix must not shrink the UTF-16 search range.
+                ("😀<p style=\"color:red\">t</p>", "😀<p>t</p>"),
+                // No-ops.
+                ("<p>no style here</p>", "<p>no style here</p>"),
+                ("", "")
+            ]
+        )
+        func strips(input: String, expected: String) {
+            #expect(RichContentFormatter.removeInlineStyles(input) == expected)
+        }
+    }
+
+    // MARK: - normalizeParagraphs
+
+    @Suite("normalizeParagraphs")
+    struct NormalizeParagraphs {
+        @Test(
+            "converts DIVs to Ps, collapses redundant Ps, and drops non-PRE newlines",
+            arguments: [
+                // Anchor case from the original suite.
+                (
+                    "<div><p>test</p></div><pre>\n\ntest\n\n</pre>\n<p><div>test</div></p>\n",
+                    "<p>test</p><pre>\n\ntest\n\n</pre><p>test</p>"
+                ),
+                // Simple div -> p.
+                ("<div>x</div>", "<p>x</p>"),
+                // Div with attributes.
+                ("<div class=\"wp-block\">x</div>", "<p>x</p>"),
+                // Already-normal paragraphs are left alone.
+                ("<p>a</p><p>b</p>", "<p>a</p><p>b</p>"),
+                // Non-BMP prefix must not desync the div->p conversion (balanced tags).
+                ("😀😀😀😀😀<div>x</div>", "😀😀😀😀😀<p>x</p>"),
+                ("", "")
+            ]
+        )
+        func normalizes(input: String, expected: String) {
+            #expect(RichContentFormatter.normalizeParagraphs(input) == expected)
+        }
+    }
+
+    // MARK: - filterNewLines
+
+    @Suite("filterNewLines")
+    struct FilterNewLines {
+        @Test(
+            "removes newlines except inside <pre> blocks",
+            arguments: [
+                // No PRE: every newline goes.
+                ("a\nb\nc", "abc"),
+                ("\n\n\n", ""),
+                // Newlines inside PRE are preserved; those outside are removed.
+                ("<pre>a\nb</pre>", "<pre>a\nb</pre>"),
+                ("x\n<pre>a\nb</pre>\ny", "x<pre>a\nb</pre>y"),
+                // Multiple PRE blocks.
+                ("<pre>1\n2</pre>\n<pre>3\n4</pre>\n", "<pre>1\n2</pre><pre>3\n4</pre>"),
+                ("", "")
+            ]
+        )
+        func filters(input: String, expected: String) {
+            #expect(RichContentFormatter.filterNewLines(input) == expected)
+        }
+
+        @Test("drops a newline after a non-BMP character (UTF-16-correct NSRange)")
+        func dropsNewlineAfterNonBMP() {
+            // "😀" is one Character but two UTF-16 code units; the range must use the UTF-16
+            // length or the trailing newline falls outside it and is left in place.
+            #expect(RichContentFormatter.filterNewLines("ab😀\n") == "ab😀")
+        }
+    }
+
+    // MARK: - removeTrailingBreakTags
+
+    @Suite("removeTrailingBreakTags")
+    struct RemoveTrailingBreakTags {
+        @Test(
+            "trims trailing <br> runs (and surrounding whitespace) but keeps interior ones",
+            arguments: [
+                // Anchor case.
+                ("<p>test</p><br><p>test</p><br><br> ", "<p>test</p><br><p>test</p>"),
+                // Single trailing break, various spellings.
+                ("text<br>", "text"),
+                ("text<br/>", "text"),
+                ("text<br />", "text"),
+                ("text<BR>", "text"),
+                // Runs.
+                ("text<br><br><br>", "text"),
+                ("<br><br>", ""),
+                // Interior break is preserved.
+                ("a<br>b", "a<br>b"),
+                // Non-BMP prefix: trailing <br> still trimmed, and no out-of-bounds crash.
+                ("😀<br>", "😀"),
+                ("😀😀😀😀😀<br>", "😀😀😀😀😀"),
+                // Leading/trailing whitespace is trimmed even with no break.
+                ("  spaced  ", "spaced"),
+                ("no breaks", "no breaks"),
+                ("", "")
+            ]
+        )
+        func trims(input: String, expected: String) {
+            #expect(RichContentFormatter.removeTrailingBreakTags(input) == expected)
+        }
+    }
+
+    // MARK: - formatVideoTags
+
+    @Suite("formatVideoTags")
+    struct FormatVideoTags {
+        @Test(
+            "adds a controls attribute only when absent",
+            arguments: [
+                ("<p>x</p><video></video><p>y</p>", "<p>x</p><video controls></video><p>y</p>"),
+                ("<video autoplay></video>", "<video controls autoplay></video>"),
+                // Already has controls -> untouched.
+                ("<video controls></video>", "<video controls></video>"),
+                // `controls` inside an attribute value/name is not the controls attribute.
+                (
+                    "<video poster=\"https://x/controls.jpg\"></video>",
+                    "<video controls poster=\"https://x/controls.jpg\"></video>"
+                ),
+                ("<video class=\"my-controls\"></video>", "<video controls class=\"my-controls\"></video>"),
+                ("<video controlslist=\"nodownload\"></video>", "<video controls controlslist=\"nodownload\"></video>"),
+                // Existing CONTROLS (case-insensitive) is not duplicated.
+                ("<video CONTROLS></video>", "<video CONTROLS></video>"),
+                // Must not over-match a different element.
+                ("<videoxyz></videoxyz>", "<videoxyz></videoxyz>"),
+                // No video -> untouched.
+                ("<p>no video</p>", "<p>no video</p>"),
+                ("", "")
+            ]
+        )
+        func addsControls(input: String, expected: String) {
+            #expect(RichContentFormatter.formatVideoTags(input) == expected)
+        }
+
+        @Test("preserves the opening tag's original casing when inserting controls")
+        func preservesOpeningTagCasing() {
+            #expect(RichContentFormatter.formatVideoTags("<VIDEO></VIDEO>") == "<VIDEO controls></VIDEO>")
+        }
+    }
+
+    // MARK: - parseValueForAttribute
+
+    @Suite("parseValueForAttribute")
+    struct ParseValueForAttribute {
+        @Test(
+            "returns the double-quoted value of an attribute, or empty when absent",
+            arguments: [
+                ("src", "<img src=\"http://example.com/a.jpg\">", "http://example.com/a.jpg"),
+                (
+                    "data-orig-file", "<img data-orig-file=\"http://example.com/o.jpg\" src=\"s\">",
+                    "http://example.com/o.jpg"
+                ),
+                // Missing attribute.
+                ("href", "<img src=\"x\">", ""),
+                // Present but empty.
+                ("src", "<img src=\"\">", ""),
+                // First match wins.
+                ("src", "<img src=\"a\" src=\"b\">", "a")
+            ]
+        )
+        func parses(attribute: String, element: String, expected: String) {
+            #expect(RichContentFormatter.parseValueForAttribute(attribute, inElement: element) == expected)
+        }
+
+        @Test("Regression: an unterminated attribute quote returns empty instead of crashing")
+        func unterminatedQuoteReturnsEmpty() {
+            // Previously `ending.location == NSNotFound` was fed into `substringWithRange:`,
+            // throwing NSInvalidArgumentException. Reachable from adversarial gallery HTML via
+            // `resizeGalleryImageURL`. Now guarded to return "".
+            #expect(RichContentFormatter.parseValueForAttribute("src", inElement: "<img src=\"unterminated>").isEmpty)
+        }
+
+        @Test("does not match an attribute name as a substring of another attribute")
+        func doesNotMatchSubstringAttributeName() {
+            // "rc" must not match inside "src", nor "orig-file" inside "data-orig-file".
+            #expect(RichContentFormatter.parseValueForAttribute("rc", inElement: "<img src=\"x\">").isEmpty)
+            #expect(
+                RichContentFormatter.parseValueForAttribute("orig-file", inElement: "<img data-orig-file=\"y\">")
+                    .isEmpty
+            )
+        }
+    }
+
+    // MARK: - formatGutenbergGallery
+
+    @Suite("formatGutenbergGallery")
+    struct FormatGutenbergGallery {
+        @Test(
+            "leaves non-gallery content untouched",
+            arguments: [
+                "<p>hello</p>",
+                "<ul><li>plain list</li></ul>",
+                ""
+            ]
+        )
+        func noOp(input: String) {
+            #expect(RichContentFormatter.formatGutenbergGallery(input) == input)
+        }
+
+        @Test("removes gallery UL/LI markup while keeping the figures inside")
+        func stripsGalleryMarkupKeepsFigures() {
+            let input =
+                "Before. <ul class=\"wp-block-gallery columns-3 is-cropped\">"
+                + "<li class=\"blocks-gallery-item\"><figure><img src=\"https://example.com/1.jpg\" />"
+                + "<figcaption>One</figcaption></figure></li>"
+                + "<li class=\"blocks-gallery-item\"><figure><img src=\"https://example.com/2.jpg\" /></figure></li>"
+                + "</ul> After."
+            let output = RichContentFormatter.formatGutenbergGallery(input) as NSString
+
+            #expect(output.range(of: "block-gallery").location == NSNotFound)
+            #expect(output.range(of: "blocks-gallery").location == NSNotFound)
+            #expect(output.range(of: "<figure>").location != NSNotFound)
+            #expect(output.range(of: "figcaption").location != NSNotFound)
+            #expect(output.range(of: "https://example.com/1.jpg").location != NSNotFound)
+            #expect(output.range(of: "https://example.com/2.jpg").location != NSNotFound)
+        }
+    }
+}

--- a/Modules/Tests/WordPressSharedTests/RichContentFormatterTests.swift
+++ b/Modules/Tests/WordPressSharedTests/RichContentFormatterTests.swift
@@ -65,4 +65,114 @@ class RichContentFormatterTests: XCTestCase {
         let sanitizedStr3 = RichContentFormatter.formatVideoTags(str3) as NSString
         XCTAssert(!sanitizedStr3.contains("controls controls"))
     }
+
+    // MARK: - Multi-code-unit input
+    //
+    // The bug sized each search range from the grapheme count (`content.count`) rather than the
+    // UTF-16 length. A cluster that is one grapheme but several UTF-16 units — emoji, a ZWJ
+    // sequence, a flag, a keycap, a skin-tone modifier, or a decomposed accent — therefore leaves
+    // a token near the end of the string just past the range, so the search never reaches it.
+    // Each test drives one such spot; the exact-output check also confirms the cluster is intact.
+
+    func testRegionalFlagStyleBlockSurvivesInTail() {
+        // A <style> block after a flag emoji is stripped; the neighbouring <b> stays.
+        let out = RichContentFormatter.removeForbiddenTags("🇺🇸<b>hi</b><style>zz</style>")
+        XCTAssertEqual(out, "🇺🇸<b>hi</b>")
+    }
+
+    func testZWJFamilyScriptTagSurvivesInTail() {
+        // A <script> after a family emoji — one grapheme but 11 UTF-16 units, the widest gap here.
+        let out = RichContentFormatter.removeForbiddenTags("👨‍👩‍👧‍👦<script>x</script>")
+        XCTAssertEqual(out, "👨‍👩‍👧‍👦")
+    }
+
+    func testKeycapGutenbergCommentSurvivesInTail() {
+        // A Gutenberg block comment after a keycap emoji is stripped.
+        let out = RichContentFormatter.removeForbiddenTags("1️⃣<p><!-- wp:paragraph --></p>")
+        XCTAssertEqual(out, "1️⃣")
+    }
+
+    func testSkinToneDivStartNotConvertedInTail() {
+        // <div> is converted to <p> even after a skin-tone emoji.
+        let out = RichContentFormatter.normalizeParagraphs("👍🏽<div>")
+        XCTAssertEqual(out, "👍🏽<p>")
+    }
+
+    func testNFDCombiningDivEndNotConvertedInTail() {
+        // </div> is converted to </p> after a decomposed "é" (e + a combining accent). A composed
+        // "é" is a single UTF-16 unit and would not reach past the range, so the decomposition matters.
+        let out = RichContentFormatter.normalizeParagraphs("cafe\u{301}</div>")
+        XCTAssertEqual(out, "cafe\u{301}</p>")
+    }
+
+    func testNormalizeParagraphsMergesTrailingDoubleOpenParagraph() {
+        // A redundant <p><p> is collapsed to a single <p>.
+        let out = RichContentFormatter.normalizeParagraphs("😀<p><p>")
+        XCTAssertEqual(out, "😀<p>")
+    }
+
+    func testNormalizeParagraphsMergesTrailingDoubleCloseParagraph() {
+        // A redundant </p></p> is collapsed to a single </p>.
+        let out = RichContentFormatter.normalizeParagraphs("😀</p></p>")
+        XCTAssertEqual(out, "😀</p>")
+    }
+
+    func testFilterNewLinesNoPreFallbackRemovesNewlinePastWideCluster() {
+        // A newline outside any <pre> block is removed.
+        let out = RichContentFormatter.filterNewLines("👨‍👩‍👧‍👦\nA")
+        XCTAssertEqual(out, "👨‍👩‍👧‍👦A")
+    }
+
+    func testFilterNewLinesElseBranchPreservesTrailingNewlineAfterWideCluster() {
+        // With a <pre> block present, a newline that follows it (outside the block) is still removed.
+        let out = RichContentFormatter.filterNewLines("<pre>\n</pre>👨‍👩‍👧‍👦\nZ")
+        XCTAssertEqual(out, "<pre>\n</pre>👨‍👩‍👧‍👦Z")
+    }
+
+    func testFilterNewLinesMultiPreInverseRanges() {
+        // Across several <pre> blocks: newlines inside them are kept, newlines outside are removed.
+        let out = RichContentFormatter.filterNewLines("👨‍👩‍👧‍👦\n<pre>a\nb</pre>\n😀\n<pre>c\nd</pre>\n🇺🇸\n")
+        XCTAssertEqual(out, "👨‍👩‍👧‍👦<pre>a\nb</pre>😀<pre>c\nd</pre>🇺🇸")
+    }
+
+    func testZWJFamilyStyleAttrSurvivesInTruncatedTail() {
+        // An inline style attribute after a family emoji is stripped.
+        let out = RichContentFormatter.removeInlineStyles("👨‍👩‍👧‍👦<div style=\"x\">")
+        XCTAssertEqual(out, "👨‍👩‍👧‍👦<div>")
+    }
+
+    func testZWJFamilyTrailingBreakSurvivesAndCutsCleanly() {
+        // A trailing <br> after a family emoji is removed, and the emoji before it stays intact.
+        let out = RichContentFormatter.removeTrailingBreakTags("👨‍👩‍👧‍👦text<br>")
+        XCTAssertEqual(out, "👨‍👩‍👧‍👦text")
+    }
+
+    func testTrailingBreakOnlyFinalRemovedEmojiIntact() {
+        // Only the trailing <br> is removed; an earlier <br> in the middle of the text stays.
+        let out = RichContentFormatter.removeTrailingBreakTags("😀<br>text<br>")
+        XCTAssertEqual(out, "😀<br>text")
+    }
+
+    func testForbiddenCleanMultibyteUnchanged() {
+        // Content with no tags to strip passes through unchanged.
+        let out = RichContentFormatter.removeForbiddenTags("Hello 👨‍👩‍👧‍👦 world 😀!")
+        XCTAssertEqual(out, "Hello 👨‍👩‍👧‍👦 world 😀!")
+    }
+
+    // MARK: - Boundary + selectivity (not new fix sites)
+
+    func testBoundaryStraddleOffByOne() {
+        // One emoji makes the range exactly one UTF-16 unit short, and the token's closing ">"
+        // is exactly that dropped unit — pins the off-by-one where the wide-gap cases have slack.
+        let out = RichContentFormatter.removeForbiddenTags("text<script>😀</script>")
+        XCTAssertEqual(out, "text")
+    }
+
+    func testStripsTagInRangeAndInTailNotJustEverything() {
+        // The first style attribute is always in range; the ZWJ family pushes the second into the
+        // truncated tail. The fix strips both; the bug strips only the first — so the range, not a
+        // blanket "strip everything", decides which tags go.
+        let out = RichContentFormatter.removeInlineStyles("<a style=\"one\">👨‍👩‍👧‍👦<b style=\"two\">")
+        XCTAssertEqual(out, "<a>👨‍👩‍👧‍👦<b>")
+    }
 }

--- a/Modules/Tests/WordPressSharedTests/RichContentFormatterTests.swift
+++ b/Modules/Tests/WordPressSharedTests/RichContentFormatterTests.swift
@@ -1,69 +1,73 @@
-import XCTest
+import Foundation
+import Testing
+
 @testable import WordPressShared
 
-class RichContentFormatterTests: XCTestCase {
+struct RichContentFormatterTests {
 
-    func testRemoveInlineStyles() {
+    @Test func testRemoveInlineStyles() {
         let str = "<p>test</p><p>test</p>"
         let styleStr = "<p style=\"background-color:#fff;\">test</p><p style=\"background-color:#fff;\">test</p>"
         let sanitizedStr = RichContentFormatter.removeInlineStyles(styleStr)
-        XCTAssertTrue(str == sanitizedStr, "The inline styles were not removed.")
+        #expect(str == sanitizedStr, "The inline styles were not removed.")
     }
 
-    func testRemoveForbiddenTags() {
+    @Test func testRemoveForbiddenTags() {
         let str = "<p>test</p><p>test</p><img>"
-        let styleStr = "<script>alert();</script><style>body{color:#000;}</style><p>test</p><script>alert();</script><style>body{color:#000;}</style><p>test</p><p><!-- wp:paragraph {\"fontSize\":\"large\"}--></p><p><!-- /wp:paragraph --></p>\n<img><p><!-- wp:self-closing-tag /--></p><script>alert();</script><style>body{color:#000;}</style>"
+        let styleStr =
+            "<script>alert();</script><style>body{color:#000;}</style><p>test</p><script>alert();</script><style>body{color:#000;}</style><p>test</p><p><!-- wp:paragraph {\"fontSize\":\"large\"}--></p><p><!-- /wp:paragraph --></p>\n<img><p><!-- wp:self-closing-tag /--></p><script>alert();</script><style>body{color:#000;}</style>"
         let sanitizedStr = RichContentFormatter.removeForbiddenTags(styleStr)
-        XCTAssertTrue(str == sanitizedStr, "The forbidden tags were not removed.")
+        #expect(str == sanitizedStr, "The forbidden tags were not removed.")
     }
 
-    func testNormalizeParagraphs() {
+    @Test func testNormalizeParagraphs() {
         let str = "<p>test</p><pre>\n\ntest\n\n</pre><p>test</p>"
         let styleStr = "<div><p>test</p></div><pre>\n\ntest\n\n</pre>\n<p><div>test</div></p>\n"
         let sanitizedStr = RichContentFormatter.normalizeParagraphs(styleStr)
-        XCTAssertTrue(str == sanitizedStr, "Not all paragraphs were normalized.")
+        #expect(str == sanitizedStr, "Not all paragraphs were normalized.")
     }
 
-    func testFilterNewLines() {
+    @Test func testFilterNewLines() {
         let str = "<div><p>test</p></div><pre>\n\ntest\n\n</pre><p><div>test</div></p>"
         let styleStr = "<div><p>test</p></div><pre>\n\ntest\n\n</pre>\n<p><div>test</div></p>\n"
         let sanitizedStr = RichContentFormatter.filterNewLines(styleStr)
-        XCTAssertTrue(str == sanitizedStr, "Not all paragraphs were normalized.")
+        #expect(str == sanitizedStr, "Not all paragraphs were normalized.")
     }
 
-    func testRemoveTrailingBRTags() {
+    @Test func testRemoveTrailingBRTags() {
         let str = "<p>test</p><br><p>test</p>"
         let styleStr = "<p>test</p><br><p>test</p><br><br> "
         let sanitizedStr = RichContentFormatter.removeTrailingBreakTags(styleStr)
-        XCTAssertTrue(str == sanitizedStr, "The inline styles were not removed.")
+        #expect(str == sanitizedStr, "The inline styles were not removed.")
     }
 
-    func testRemoveGutenbergGalleryListMarkup() {
-        let str = "Some text. <ul class=\"wp-block-gallery columns-3 is-cropped\"><li class=\"blocks-gallery-item\"><figure><img src=\"https://example.com/wp-content/uploads/2017/05/IMG_1364.jpg\" alt=\"\" data-id=\"103\" data-link=\"https://example.com/img_1364/\" class=\"wp-image-103\" srcset=\"https://example.com/wp-content/uploads/2017/05/IMG_1364.jpg 2048w, https://example.com/wp-content/uploads/2017/05/IMG_1364-300x225.jpg 300w, https://example.com/wp-content/uploads/2017/05/IMG_1364-768x576.jpg 768w, https://example.com/wp-content/uploads/2017/05/IMG_1364-1024x768.jpg 1024w, https://example.com/wp-content/uploads/2017/05/IMG_1364-1200x900.jpg 1200w\" sizes=\"(max-width: 2048px) 100vw, 2048px\" /><figcaption>Plants<br></figcaption></figure></li><li class=\"blocks-gallery-item\"><figure><img src=\"https://example.com/wp-content/uploads/2017/05/IMG_1215.jpg\" alt=\"\" data-id=\"102\" data-link=\"https://example.com/img_1215/\" class=\"wp-image-102\" srcset=\"https://example.com/wp-content/uploads/2017/05/IMG_1215.jpg 2048w, https://example.com/wp-content/uploads/2017/05/IMG_1215-300x225.jpg 300w, https://example.com/wp-content/uploads/2017/05/IMG_1215-768x576.jpg 768w, https://example.com/wp-content/uploads/2017/05/IMG_1215-1024x768.jpg 1024w, https://example.com/wp-content/uploads/2017/05/IMG_1215-1200x900.jpg 1200w\" sizes=\"(max-width: 2048px) 100vw, 2048px\" /></figure></li><li class=\"blocks-gallery-item\"><figure><img src=\"https://example.com/wp-content/uploads/2017/05/img_5918.jpg\" alt=\"\" data-id=\"101\" data-link=\"https://example.com/img_5918-jpg/\" class=\"wp-image-101\" srcset=\"https://example.com/wp-content/uploads/2017/05/img_5918.jpg 1000w, https://example.com/wp-content/uploads/2017/05/img_5918-225x300.jpg 225w, https://example.com/wp-content/uploads/2017/05/img_5918-768x1024.jpg 768w\" sizes=\"(max-width: 1000px) 100vw, 1000px\" /></figure></li></ul> Some text."
+    @Test func testRemoveGutenbergGalleryListMarkup() {
+        let str =
+            "Some text. <ul class=\"wp-block-gallery columns-3 is-cropped\"><li class=\"blocks-gallery-item\"><figure><img src=\"https://example.com/wp-content/uploads/2017/05/IMG_1364.jpg\" alt=\"\" data-id=\"103\" data-link=\"https://example.com/img_1364/\" class=\"wp-image-103\" srcset=\"https://example.com/wp-content/uploads/2017/05/IMG_1364.jpg 2048w, https://example.com/wp-content/uploads/2017/05/IMG_1364-300x225.jpg 300w, https://example.com/wp-content/uploads/2017/05/IMG_1364-768x576.jpg 768w, https://example.com/wp-content/uploads/2017/05/IMG_1364-1024x768.jpg 1024w, https://example.com/wp-content/uploads/2017/05/IMG_1364-1200x900.jpg 1200w\" sizes=\"(max-width: 2048px) 100vw, 2048px\" /><figcaption>Plants<br></figcaption></figure></li><li class=\"blocks-gallery-item\"><figure><img src=\"https://example.com/wp-content/uploads/2017/05/IMG_1215.jpg\" alt=\"\" data-id=\"102\" data-link=\"https://example.com/img_1215/\" class=\"wp-image-102\" srcset=\"https://example.com/wp-content/uploads/2017/05/IMG_1215.jpg 2048w, https://example.com/wp-content/uploads/2017/05/IMG_1215-300x225.jpg 300w, https://example.com/wp-content/uploads/2017/05/IMG_1215-768x576.jpg 768w, https://example.com/wp-content/uploads/2017/05/IMG_1215-1024x768.jpg 1024w, https://example.com/wp-content/uploads/2017/05/IMG_1215-1200x900.jpg 1200w\" sizes=\"(max-width: 2048px) 100vw, 2048px\" /></figure></li><li class=\"blocks-gallery-item\"><figure><img src=\"https://example.com/wp-content/uploads/2017/05/img_5918.jpg\" alt=\"\" data-id=\"101\" data-link=\"https://example.com/img_5918-jpg/\" class=\"wp-image-101\" srcset=\"https://example.com/wp-content/uploads/2017/05/img_5918.jpg 1000w, https://example.com/wp-content/uploads/2017/05/img_5918-225x300.jpg 225w, https://example.com/wp-content/uploads/2017/05/img_5918-768x1024.jpg 768w\" sizes=\"(max-width: 1000px) 100vw, 1000px\" /></figure></li></ul> Some text."
         let sanitizedString = RichContentFormatter.formatGutenbergGallery(str) as NSString
         // Checks if the UL was removed.
         var range = sanitizedString.range(of: "block-gallery")
-        XCTAssertTrue(range.location == NSNotFound)
+        #expect(range.location == NSNotFound)
         // Checks if the LI was removed
         range = sanitizedString.range(of: "blocks-gallery")
-        XCTAssertTrue(range.location == NSNotFound)
+        #expect(range.location == NSNotFound)
         // Checks if the FIGCAPTION was kept.
         range = sanitizedString.range(of: "figcaption")
-        XCTAssertTrue(range.location != NSNotFound)
+        #expect(range.location != NSNotFound)
     }
 
-    func testFormatVideoTags() {
+    @Test func testFormatVideoTags() {
         let str1 = "<p>Some text.</p><video></video><p>Some text.</p>"
         let sanitizedStr1 = RichContentFormatter.formatVideoTags(str1) as NSString
-        XCTAssert(sanitizedStr1.contains("controls"))
+        #expect(sanitizedStr1.contains("controls"))
 
         let str2 = "<p>Some text.</p><video autoplay></video><p>Some text.</p>"
         let sanitizedStr2 = RichContentFormatter.formatVideoTags(str2) as NSString
-        XCTAssert(sanitizedStr2.contains(" controls "))
+        #expect(sanitizedStr2.contains(" controls "))
 
         let str3 = "<p>Some text.</p><video controls></video><p>Some text.</p>"
         let sanitizedStr3 = RichContentFormatter.formatVideoTags(str3) as NSString
-        XCTAssert(!sanitizedStr3.contains("controls controls"))
+        #expect(!sanitizedStr3.contains("controls controls"))
     }
 
     // MARK: - Multi-code-unit input
@@ -74,105 +78,105 @@ class RichContentFormatterTests: XCTestCase {
     // a token near the end of the string just past the range, so the search never reaches it.
     // Each test drives one such spot; the exact-output check also confirms the cluster is intact.
 
-    func testRegionalFlagStyleBlockSurvivesInTail() {
+    @Test func testRegionalFlagStyleBlockSurvivesInTail() {
         // A <style> block after a flag emoji is stripped; the neighbouring <b> stays.
         let out = RichContentFormatter.removeForbiddenTags("🇺🇸<b>hi</b><style>zz</style>")
-        XCTAssertEqual(out, "🇺🇸<b>hi</b>")
+        #expect(out == "🇺🇸<b>hi</b>")
     }
 
-    func testZWJFamilyScriptTagSurvivesInTail() {
+    @Test func testZWJFamilyScriptTagSurvivesInTail() {
         // A <script> after a family emoji — one grapheme but 11 UTF-16 units, the widest gap here.
         let out = RichContentFormatter.removeForbiddenTags("👨‍👩‍👧‍👦<script>x</script>")
-        XCTAssertEqual(out, "👨‍👩‍👧‍👦")
+        #expect(out == "👨‍👩‍👧‍👦")
     }
 
-    func testKeycapGutenbergCommentSurvivesInTail() {
+    @Test func testKeycapGutenbergCommentSurvivesInTail() {
         // A Gutenberg block comment after a keycap emoji is stripped.
         let out = RichContentFormatter.removeForbiddenTags("1️⃣<p><!-- wp:paragraph --></p>")
-        XCTAssertEqual(out, "1️⃣")
+        #expect(out == "1️⃣")
     }
 
-    func testSkinToneDivStartNotConvertedInTail() {
+    @Test func testSkinToneDivStartNotConvertedInTail() {
         // <div> is converted to <p> even after a skin-tone emoji.
         let out = RichContentFormatter.normalizeParagraphs("👍🏽<div>")
-        XCTAssertEqual(out, "👍🏽<p>")
+        #expect(out == "👍🏽<p>")
     }
 
-    func testNFDCombiningDivEndNotConvertedInTail() {
+    @Test func testNFDCombiningDivEndNotConvertedInTail() {
         // </div> is converted to </p> after a decomposed "é" (e + a combining accent). A composed
         // "é" is a single UTF-16 unit and would not reach past the range, so the decomposition matters.
         let out = RichContentFormatter.normalizeParagraphs("cafe\u{301}</div>")
-        XCTAssertEqual(out, "cafe\u{301}</p>")
+        #expect(out == "cafe\u{301}</p>")
     }
 
-    func testNormalizeParagraphsMergesTrailingDoubleOpenParagraph() {
+    @Test func testNormalizeParagraphsMergesTrailingDoubleOpenParagraph() {
         // A redundant <p><p> is collapsed to a single <p>.
         let out = RichContentFormatter.normalizeParagraphs("😀<p><p>")
-        XCTAssertEqual(out, "😀<p>")
+        #expect(out == "😀<p>")
     }
 
-    func testNormalizeParagraphsMergesTrailingDoubleCloseParagraph() {
+    @Test func testNormalizeParagraphsMergesTrailingDoubleCloseParagraph() {
         // A redundant </p></p> is collapsed to a single </p>.
         let out = RichContentFormatter.normalizeParagraphs("😀</p></p>")
-        XCTAssertEqual(out, "😀</p>")
+        #expect(out == "😀</p>")
     }
 
-    func testFilterNewLinesNoPreFallbackRemovesNewlinePastWideCluster() {
+    @Test func testFilterNewLinesNoPreFallbackRemovesNewlinePastWideCluster() {
         // A newline outside any <pre> block is removed.
         let out = RichContentFormatter.filterNewLines("👨‍👩‍👧‍👦\nA")
-        XCTAssertEqual(out, "👨‍👩‍👧‍👦A")
+        #expect(out == "👨‍👩‍👧‍👦A")
     }
 
-    func testFilterNewLinesElseBranchPreservesTrailingNewlineAfterWideCluster() {
+    @Test func testFilterNewLinesElseBranchPreservesTrailingNewlineAfterWideCluster() {
         // With a <pre> block present, a newline that follows it (outside the block) is still removed.
         let out = RichContentFormatter.filterNewLines("<pre>\n</pre>👨‍👩‍👧‍👦\nZ")
-        XCTAssertEqual(out, "<pre>\n</pre>👨‍👩‍👧‍👦Z")
+        #expect(out == "<pre>\n</pre>👨‍👩‍👧‍👦Z")
     }
 
-    func testFilterNewLinesMultiPreInverseRanges() {
+    @Test func testFilterNewLinesMultiPreInverseRanges() {
         // Across several <pre> blocks: newlines inside them are kept, newlines outside are removed.
         let out = RichContentFormatter.filterNewLines("👨‍👩‍👧‍👦\n<pre>a\nb</pre>\n😀\n<pre>c\nd</pre>\n🇺🇸\n")
-        XCTAssertEqual(out, "👨‍👩‍👧‍👦<pre>a\nb</pre>😀<pre>c\nd</pre>🇺🇸")
+        #expect(out == "👨‍👩‍👧‍👦<pre>a\nb</pre>😀<pre>c\nd</pre>🇺🇸")
     }
 
-    func testZWJFamilyStyleAttrSurvivesInTruncatedTail() {
+    @Test func testZWJFamilyStyleAttrSurvivesInTruncatedTail() {
         // An inline style attribute after a family emoji is stripped.
         let out = RichContentFormatter.removeInlineStyles("👨‍👩‍👧‍👦<div style=\"x\">")
-        XCTAssertEqual(out, "👨‍👩‍👧‍👦<div>")
+        #expect(out == "👨‍👩‍👧‍👦<div>")
     }
 
-    func testZWJFamilyTrailingBreakSurvivesAndCutsCleanly() {
+    @Test func testZWJFamilyTrailingBreakSurvivesAndCutsCleanly() {
         // A trailing <br> after a family emoji is removed, and the emoji before it stays intact.
         let out = RichContentFormatter.removeTrailingBreakTags("👨‍👩‍👧‍👦text<br>")
-        XCTAssertEqual(out, "👨‍👩‍👧‍👦text")
+        #expect(out == "👨‍👩‍👧‍👦text")
     }
 
-    func testTrailingBreakOnlyFinalRemovedEmojiIntact() {
+    @Test func testTrailingBreakOnlyFinalRemovedEmojiIntact() {
         // Only the trailing <br> is removed; an earlier <br> in the middle of the text stays.
         let out = RichContentFormatter.removeTrailingBreakTags("😀<br>text<br>")
-        XCTAssertEqual(out, "😀<br>text")
+        #expect(out == "😀<br>text")
     }
 
-    func testForbiddenCleanMultibyteUnchanged() {
+    @Test func testForbiddenCleanMultibyteUnchanged() {
         // Content with no tags to strip passes through unchanged.
         let out = RichContentFormatter.removeForbiddenTags("Hello 👨‍👩‍👧‍👦 world 😀!")
-        XCTAssertEqual(out, "Hello 👨‍👩‍👧‍👦 world 😀!")
+        #expect(out == "Hello 👨‍👩‍👧‍👦 world 😀!")
     }
 
     // MARK: - Boundary + selectivity (not new fix sites)
 
-    func testBoundaryStraddleOffByOne() {
+    @Test func testBoundaryStraddleOffByOne() {
         // One emoji makes the range exactly one UTF-16 unit short, and the token's closing ">"
         // is exactly that dropped unit — pins the off-by-one where the wide-gap cases have slack.
         let out = RichContentFormatter.removeForbiddenTags("text<script>😀</script>")
-        XCTAssertEqual(out, "text")
+        #expect(out == "text")
     }
 
-    func testStripsTagInRangeAndInTailNotJustEverything() {
+    @Test func testStripsTagInRangeAndInTailNotJustEverything() {
         // The first style attribute is always in range; the ZWJ family pushes the second into the
         // truncated tail. The fix strips both; the bug strips only the first — so the range, not a
         // blanket "strip everything", decides which tags go.
         let out = RichContentFormatter.removeInlineStyles("<a style=\"one\">👨‍👩‍👧‍👦<b style=\"two\">")
-        XCTAssertEqual(out, "<a>👨‍👩‍👧‍👦<b>")
+        #expect(out == "<a>👨‍👩‍👧‍👦<b>")
     }
 }

--- a/Modules/Tests/WordPressSharedTests/RichContentFormatterTests.swift
+++ b/Modules/Tests/WordPressSharedTests/RichContentFormatterTests.swift
@@ -179,4 +179,23 @@ struct RichContentFormatterTests {
         let out = RichContentFormatter.removeInlineStyles("<a style=\"one\">👨‍👩‍👧‍👦<b style=\"two\">")
         #expect(out == "<a>👨‍👩‍👧‍👦<b>")
     }
+
+    // MARK: - parseValueForAttribute robustness
+
+    @Test func testParseValueForAttributeReturnsValue() {
+        let value = RichContentFormatter.parseValueForAttribute("src", inElement: "<img src=\"http://x/a.jpg\">")
+        #expect(value == "http://x/a.jpg")
+    }
+
+    @Test func testParseValueForAttributeMissingClosingQuoteReturnsEmpty() {
+        // Opening quote but no closing quote: the closing-quote search returns NSNotFound, so the
+        // range length would underflow to a huge value and crash substring(with:). Return "" instead.
+        let value = RichContentFormatter.parseValueForAttribute("src", inElement: "<img src=\"http://x/a.jpg>")
+        #expect(value.isEmpty)
+    }
+
+    @Test func testParseValueForAttributeAbsentReturnsEmpty() {
+        let value = RichContentFormatter.parseValueForAttribute("src", inElement: "<img alt=\"x\">")
+        #expect(value.isEmpty)
+    }
 }

--- a/Modules/Tests/WordPressSharedTests/RichContentFormatterUITests.swift
+++ b/Modules/Tests/WordPressSharedTests/RichContentFormatterUITests.swift
@@ -27,4 +27,13 @@ struct RichContentFormatterUITests {
         // ...and the emoji cluster survived byte-for-byte.
         #expect(output.contains("😀😀😀😀😀"))
     }
+
+    @Test func testResizeGalleryImageURLLeavesSrcsetIntact() {
+        // The src value also appears in srcset; only the src attribute should be rewritten.
+        let srcset = "srcset=\"https://example.com/a.jpg 1x, https://example.com/b.jpg 2x\""
+        let input =
+            "<img src=\"https://example.com/a.jpg\" \(srcset) data-orig-file=\"https://example.com/orig.jpg\" />"
+        let output = RichContentFormatter.resizeGalleryImageURL(input, isPrivateSite: false)
+        #expect(output.contains(srcset), "srcset must be left intact when the src is resized")
+    }
 }

--- a/Modules/Tests/WordPressSharedTests/RichContentFormatterUITests.swift
+++ b/Modules/Tests/WordPressSharedTests/RichContentFormatterUITests.swift
@@ -1,11 +1,13 @@
-import XCTest
+import Foundation
+import Testing
+
 @testable import WordPressShared
 @testable import WordPressSharedUI
 
-class RichContentFormatterUITests: XCTestCase {
+struct RichContentFormatterUITests {
 
-    func testResizeGalleryImageURLsForContentEmptyString() {
-        XCTAssertTrue("" == RichContentFormatter.resizeGalleryImageURL("", isPrivateSite: false))
+    @Test func testResizeGalleryImageURLsForContentEmptyString() {
+        #expect(RichContentFormatter.resizeGalleryImageURL("", isPrivateSite: false).isEmpty)
     }
 
     // The gallery-image src rewrite sized its search range from the grapheme count
@@ -13,16 +15,16 @@ class RichContentFormatterUITests: XCTestCase {
     // multi-code-unit cluster fell outside the range and was never swapped for the resized
     // URL. Here five emoji in `alt` (10 UTF-16 units, 5 graphemes) push the trailing `src`
     // past a grapheme-count range; the resized URL must still replace it, cluster intact.
-    func testResizeGalleryImageURLReplacesSrcPastMultibyteCluster() {
+    @Test func testResizeGalleryImageURLReplacesSrcPastMultibyteCluster() {
         let input =
             "<img data-orig-file=\"https://example.com/orig.jpg\" alt=\"😀😀😀😀😀\" src=\"https://example.com/small.jpg\"/>"
 
         let output = RichContentFormatter.resizeGalleryImageURL(input, isPrivateSite: false)
 
         // The original src was found and rewritten to a resized (Photon) URL...
-        XCTAssertFalse(output.contains("https://example.com/small.jpg"))
-        XCTAssertTrue(output.contains(".wp.com"))
+        #expect(!output.contains("https://example.com/small.jpg"))
+        #expect(output.contains(".wp.com"))
         // ...and the emoji cluster survived byte-for-byte.
-        XCTAssertTrue(output.contains("😀😀😀😀😀"))
+        #expect(output.contains("😀😀😀😀😀"))
     }
 }

--- a/Modules/Tests/WordPressSharedTests/RichContentFormatterUITests.swift
+++ b/Modules/Tests/WordPressSharedTests/RichContentFormatterUITests.swift
@@ -7,4 +7,22 @@ class RichContentFormatterUITests: XCTestCase {
     func testResizeGalleryImageURLsForContentEmptyString() {
         XCTAssertTrue("" == RichContentFormatter.resizeGalleryImageURL("", isPrivateSite: false))
     }
+
+    // The gallery-image src rewrite sized its search range from the grapheme count
+    // (`imgElementStr.count`) rather than the UTF-16 length, so a `src` sitting past a
+    // multi-code-unit cluster fell outside the range and was never swapped for the resized
+    // URL. Here five emoji in `alt` (10 UTF-16 units, 5 graphemes) push the trailing `src`
+    // past a grapheme-count range; the resized URL must still replace it, cluster intact.
+    func testResizeGalleryImageURLReplacesSrcPastMultibyteCluster() {
+        let input =
+            "<img data-orig-file=\"https://example.com/orig.jpg\" alt=\"😀😀😀😀😀\" src=\"https://example.com/small.jpg\"/>"
+
+        let output = RichContentFormatter.resizeGalleryImageURL(input, isPrivateSite: false)
+
+        // The original src was found and rewritten to a resized (Photon) URL...
+        XCTAssertFalse(output.contains("https://example.com/small.jpg"))
+        XCTAssertTrue(output.contains(".wp.com"))
+        // ...and the emoji cluster survived byte-for-byte.
+        XCTAssertTrue(output.contains("😀😀😀😀😀"))
+    }
 }


### PR DESCRIPTION
## Summary

Stacked on **#25833**, which fixes the `String.count`/UTF-16 `NSRange` bug, hardens `parseValueForAttribute` against a missing closing quote, and migrates the `RichContentFormatter` tests to Swift Testing. This PR adds the *remaining* sanitization fixes the tests + a follow-up audit exposed, plus a comprehensive sanitization test suite.

> Base is `jkmassel/richcontentformatter-utf16-range` (#25833) → which stacks on #25832 → trunk. Retargets up the stack as each parent merges.

## Fixes (on top of #25833)

- **Unclosed `<script>`/`<style>`** are now stripped through end of input, not only closed pairs (fail-closed).
- **Single-quoted inline styles** are stripped, and `style=` now requires a whitespace boundary so it no longer matches inside a longer name like `data-style` / `data-mce-style`.
- **`formatVideoTags`** detects the `controls` attribute as a word-boundaried, case-insensitive token — so a value/name containing `controls` (`poster="…/controls.jpg"`, `class="…-controls"`, `data-controls`, `controlslist`) no longer leaves a video **uncontrolled**, and `CONTROLS` isn't duplicated; the `<video>` match is tightened against `<videoxyz>`, and `controls` is inserted in place, preserving the tag's casing.
- **`parseValueForAttribute`** matches the attribute name on a word boundary, so `"rc"` no longer returns `src`'s value. (Upgrades #25833's crash guard to a value-capturing regex, which also keeps its no-crash guarantee.)
- **`resizeGalleryImageURL`** anchors the `src` rewrite to the whole `src="…"` token, so it can't also rewrite the same URL where it appears in `srcset`.

## Tests

A ~75-case parameterized Swift Testing suite (`RichContentFormatterSanitizationTests`) covering every sanitization method — quote/whitespace/case variants, multiple matches, empty input, no-ops — plus an iOS `srcset`-preservation regression test. It coexists with #25833's migrated `RichContentFormatterTests`; all suites run green together (39 tests / 10 suites on the macOS host).

## Owned by #25833 (not here)

The `String.count`→UTF-16 `NSRange` fix, the `removeTrailingBreakTags` `offsetBy`→`Range(_:in:)` fix, the `parseValueForAttribute` missing-quote guard, and the Swift Testing test migration.

## Known limitation (not addressed)

This is not an XSS sanitizer: event-handler attributes (`onerror`/`onclick`), `javascript:`/`data:` URLs, and `<iframe>`/`<object>` pass through — a best-effort regex limitation, relevant only if output reaches a JS-enabled `WKWebView`. A follow-up rewrite on SwiftSoup (already a `WordPressShared` dependency) would dissolve the whole regex-fragility class; this suite is the behavioral contract for it.

## Test plan

- [x] `swift test --filter RichContentFormatter` (macOS host) — 39 tests / 10 suites pass (#25833's migrated suite + this suite), no known issues, no crash.
- [x] `swift-format` stable; SwiftLint clean on all changed files.
- [ ] CI green (incl. the iOS-hosted `KeystoneTests` gallery tests that exercise `resizeGalleryImageURL`).
