### PR TITLE
Consolidate the Spotlight open path

### DIFF
--- a/Modules/Sources/WordPressData/Swift/SearchIdentifierGenerator.swift
+++ b/Modules/Sources/WordPressData/Swift/SearchIdentifierGenerator.swift
@@ -3,11 +3,17 @@ import Foundation
 public struct SearchIdentifierGenerator {
     internal static let separator = "|~~~|"
 
-    internal static func composeUniqueIdentifier(itemType: SearchItemType, domain: String, identifier: String) -> String {
-        return "\(itemType.stringValue())\(separator)\(domain)\(separator)\(identifier)"
+    internal static func composeUniqueIdentifier(
+        itemType: SearchItemType,
+        domain: String,
+        identifier: String
+    ) -> String {
+        "\(itemType.stringValue())\(separator)\(domain)\(separator)\(identifier)"
     }
 
-    public static func decomposeFromUniqueIdentifier(_ combined: String) -> (itemType: SearchItemType, domain: String, identifier: String) {
+    public static func decomposeFromUniqueIdentifier(
+        _ combined: String
+    ) -> (itemType: SearchItemType, domain: String, identifier: String) {
         let components = combined.components(separatedBy: separator)
 
         return (SearchItemType(index: components[0]), components[1], components[2])

--- a/Modules/Sources/WordPressData/Swift/SearchIdentifierGenerator.swift
+++ b/Modules/Sources/WordPressData/Swift/SearchIdentifierGenerator.swift
@@ -11,11 +11,20 @@ public struct SearchIdentifierGenerator {
         "\(itemType.stringValue())\(separator)\(domain)\(separator)\(identifier)"
     }
 
+    /// Returns `nil` for identifiers that are not in the composite format or
+    /// name an unknown item type. Identifiers arrive from the system (Spotlight
+    /// activities), so the format cannot be assumed.
     public static func decomposeFromUniqueIdentifier(
         _ combined: String
-    ) -> (itemType: SearchItemType, domain: String, identifier: String) {
+    ) -> (itemType: SearchItemType, domain: String, identifier: String)? {
         let components = combined.components(separatedBy: separator)
-
-        return (SearchItemType(index: components[0]), components[1], components[2])
+        guard components.count == 3 else {
+            return nil
+        }
+        let itemType = SearchItemType(index: components[0])
+        guard itemType != .none else {
+            return nil
+        }
+        return (itemType, components[1], components[2])
     }
 }

--- a/Tests/KeystoneTests/Tests/Models/PostSearchIdentifierTests.swift
+++ b/Tests/KeystoneTests/Tests/Models/PostSearchIdentifierTests.swift
@@ -1,0 +1,112 @@
+import Foundation
+import Testing
+
+@testable import WordPress
+@testable import WordPressData
+
+@Suite("Spotlight identifier decomposition")
+struct SearchIdentifierDecompositionTests {
+    @Test("a well-formed identifier decomposes")
+    func wellFormedIdentifierDecomposes() {
+        let parts = SearchIdentifierGenerator.decomposeFromUniqueIdentifier("readerPost|~~~|111|~~~|42")
+
+        #expect(parts?.itemType == .readerPost)
+        #expect(parts?.domain == "111")
+        #expect(parts?.identifier == "42")
+    }
+
+    @Test("malformed identifiers do not decompose")
+    func malformedIdentifiersDoNotDecompose() {
+        #expect(SearchIdentifierGenerator.decomposeFromUniqueIdentifier("abstractPost|~~~|111") == nil)
+        #expect(SearchIdentifierGenerator.decomposeFromUniqueIdentifier("unknown|~~~|111|~~~|42") == nil)
+        #expect(SearchIdentifierGenerator.decomposeFromUniqueIdentifier("garbage") == nil)
+    }
+}
+
+@Suite("Post search identifier parsing")
+struct PostSearchIdentifierParsingTests {
+    @Test("a post identifier with a numeric domain parses")
+    func postIdentifierWithSiteIDParses() {
+        let identifier = AbstractPost.SearchIdentifier(identifier: "abstractPost|~~~|111|~~~|42")
+
+        #expect(identifier?.domain == "111")
+        #expect(identifier?.postID == 42)
+        #expect(identifier?.isDotCom == true)
+    }
+
+    @Test("a post identifier with an xmlrpc domain parses")
+    func postIdentifierWithXMLRPCDomainParses() {
+        let identifier = AbstractPost.SearchIdentifier(
+            identifier: "abstractPost|~~~|https://example.com/xmlrpc.php|~~~|7"
+        )
+
+        #expect(identifier?.domain == "https://example.com/xmlrpc.php")
+        #expect(identifier?.postID == 7)
+        #expect(identifier?.isDotCom == false)
+    }
+
+    @Test("invalid post identifiers do not parse")
+    func invalidPostIdentifiersDoNotParse() {
+        #expect(AbstractPost.SearchIdentifier(identifier: "readerPost|~~~|111|~~~|42") == nil)
+        #expect(AbstractPost.SearchIdentifier(identifier: "abstractPost|~~~|111|~~~|not-a-number") == nil)
+        #expect(AbstractPost.SearchIdentifier(identifier: "abstractPost|~~~|111") == nil)
+        #expect(AbstractPost.SearchIdentifier(identifier: "garbage") == nil)
+    }
+}
+
+@MainActor
+@Suite("Post search identifier resolution")
+struct PostSearchIdentifierResolutionTests {
+    @Test("a WP.com post identifier resolves the matching post")
+    func dotComPostResolves() {
+        let context = ContextManager.forTesting().mainContext
+        let blog = BlogBuilder(context).with(dotComID: 111).build()
+        let post = PostBuilder(context, blog: blog).published().build()
+        post.postID = 42
+
+        #expect(AbstractPost.SearchIdentifier(identifier: "abstractPost|~~~|111|~~~|42")?.post(in: context) == post)
+    }
+
+    @Test("a self-hosted post identifier resolves via the xmlrpc domain")
+    func selfHostedPostResolves() {
+        let context = ContextManager.forTesting().mainContext
+        let blog = BlogBuilder(context, dotComID: nil).build()
+        blog.xmlrpc = "https://example.com/xmlrpc.php"
+        let post = PostBuilder(context, blog: blog).published().build()
+        post.postID = 7
+
+        #expect(
+            AbstractPost.SearchIdentifier(identifier: "abstractPost|~~~|https://example.com/xmlrpc.php|~~~|7")?
+                .post(in: context)
+                == post
+        )
+    }
+
+    @Test("a page identifier resolves the matching page")
+    func pageResolves() {
+        let context = ContextManager.forTesting().mainContext
+        let blog = BlogBuilder(context).with(dotComID: 333).build()
+        let page = PageBuilder(context).build()
+        page.blog = blog
+        page.postID = 9
+
+        #expect(AbstractPost.SearchIdentifier(identifier: "abstractPost|~~~|333|~~~|9")?.post(in: context) == page)
+    }
+
+    @Test("an identifier for an unknown post resolves nothing")
+    func unknownPostResolvesNil() {
+        let context = ContextManager.forTesting().mainContext
+        BlogBuilder(context).with(dotComID: 111).build()
+
+        #expect(AbstractPost.SearchIdentifier(identifier: "abstractPost|~~~|111|~~~|42")?.post(in: context) == nil)
+    }
+
+    @Test("an identifier for an unknown site resolves nothing")
+    func unknownSiteResolvesNil() {
+        let context = ContextManager.forTesting().mainContext
+        let post = PostBuilder(context, blog: BlogBuilder(context).with(dotComID: 111).build()).build()
+        post.postID = 42
+
+        #expect(AbstractPost.SearchIdentifier(identifier: "abstractPost|~~~|999|~~~|42")?.post(in: context) == nil)
+    }
+}

--- a/WordPress/Classes/Models/AbstractPost+SearchIdentifier.swift
+++ b/WordPress/Classes/Models/AbstractPost+SearchIdentifier.swift
@@ -1,0 +1,46 @@
+import Foundation
+import WordPressData
+
+extension AbstractPost {
+    /// The parsed components of a post's composite Spotlight identifier
+    /// (`abstractPost|~~~|<dotComID or xmlrpc>|~~~|<postID>`).
+    struct SearchIdentifier {
+        /// A WP.com site ID when numeric, the site's xmlrpc URL otherwise,
+        /// matching the Spotlight identifier convention.
+        let domain: String
+        let postID: Int
+
+        init?(identifier: String) {
+            guard
+                let (itemType, domain, postIDString) = SearchIdentifierGenerator.decomposeFromUniqueIdentifier(
+                    identifier
+                ),
+                itemType == .abstractPost,
+                let postID = Int(postIDString)
+            else {
+                return nil
+            }
+            self.domain = domain
+            self.postID = postID
+        }
+
+        /// Whether the post lives on a WP.com site.
+        var isDotCom: Bool {
+            Int(domain) != nil
+        }
+
+        /// The site the identifier belongs to, if it is in the local store.
+        func blog(in context: NSManagedObjectContext) -> Blog? {
+            if let siteID = Int(domain) {
+                return try? Blog.lookup(withID: siteID, in: context)
+            }
+            return try? BlogQuery().hostedByWPCom(false).xmlrpc(matching: domain).blog(in: context)
+        }
+
+        /// The post the identifier refers to, if it is in the local store.
+        /// Resolution never falls back to another post.
+        func post(in context: NSManagedObjectContext) -> AbstractPost? {
+            blog(in: context)?.lookupPost(withID: postID, in: context)
+        }
+    }
+}

--- a/WordPress/Classes/Utility/Spotlight/SearchManager.swift
+++ b/WordPress/Classes/Utility/Spotlight/SearchManager.swift
@@ -34,12 +34,16 @@ import WordPressData
             return
         }
 
-        CSSearchableIndex.default().indexSearchableItems(items, completionHandler: { (error: Error?) -> Void in
-            guard let error else {
-                return
-            }
-            DDLogError("Could not index post. Error: \(error.localizedDescription)")
-        })
+        CSSearchableIndex.default()
+            .indexSearchableItems(
+                items,
+                completionHandler: { (error: Error?) -> Void in
+                    guard let error else {
+                        return
+                    }
+                    DDLogError("Could not index post. Error: \(error.localizedDescription)")
+                }
+            )
     }
 
     // MARK: - Removal
@@ -73,12 +77,16 @@ import WordPressData
             return
         }
 
-        CSSearchableIndex.default().deleteSearchableItems(withIdentifiers: ids, completionHandler: { (error: Error?) -> Void in
-            guard let error else {
-                return
-            }
-            DDLogError("Could not delete CSSearchableItem item. Error: \(error.localizedDescription)")
-        })
+        CSSearchableIndex.default()
+            .deleteSearchableItems(
+                withIdentifiers: ids,
+                completionHandler: { (error: Error?) -> Void in
+                    guard let error else {
+                        return
+                    }
+                    DDLogError("Could not delete CSSearchableItem item. Error: \(error.localizedDescription)")
+                }
+            )
     }
 
     /// Removes every item indexed for a site. Call it before the site is
@@ -114,12 +122,18 @@ import WordPressData
             return
         }
 
-        CSSearchableIndex.default().deleteSearchableItems(withDomainIdentifiers: domains, completionHandler: { (error: Error?) -> Void in
-            guard let error else {
-                return
-            }
-            DDLogError("Could not delete CSSearchableItem items for domains: \(domains.joined(separator: ", ")). Error: \(error.localizedDescription)")
-        })
+        CSSearchableIndex.default()
+            .deleteSearchableItems(
+                withDomainIdentifiers: domains,
+                completionHandler: { (error: Error?) -> Void in
+                    guard let error else {
+                        return
+                    }
+                    DDLogError(
+                        "Could not delete CSSearchableItem items for domains: \(domains.joined(separator: ", ")). Error: \(error.localizedDescription)"
+                    )
+                }
+            )
     }
 
     /// Removes *all* items from the on-device, CoreSpotlight index.
@@ -128,12 +142,13 @@ import WordPressData
     /// if this function is called (each indexed activity item will expire automatically based on the original expiration date).
     ///
     @objc func deleteAllSearchableItems() {
-        CSSearchableIndex.default().deleteAllSearchableItems(completionHandler: { (error: Error?) -> Void in
-            guard let error else {
-                return
-            }
-            DDLogError("Could not delete all CSSearchableItem items. Error: \(error.localizedDescription)")
-        })
+        CSSearchableIndex.default()
+            .deleteAllSearchableItems(completionHandler: { (error: Error?) -> Void in
+                guard let error else {
+                    return
+                }
+                DDLogError("Could not delete all CSSearchableItem items. Error: \(error.localizedDescription)")
+            })
     }
 
     // MARK: - NSUserActivity Handling
@@ -157,7 +172,10 @@ import WordPressData
             WPAppAnalytics.track(.spotlightSearchOpenedApp, withProperties: ["via": WPActivityType.siteList.rawValue])
             return openMySitesTab()
         case WPActivityType.siteDetails.rawValue:
-            WPAppAnalytics.track(.spotlightSearchOpenedApp, withProperties: ["via": WPActivityType.siteDetails.rawValue])
+            WPAppAnalytics.track(
+                .spotlightSearchOpenedApp,
+                withProperties: ["via": WPActivityType.siteDetails.rawValue]
+            )
             return handleSite(activity: activity)
         case WPActivityType.reader.rawValue:
             WPAppAnalytics.track(.spotlightSearchOpenedApp, withProperties: ["via": WPActivityType.reader.rawValue])
@@ -166,16 +184,25 @@ import WordPressData
             WPAppAnalytics.track(.spotlightSearchOpenedApp, withProperties: ["via": WPActivityType.me.rawValue])
             return openMeTab()
         case WPActivityType.appSettings.rawValue:
-            WPAppAnalytics.track(.spotlightSearchOpenedApp, withProperties: ["via": WPActivityType.appSettings.rawValue])
+            WPAppAnalytics.track(
+                .spotlightSearchOpenedApp,
+                withProperties: ["via": WPActivityType.appSettings.rawValue]
+            )
             return openAppSettingsScreen()
         case WPActivityType.notificationSettings.rawValue:
-            WPAppAnalytics.track(.spotlightSearchOpenedApp, withProperties: ["via": WPActivityType.notificationSettings.rawValue])
+            WPAppAnalytics.track(
+                .spotlightSearchOpenedApp,
+                withProperties: ["via": WPActivityType.notificationSettings.rawValue]
+            )
             return openNotificationSettingsScreen()
         case WPActivityType.support.rawValue:
             WPAppAnalytics.track(.spotlightSearchOpenedApp, withProperties: ["via": WPActivityType.support.rawValue])
             return openSupportScreen()
         case WPActivityType.notifications.rawValue:
-            WPAppAnalytics.track(.spotlightSearchOpenedApp, withProperties: ["via": WPActivityType.notifications.rawValue])
+            WPAppAnalytics.track(
+                .spotlightSearchOpenedApp,
+                withProperties: ["via": WPActivityType.notifications.rawValue]
+            )
             return openNotificationsTab()
         default:
             return false
@@ -184,11 +211,14 @@ import WordPressData
 
     fileprivate func handleCoreSpotlightSearchableActivityType(activity: NSUserActivity) -> Bool {
         guard activity.activityType == CSSearchableItemActionType,
-            let compositeIdentifier = activity.userInfo?[CSSearchableItemActivityIdentifier] as? String else {
+            let compositeIdentifier = activity.userInfo?[CSSearchableItemActivityIdentifier] as? String
+        else {
             return false
         }
 
-        let (itemType, domainString, identifier) = SearchIdentifierGenerator.decomposeFromUniqueIdentifier(compositeIdentifier)
+        let (itemType, domainString, identifier) = SearchIdentifierGenerator.decomposeFromUniqueIdentifier(
+            compositeIdentifier
+        )
         switch itemType {
         case .abstractPost:
             return handleAbstractPost(domainString: domainString, identifier: identifier)
@@ -201,22 +231,36 @@ import WordPressData
 
     fileprivate func handleAbstractPost(domainString: String, identifier: String) -> Bool {
         guard let postID = NumberFormatter().number(from: identifier) else {
-            DDLogError("Search manager unable to parse postID/siteID for identifier:\(identifier) domain:\(domainString)")
+            DDLogError(
+                "Search manager unable to parse postID/siteID for identifier:\(identifier) domain:\(domainString)"
+            )
             return false
         }
 
         if let siteID = validWPComSiteID(with: domainString) {
-            fetchPost(postID, blogID: siteID, onSuccess: { [weak self] apost in
-                self?.navigateToScreen(for: apost)
-                }, onFailure: {
+            fetchPost(
+                postID,
+                blogID: siteID,
+                onSuccess: { [weak self] apost in
+                    self?.navigateToScreen(for: apost)
+                },
+                onFailure: {
                     DDLogError("Search manager unable to open post - postID:\(postID) siteID:\(siteID)")
-            })
+                }
+            )
         } else {
-            fetchSelfHostedPost(postID, blogXMLRpcString: domainString, onSuccess: { [weak self] apost in
-                self?.navigateToScreen(for: apost, isDotCom: false)
-                }, onFailure: {
-                    DDLogError("Search manager unable to open self hosted post - postID:\(postID) xmlrpc:\(domainString)")
-            })
+            fetchSelfHostedPost(
+                postID,
+                blogXMLRpcString: domainString,
+                onSuccess: { [weak self] apost in
+                    self?.navigateToScreen(for: apost, isDotCom: false)
+                },
+                onFailure: {
+                    DDLogError(
+                        "Search manager unable to open self hosted post - postID:\(postID) xmlrpc:\(domainString)"
+                    )
+                }
+            )
         }
 
         return true
@@ -224,39 +268,55 @@ import WordPressData
 
     fileprivate func handleReaderPost(domainString: String, identifier: String) -> Bool {
         guard let siteID = validWPComSiteID(with: domainString),
-            let readerPostID = NumberFormatter().number(from: identifier) else {
-                DDLogError("Search manager unable to parse postID/siteID for identifier:\(identifier) domain:\(domainString)")
-                return false
+            let readerPostID = NumberFormatter().number(from: identifier)
+        else {
+            DDLogError(
+                "Search manager unable to parse postID/siteID for identifier:\(identifier) domain:\(domainString)"
+            )
+            return false
         }
         var properties = [AnyHashable: Any]()
         properties[WPAppAnalyticsKeyBlogID] = siteID
         properties[WPAppAnalyticsKeyPostID] = readerPostID
         WPAppAnalytics.track(.spotlightSearchOpenedReaderPost, withProperties: properties)
-        openReader(for: readerPostID, siteID: siteID, onFailure: {
-            DDLogError("Search manager unable to open reader for readerPostID:\(readerPostID) siteID:\(siteID)")
-        })
+        openReader(
+            for: readerPostID,
+            siteID: siteID,
+            onFailure: {
+                DDLogError("Search manager unable to open reader for readerPostID:\(readerPostID) siteID:\(siteID)")
+            }
+        )
 
         return true
     }
 
     fileprivate func handleSite(activity: NSUserActivity) -> Bool {
         guard let userInfo = activity.userInfo as? [String: Any],
-            let siteID = userInfo.valueAsString(forKey: WPActivityUserInfoKeys.siteId.rawValue) else {
+            let siteID = userInfo.valueAsString(forKey: WPActivityUserInfoKeys.siteId.rawValue)
+        else {
             return false
         }
 
         if let siteID = validWPComSiteID(with: siteID) {
-            fetchBlog(siteID, onSuccess: { [weak self] blog in
-                self?.openSiteDetailsScreen(for: blog)
-                }, onFailure: {
+            fetchBlog(
+                siteID,
+                onSuccess: { [weak self] blog in
+                    self?.openSiteDetailsScreen(for: blog)
+                },
+                onFailure: {
                     DDLogError("Search manager unable to open site - siteID:\(siteID)")
-            })
+                }
+            )
         } else {
-            fetchSelfHostedBlog(siteID, onSuccess: { [weak self] blog in
-                self?.openSiteDetailsScreen(for: blog)
-                }, onFailure: {
+            fetchSelfHostedBlog(
+                siteID,
+                onSuccess: { [weak self] blog in
+                    self?.openSiteDetailsScreen(for: blog)
+                },
+                onFailure: {
                     DDLogError("Search manager unable to open self hosted site - xmlrpc:\(siteID)")
-            })
+                }
+            )
         }
         return true
     }
@@ -266,40 +326,20 @@ import WordPressData
 
 fileprivate extension SearchManager {
     func validWPComSiteID(with domainString: String) -> NSNumber? {
-        return NumberFormatter().number(from: domainString)
+        NumberFormatter().number(from: domainString)
     }
 
     // MARK: Fetching
 
-    func fetchPost(_ postID: NSNumber,
-                   blogID: NSNumber,
-                   onSuccess: @escaping (_ post: AbstractPost) -> Void,
-                   onFailure: @escaping () -> Void) {
+    func fetchPost(
+        _ postID: NSNumber,
+        blogID: NSNumber,
+        onSuccess: @escaping (_ post: AbstractPost) -> Void,
+        onFailure: @escaping () -> Void
+    ) {
         let coreDataStack = ContextManager.shared
 
         guard let blog = Blog.lookup(withID: blogID, in: coreDataStack.mainContext) else {
-                onFailure()
-                return
-        }
-
-        let postRepository = PostRepository(coreDataStack: coreDataStack)
-        Task { @MainActor in
-            do {
-                let postObjectID = try await postRepository.getPost(withID: postID, from: .init(blog))
-                let post = try coreDataStack.mainContext.existingObject(with: postObjectID)
-                onSuccess(post)
-            } catch {
-                onFailure()
-            }
-        }
-    }
-
-    func fetchSelfHostedPost(_ postID: NSNumber,
-                             blogXMLRpcString: String,
-                             onSuccess: @escaping (_ post: AbstractPost) -> Void,
-                             onFailure: @escaping () -> Void) {
-        let coreDataStack = ContextManager.shared
-        guard let blog = Blog.selfHosted(in: coreDataStack.mainContext).first(where: { $0.xmlrpc == blogXMLRpcString }) else {
             onFailure()
             return
         }
@@ -316,9 +356,36 @@ fileprivate extension SearchManager {
         }
     }
 
-    func fetchBlog(_ blogID: NSNumber,
-                   onSuccess: @escaping (_ blog: Blog) -> Void,
-                   onFailure: @escaping () -> Void) {
+    func fetchSelfHostedPost(
+        _ postID: NSNumber,
+        blogXMLRpcString: String,
+        onSuccess: @escaping (_ post: AbstractPost) -> Void,
+        onFailure: @escaping () -> Void
+    ) {
+        let coreDataStack = ContextManager.shared
+        guard let blog = Blog.selfHosted(in: coreDataStack.mainContext).first(where: { $0.xmlrpc == blogXMLRpcString })
+        else {
+            onFailure()
+            return
+        }
+
+        let postRepository = PostRepository(coreDataStack: coreDataStack)
+        Task { @MainActor in
+            do {
+                let postObjectID = try await postRepository.getPost(withID: postID, from: .init(blog))
+                let post = try coreDataStack.mainContext.existingObject(with: postObjectID)
+                onSuccess(post)
+            } catch {
+                onFailure()
+            }
+        }
+    }
+
+    func fetchBlog(
+        _ blogID: NSNumber,
+        onSuccess: @escaping (_ blog: Blog) -> Void,
+        onFailure: @escaping () -> Void
+    ) {
         let context = ContextManager.shared.mainContext
 
         guard let blog = Blog.lookup(withID: blogID, in: context) else {
@@ -328,9 +395,11 @@ fileprivate extension SearchManager {
         onSuccess(blog)
     }
 
-    func fetchSelfHostedBlog(_ blogXMLRpcString: String,
-                             onSuccess: @escaping (_ blog: Blog) -> Void,
-                             onFailure: @escaping () -> Void) {
+    func fetchSelfHostedBlog(
+        _ blogXMLRpcString: String,
+        onSuccess: @escaping (_ blog: Blog) -> Void,
+        onFailure: @escaping () -> Void
+    ) {
         let context = ContextManager.shared.mainContext
         guard let blog = Blog.selfHosted(in: context).first(where: { $0.xmlrpc == blogXMLRpcString }) else {
             onFailure()
@@ -400,10 +469,13 @@ fileprivate extension SearchManager {
         WPAppAnalytics.track(.spotlightSearchOpenedPost, post: post)
         let postIsPublishedOrScheduled = (post.status == .publish || post.status == .scheduled)
         if postIsPublishedOrScheduled && isDotCom {
-            openReader(for: post, onFailure: {
-                // If opening the reader fails, just open preview.
-                openPreview(for: post)
-            })
+            openReader(
+                for: post,
+                onFailure: {
+                    // If opening the reader fails, just open preview.
+                    openPreview(for: post)
+                }
+            )
         } else if postIsPublishedOrScheduled {
             openPreview(for: post)
         } else {
@@ -415,10 +487,13 @@ fileprivate extension SearchManager {
         WPAppAnalytics.track(.spotlightSearchOpenedPage, post: page)
         let pageIsPublishedOrScheduled = (page.status == .publish || page.status == .scheduled)
         if pageIsPublishedOrScheduled && isDotCom {
-            openReader(for: page, onFailure: {
-                // If opening the reader fails, just open preview.
-                openPreview(for: page)
-            })
+            openReader(
+                for: page,
+                onFailure: {
+                    // If opening the reader fails, just open preview.
+                    openPreview(for: page)
+                }
+            )
         } else if pageIsPublishedOrScheduled {
             openPreview(for: page)
         } else {
@@ -439,9 +514,10 @@ fileprivate extension SearchManager {
         closePreviewIfNeeded(for: apost)
         guard let postID = apost.postID,
             postID.intValue > 0,
-            let blogID = apost.blog.dotComID else {
-                onFailure()
-                return
+            let blogID = apost.blog.dotComID
+        else {
+            onFailure()
+            return
         }
         RootViewCoordinator.sharedPresenter.showReader(path: .post(postID: postID.intValue, siteID: blogID.intValue))
     }
@@ -501,9 +577,10 @@ fileprivate extension SearchManager {
         }
 
         guard let previewVC = navController.topViewController as? PreviewWebKitViewController,
-            previewVC.post != apost else {
-                // Do nothing — post is already loaded or the post preview view controller isn't visible
-                return
+            previewVC.post != apost
+        else {
+            // Do nothing — post is already loaded or the post preview view controller isn't visible
+            return
         }
 
         navController.dismiss(animated: true)
@@ -514,8 +591,9 @@ fileprivate extension SearchManager {
     func closeAnyOpenPreview() {
         let rootViewController = RootViewCoordinator.sharedPresenter.rootViewController
         guard let navController = rootViewController.presentedViewController as? UINavigationController,
-            navController.topViewController is PreviewWebKitViewController else {
-                return
+            navController.topViewController is PreviewWebKitViewController
+        else {
+            return
         }
         navController.dismiss(animated: true)
     }

--- a/WordPress/Classes/Utility/Spotlight/SearchManager.swift
+++ b/WordPress/Classes/Utility/Spotlight/SearchManager.swift
@@ -211,58 +211,55 @@ import WordPressData
 
     fileprivate func handleCoreSpotlightSearchableActivityType(activity: NSUserActivity) -> Bool {
         guard activity.activityType == CSSearchableItemActionType,
-            let compositeIdentifier = activity.userInfo?[CSSearchableItemActivityIdentifier] as? String
+            let compositeIdentifier = activity.userInfo?[CSSearchableItemActivityIdentifier] as? String,
+            SearchIdentifierGenerator.decomposeFromUniqueIdentifier(compositeIdentifier) != nil
         else {
             return false
         }
 
-        let (itemType, domainString, identifier) = SearchIdentifierGenerator.decomposeFromUniqueIdentifier(
-            compositeIdentifier
-        )
+        Task { @MainActor in
+            await self.openItem(withUniqueIdentifier: compositeIdentifier)
+        }
+        return true
+    }
+
+    /// Opens the content a composite Spotlight identifier points to, with the
+    /// same routing as tapping the item in Spotlight.
+    ///
+    /// - Returns: Whether the target could be resolved and put on screen, so
+    ///   callers can surface a failure instead of reporting success blindly.
+    @discardableResult
+    @MainActor
+    func openItem(withUniqueIdentifier compositeIdentifier: String) async -> Bool {
+        guard
+            let (itemType, domainString, identifier) = SearchIdentifierGenerator.decomposeFromUniqueIdentifier(
+                compositeIdentifier
+            )
+        else {
+            DDLogError("Search manager unable to parse identifier: \(compositeIdentifier)")
+            return false
+        }
         switch itemType {
         case .abstractPost:
-            return handleAbstractPost(domainString: domainString, identifier: identifier)
+            guard let postIdentifier = AbstractPost.SearchIdentifier(identifier: compositeIdentifier) else {
+                DDLogError("Search manager unable to parse post identifier: \(compositeIdentifier)")
+                return false
+            }
+            return await handleAbstractPost(postIdentifier)
         case .readerPost:
             return handleReaderPost(domainString: domainString, identifier: identifier)
-        default:
+        case .none:
             return false
         }
     }
 
-    fileprivate func handleAbstractPost(domainString: String, identifier: String) -> Bool {
-        guard let postID = NumberFormatter().number(from: identifier) else {
-            DDLogError(
-                "Search manager unable to parse postID/siteID for identifier:\(identifier) domain:\(domainString)"
-            )
+    @MainActor
+    fileprivate func handleAbstractPost(_ identifier: AbstractPost.SearchIdentifier) async -> Bool {
+        guard let post = await fetchPost(identifier), post.status != .trash else {
+            DDLogError("Search manager unable to open post - postID:\(identifier.postID) domain:\(identifier.domain)")
             return false
         }
-
-        if let siteID = validWPComSiteID(with: domainString) {
-            fetchPost(
-                postID,
-                blogID: siteID,
-                onSuccess: { [weak self] apost in
-                    self?.navigateToScreen(for: apost)
-                },
-                onFailure: {
-                    DDLogError("Search manager unable to open post - postID:\(postID) siteID:\(siteID)")
-                }
-            )
-        } else {
-            fetchSelfHostedPost(
-                postID,
-                blogXMLRpcString: domainString,
-                onSuccess: { [weak self] apost in
-                    self?.navigateToScreen(for: apost, isDotCom: false)
-                },
-                onFailure: {
-                    DDLogError(
-                        "Search manager unable to open self hosted post - postID:\(postID) xmlrpc:\(domainString)"
-                    )
-                }
-            )
-        }
-
+        navigateToScreen(for: post, isDotCom: identifier.isDotCom)
         return true
     }
 
@@ -279,14 +276,10 @@ import WordPressData
         properties[WPAppAnalyticsKeyBlogID] = siteID
         properties[WPAppAnalyticsKeyPostID] = readerPostID
         WPAppAnalytics.track(.spotlightSearchOpenedReaderPost, withProperties: properties)
-        openReader(
-            for: readerPostID,
-            siteID: siteID,
-            onFailure: {
-                DDLogError("Search manager unable to open reader for readerPostID:\(readerPostID) siteID:\(siteID)")
-            }
-        )
-
+        guard openReader(for: readerPostID.intValue, siteID: siteID.intValue) else {
+            DDLogError("Search manager unable to open reader for readerPostID:\(readerPostID) siteID:\(siteID)")
+            return false
+        }
         return true
     }
 
@@ -331,53 +324,27 @@ fileprivate extension SearchManager {
 
     // MARK: Fetching
 
-    func fetchPost(
-        _ postID: NSNumber,
-        blogID: NSNumber,
-        onSuccess: @escaping (_ post: AbstractPost) -> Void,
-        onFailure: @escaping () -> Void
-    ) {
+    @MainActor
+    func fetchPost(_ identifier: AbstractPost.SearchIdentifier) async -> AbstractPost? {
         let coreDataStack = ContextManager.shared
-
-        guard let blog = Blog.lookup(withID: blogID, in: coreDataStack.mainContext) else {
-            onFailure()
-            return
+        guard let blog = identifier.blog(in: coreDataStack.mainContext) else {
+            return nil
+        }
+        // A cached copy opens immediately; the network fetch covers posts
+        // that are indexed but no longer cached locally.
+        if let post = identifier.post(in: coreDataStack.mainContext) {
+            return post
         }
 
         let postRepository = PostRepository(coreDataStack: coreDataStack)
-        Task { @MainActor in
-            do {
-                let postObjectID = try await postRepository.getPost(withID: postID, from: .init(blog))
-                let post = try coreDataStack.mainContext.existingObject(with: postObjectID)
-                onSuccess(post)
-            } catch {
-                onFailure()
-            }
-        }
-    }
-
-    func fetchSelfHostedPost(
-        _ postID: NSNumber,
-        blogXMLRpcString: String,
-        onSuccess: @escaping (_ post: AbstractPost) -> Void,
-        onFailure: @escaping () -> Void
-    ) {
-        let coreDataStack = ContextManager.shared
-        guard let blog = Blog.selfHosted(in: coreDataStack.mainContext).first(where: { $0.xmlrpc == blogXMLRpcString })
-        else {
-            onFailure()
-            return
-        }
-
-        let postRepository = PostRepository(coreDataStack: coreDataStack)
-        Task { @MainActor in
-            do {
-                let postObjectID = try await postRepository.getPost(withID: postID, from: .init(blog))
-                let post = try coreDataStack.mainContext.existingObject(with: postObjectID)
-                onSuccess(post)
-            } catch {
-                onFailure()
-            }
+        do {
+            let postObjectID = try await postRepository.getPost(
+                withID: NSNumber(value: identifier.postID),
+                from: .init(blog)
+            )
+            return try coreDataStack.mainContext.existingObject(with: postObjectID)
+        } catch {
+            return nil
         }
     }
 
@@ -457,46 +424,18 @@ fileprivate extension SearchManager {
 
     // MARK: Specific Post & Page Navigation
 
-    func navigateToScreen(for apost: AbstractPost, isDotCom: Bool = true) {
-        if let post = apost as? Post {
-            self.navigateToScreen(for: post, isDotCom: isDotCom)
-        } else if let page = apost as? Page {
-            self.navigateToScreen(for: page, isDotCom: isDotCom)
+    func navigateToScreen(for apost: AbstractPost, isDotCom: Bool) {
+        WPAppAnalytics.track(apost is Page ? .spotlightSearchOpenedPage : .spotlightSearchOpenedPost, post: apost)
+        let isPublishedOrScheduled = (apost.status == .publish || apost.status == .scheduled)
+        if isPublishedOrScheduled && isDotCom && openReader(for: apost) {
+            return
         }
-    }
-
-    func navigateToScreen(for post: Post, isDotCom: Bool) {
-        WPAppAnalytics.track(.spotlightSearchOpenedPost, post: post)
-        let postIsPublishedOrScheduled = (post.status == .publish || post.status == .scheduled)
-        if postIsPublishedOrScheduled && isDotCom {
-            openReader(
-                for: post,
-                onFailure: {
-                    // If opening the reader fails, just open preview.
-                    openPreview(for: post)
-                }
-            )
-        } else if postIsPublishedOrScheduled {
-            openPreview(for: post)
-        } else {
+        if isPublishedOrScheduled {
+            // If opening the reader fails, just open preview.
+            openPreview(for: apost)
+        } else if let post = apost as? Post {
             openEditor(for: post)
-        }
-    }
-
-    func navigateToScreen(for page: Page, isDotCom: Bool) {
-        WPAppAnalytics.track(.spotlightSearchOpenedPage, post: page)
-        let pageIsPublishedOrScheduled = (page.status == .publish || page.status == .scheduled)
-        if pageIsPublishedOrScheduled && isDotCom {
-            openReader(
-                for: page,
-                onFailure: {
-                    // If opening the reader fails, just open preview.
-                    openPreview(for: page)
-                }
-            )
-        } else if pageIsPublishedOrScheduled {
-            openPreview(for: page)
-        } else {
+        } else if let page = apost as? Page {
             openEditor(for: page)
         }
     }
@@ -510,25 +449,21 @@ fileprivate extension SearchManager {
         }
     }
 
-    func openReader(for apost: AbstractPost, onFailure: () -> Void) {
+    func openReader(for apost: AbstractPost) -> Bool {
         closePreviewIfNeeded(for: apost)
-        guard let postID = apost.postID,
-            postID.intValue > 0,
-            let blogID = apost.blog.dotComID
-        else {
-            onFailure()
-            return
+        guard let postID = apost.postID, let blogID = apost.blog.dotComID else {
+            return false
         }
-        RootViewCoordinator.sharedPresenter.showReader(path: .post(postID: postID.intValue, siteID: blogID.intValue))
+        return openReader(for: postID.intValue, siteID: blogID.intValue)
     }
 
-    func openReader(for postID: NSNumber, siteID: NSNumber, onFailure: () -> Void) {
+    func openReader(for postID: Int, siteID: Int) -> Bool {
         closeAnyOpenPreview()
-        guard postID.intValue > 0, siteID.intValue > 0 else {
-            onFailure()
-            return
+        guard postID > 0, siteID > 0 else {
+            return false
         }
-        RootViewCoordinator.sharedPresenter.showReader(path: .post(postID: postID.intValue, siteID: siteID.intValue))
+        RootViewCoordinator.sharedPresenter.showReader(path: .post(postID: postID, siteID: siteID))
+        return true
     }
 
     // MARK: - Editor


### PR DESCRIPTION
## Description

Opening a Spotlight result currently uses separate callback-based paths for WP.com and self-hosted posts, with duplicate navigation logic for posts and pages.

This PR:

1. Makes `SearchIdentifierGenerator.decomposeFromUniqueIdentifier(_:)` reject malformed and unknown identifiers.
2. Adds `AbstractPost.SearchIdentifier` to resolve the exact site and post for WP.com and self-hosted sites.
3. Routes Spotlight results through `openItem(withUniqueIdentifier:)`, with shared post and page navigation. It opens cached posts immediately, fetches missing posts, and rejects trashed posts.

## Testing instructions

- Open published and draft posts and pages from Spotlight on WP.com and self-hosted sites.
- Open a Spotlight result for a post that is not cached locally.
- Verify invalid or stale Spotlight results do not navigate or crash.

<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., VoiceOver)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->
