### PR TITLE
Fix share extension dropping text shared alongside images

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,7 @@
 * [*] [internal] Stop donating screen activities as Siri predictions now that App Shortcuts cover them [#25757]
 * [*] Fix an issue where the Reader tab and Me tab show incorrect state after logging out [#25952]
 * [*] Stats: Open the latest post when tapping the Latest Post Summary card in the Insights tab [#25896]
+* [*] Share extension: fix text being dropped when a note containing both text and images is shared [#25987]
 
 27.2
 -----

--- a/WordPress/WordPressShareExtension/Sources/Services/ShareExtractor.swift
+++ b/WordPress/WordPressShareExtension/Sources/Services/ShareExtractor.swift
@@ -33,7 +33,7 @@ struct ExtractedShare {
 
         // Build the returned string by doing the following:
         //   * 1: Look for imported text.
-        //   * 2: Look for selected text, if it exists put it into a blockquote.
+        //   * 2: Look for selected text, quoting it only when there is a source to attribute.
         //   * 3: No selected text, but we have a page description...use that.
         //   * 4: No selected text, but we have a page title...use that.
         //   * Finally, default to a simple link if nothing else is found
@@ -42,7 +42,13 @@ struct ExtractedShare {
         }
 
         guard selectedText.isEmpty else {
-            return "<blockquote><p>\(selectedText.escapeHtmlNamedEntities())\(readOnText)</p></blockquote>"
+            let paragraphs = ExtractedShare.paragraphsHTML(from: selectedText, appending: readOnText)
+
+            // Only quote text that arrived with a source to attribute.
+            guard url != nil else {
+                return paragraphs
+            }
+            return "<blockquote>\(paragraphs)</blockquote>"
         }
 
         if !description.isEmpty {
@@ -52,6 +58,38 @@ struct ExtractedShare {
         } else {
             return "<p>\(rawLink)</p>"
         }
+    }
+
+    /// Converts plain text to paragraphs, treating a blank line as a paragraph break and a single
+    /// line break as a `<br>`. `suffix` is appended to the last paragraph.
+    private static func paragraphsHTML(from text: String, appending suffix: String) -> String {
+        var paragraphs = [[String]]()
+        var current = [String]()
+
+        for line in text.replacingOccurrences(of: "\r\n", with: "\n").components(separatedBy: "\n") {
+            if line.trimmingCharacters(in: .whitespaces).isEmpty {
+                if !current.isEmpty {
+                    paragraphs.append(current)
+                    current = []
+                }
+            } else {
+                current.append(line)
+            }
+        }
+
+        if !current.isEmpty {
+            paragraphs.append(current)
+        }
+
+        guard !paragraphs.isEmpty else {
+            return "<p>\(text.escapeHtmlNamedEntities())\(suffix)</p>"
+        }
+
+        return paragraphs.enumerated().map { index, lines in
+            let body = lines.map { $0.escapeHtmlNamedEntities() }.joined(separator: "<br>")
+            let tail = index == paragraphs.count - 1 ? suffix : ""
+            return "<p>\(body)\(tail)</p>"
+        }.joined()
     }
 }
 
@@ -231,6 +269,10 @@ private protocol ExtensionContentExtractor {
 private protocol TypeBasedExtensionContentExtractor: ExtensionContentExtractor, Sendable {
     associatedtype Payload
     var acceptedType: String { get }
+
+    /// The attachments this extractor will read. Defaults to everything matching `acceptedType`.
+    func itemProviders(in context: NSExtensionContext) -> [NSItemProvider]
+
     func convert(payload: Payload) -> ExtractedItem?
 }
 
@@ -243,12 +285,16 @@ private extension TypeBasedExtensionContentExtractor {
         return CGSize(width: dimension, height: dimension)
     }
 
+    func itemProviders(in context: NSExtensionContext) -> [NSItemProvider] {
+        return context.itemProviders(ofType: acceptedType)
+    }
+
     func canHandle(context: NSExtensionContext) -> Bool {
-        return !context.itemProviders(ofType: acceptedType).isEmpty
+        return !itemProviders(in: context).isEmpty
     }
 
     func extract(context: NSExtensionContext, completion: @escaping ([ExtractedItem]) -> Void) {
-        let itemProviders = context.itemProviders(ofType: acceptedType)
+        let itemProviders = self.itemProviders(in: context)
         print(acceptedType)
         var results = [ExtractedItem]()
         guard !itemProviders.isEmpty else {
@@ -339,6 +385,14 @@ private extension TypeBasedExtensionContentExtractor {
 private struct URLExtractor: TypeBasedExtensionContentExtractor {
     typealias Payload = URL
     let acceptedType = UTType.url.identifier
+
+    /// An image shared as a file also declares `public.url`, but `processLocalFile(url:)` cannot
+    /// convert it. Claiming it here would stop `PlainTextExtractor` reading the text beside it.
+    func itemProviders(in context: NSExtensionContext) -> [NSItemProvider] {
+        return context.itemProviders(ofType: acceptedType).filter { provider in
+            !provider.hasItemConformingToTypeIdentifier(UTType.image.identifier)
+        }
+    }
 
     func convert(payload: URL) -> ExtractedItem? {
         guard !payload.isFileURL else {

--- a/WordPress/WordPressShareExtension/Sources/UI/ShareExtensionEditorViewController.swift
+++ b/WordPress/WordPressShareExtension/Sources/UI/ShareExtensionEditorViewController.swift
@@ -1008,7 +1008,10 @@ extension ShareExtensionEditorViewController {
     }
 
     func insertImageAttachment(with url: URL) {
-        let attachment = richTextView.replaceWithImage(at: self.richTextView.selectedRange, sourceURL: url, placeHolderImage: Assets.defaultMissingImage)
+        // `setHTML` leaves the caret at the start of the document, so append instead of inserting
+        // there, which would put shared images above the text they arrived with.
+        let endOfDocument = NSRange(location: richTextView.textStorage.length, length: 0)
+        let attachment = richTextView.replaceWithImage(at: endOfDocument, sourceURL: url, placeHolderImage: Assets.defaultMissingImage)
 
         attachment.size = .full
         attachment.uploadID = url.lastPathComponent // Use the filename as the uploadID here.
@@ -1265,7 +1268,8 @@ private extension ShareExtensionEditorViewController {
         ShareExtractor(extensionContext: extensionContext)
             .loadShare { [weak self] share in
                 self?.setTitleText(share.title)
-                self?.richTextView.setHTML(share.combinedContentHTML)
+                // The trailing paragraph keeps appended images off the end of the last sentence.
+                self?.richTextView.setHTML(share.combinedContentHTML + "<p></p>")
 
                 share.images.forEach({ extractedImage in
                     if extractedImage.insertionState == .requiresInsertion {


### PR DESCRIPTION
Fixes [CMM-2397](https://linear.app/a8c/issue/CMM-2397/share-extension-sharing-text-and-an-image-together-drops-the-text)

## Description

Sharing a note that contains both text and images into WordPress or Jetpack produced a draft or post with only the images. The text was lost. 

Reproduced with Apple Notes and Day One.

**Cause.**
Text extractors are an ordered list, and the first one to claim the content wins.

`URLExtractor` is before `PlainTextExtractor`, and claims anything with a `public.url`. It doesn't actually handle the images, which are handled later by `ImageExtractor`, but it does claim all the content. It just doesn't display it

`ImageExtractor` ran separately, which is why the images still arrived.

**Fix.** `URLExtractor` now skips attachments that are images, leaving them to `ImageExtractor` so the other text extractors after it still run.

Fixing the text loss exposed three further problems in the draft that gets built, also fixed here:

- **Images were placed above the text.** `insertImageAttachment` inserted at `richTextView.selectedRange`, and `setHTML` leaves the caret at position 0, so every image went to the start of the document. They now append at the end. This is just a judgement call, to be honest, but made sense to me.
- **A shared note became a blockquote.** `combinedContentHTML` wrapped `selectedText` in `<blockquote>` unconditionally. That suits a passage quoted from a web page, where it pairs with a "Read on <site>" attribution — Safari's JS preprocessing sets `selectedText` and `url` together, and that case is unchanged. Text arriving without a source URL is more likely the author's own writing, so it now stays as ordinary paragraphs.
- **Paragraph breaks were lost.** Shared text arrives as one flat string. Blank lines now become paragraph breaks and single line breaks become `<br>`.

### Note on interleaving

Images shared with text in this way cannot be placed back between the paragraphs they came from. Day One sends the entry as one flat `public.plain-text` blob; the images carry no name and no position. 

Apps that share a TextBundle keep their images inline via the existing `handleTextBundle` path (added in #11223), which is unaffected by this change.

## Testing instructions

Requires a WordPress.com account signed in to the app, since the share extension reads its token from the shared keychain.

**The reported bug**
1. In Apple Notes or Day One, write a note with a paragraph of text and one or more images.
2. Share → WordPress (or Jetpack) → Post as draft.
3. Open the draft. **Expected:** the text is in the body and the image(s) is attached below it. On `trunk` the text is missing.

**Paragraphs and quoting**
4. Share a note with several paragraphs separated by blank lines. **Expected:** the paragraph breaks survive, and the text is *not* wrapped in a quote block.
5. In Safari, select a passage of text on a page and share it. **Expected:** unchanged from `trunk` — a blockquote with a "Read on <site>" attribution at the end.

**Regression check on packaged notes**
6. From a markdown editor that shares a TextBundle (Bear, iA Writer), share a note with text between two images. **Expected:** unchanged from `trunk` — images stay in their original positions between the paragraphs.

https://github.com/user-attachments/assets/f3c7d444-2316-4bf5-9826-a05fa15a1be0


## Release notes

Added to `RELEASE-NOTES.txt`.
