### PR TITLE
Show a loading indicator while a theme activates

### DIFF
--- a/WordPress/Classes/ViewRelated/Themes/ThemeBrowserCell.swift
+++ b/WordPress/Classes/ViewRelated/Themes/ThemeBrowserCell.swift
@@ -100,6 +100,29 @@ open class ThemeBrowserCell: UICollectionViewCell {
     @objc open var showPriceInformation: Bool = false
     open weak var presenter: ThemePresenter?
 
+    /// Replaces the action button with a spinner while the theme is being activated.
+    var isActivating: Bool = false {
+        didSet {
+            actionButton.isHidden = isActivating
+            if isActivating {
+                activatingIndicator.startAnimating()
+            } else {
+                activatingIndicator.stopAnimating()
+            }
+        }
+    }
+
+    private lazy var activatingIndicator: UIActivityIndicatorView = {
+        let indicator = UIActivityIndicatorView(style: .medium)
+        indicator.hidesWhenStopped = true
+        indicator.accessibilityLabel = NSLocalizedString(
+            "themeBrowser.cell.activating",
+            value: "Activating",
+            comment: "Accessibility label for the spinner shown while a theme is being activated"
+        )
+        return indicator
+    }()
+
     fileprivate var placeholderImage = UIImage(named: "theme-loading")
     fileprivate var activeEllipsisImage = UIImage(named: "icon-menu-ellipsis-white")
     fileprivate var inactiveEllipsisImage = UIImage(named: "icon-menu-ellipsis")
@@ -123,6 +146,13 @@ open class ThemeBrowserCell: UICollectionViewCell {
 
         actionButton.isExclusiveTouch = true
 
+        infoBar.addSubview(activatingIndicator)
+        activatingIndicator.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            activatingIndicator.centerXAnchor.constraint(equalTo: actionButton.centerXAnchor),
+            activatingIndicator.centerYAnchor.constraint(equalTo: actionButton.centerYAnchor)
+        ])
+
         layer.cornerRadius = 12
         layer.cornerCurve = .continuous
         layer.borderColor = UIColor.separator.cgColor
@@ -138,6 +168,7 @@ open class ThemeBrowserCell: UICollectionViewCell {
         theme = nil
         presenter = nil
         showPriceInformation = false
+        isActivating = false
     }
 
     fileprivate func refreshGUI() {

--- a/WordPress/Classes/ViewRelated/Themes/ThemeBrowserCell.swift
+++ b/WordPress/Classes/ViewRelated/Themes/ThemeBrowserCell.swift
@@ -13,7 +13,7 @@ public enum ThemeAction {
     case tryCustomize
     case view
 
-    static func activeActionsForTheme(_ theme: Theme) ->[ThemeAction] {
+    static func activeActionsForTheme(_ theme: Theme) -> [ThemeAction] {
         if theme.custom {
             if theme.hasDetailsURL() {
                 return [customize, details]
@@ -23,7 +23,7 @@ public enum ThemeAction {
         return [customize, details, support]
     }
 
-    static func inactiveActionsForTheme(_ theme: Theme) ->[ThemeAction] {
+    static func inactiveActionsForTheme(_ theme: Theme) -> [ThemeAction] {
         if theme.custom {
             if theme.hasDetailsURL() {
                 return [tryCustomize, activate, details]
@@ -109,9 +109,12 @@ open class ThemeBrowserCell: UICollectionViewCell {
     override open var isHighlighted: Bool {
         didSet {
             let alphaFinal: CGFloat = isHighlighted ? 0.3 : 0
-            UIView.animate(withDuration: 0.2, animations: { [weak self] in
-                self?.highlightView.alpha = alphaFinal
-            })
+            UIView.animate(
+                withDuration: 0.2,
+                animations: { [weak self] in
+                    self?.highlightView.alpha = alphaFinal
+                }
+            )
         }
     }
 
@@ -220,20 +223,25 @@ open class ThemeBrowserCell: UICollectionViewCell {
     }
 
     fileprivate func refreshScreenshotImage(_ imageUrl: String) {
-        let imageUrlWithWidth = imageUrlForWidth( imageUrl: imageUrl )
+        let imageUrlWithWidth = imageUrlForWidth(imageUrl: imageUrl)
         let screenshotUrl = URL(string: imageUrlWithWidth)
 
         imageView.backgroundColor = Styles.placeholderColor
         activityView.startAnimating()
-        imageView.downloadImage(from: screenshotUrl, success: { [weak self] _ in
-            self?.showScreenshot()
-        }, failure: { [weak self] error in
-                if let error = error as NSError?, error.domain == NSURLErrorDomain && error.code == NSURLErrorCancelled {
+        imageView.downloadImage(
+            from: screenshotUrl,
+            success: { [weak self] _ in
+                self?.showScreenshot()
+            },
+            failure: { [weak self] error in
+                let nsError = error as NSError?
+                if nsError?.domain == NSURLErrorDomain && nsError?.code == NSURLErrorCancelled {
                     return
                 }
                 DDLogError("Error loading theme screenshot: \(String(describing: error?.localizedDescription))")
                 self?.showPlaceholder()
-        })
+            }
+        )
     }
 
     // MARK: - Actions
@@ -245,13 +253,17 @@ open class ThemeBrowserCell: UICollectionViewCell {
 
         let alertController = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
 
-        let themeActions = theme.isCurrentTheme() ? ThemeAction.activeActionsForTheme(theme) : ThemeAction.inactiveActionsForTheme(theme)
+        let themeActions =
+            theme.isCurrentTheme()
+            ? ThemeAction.activeActionsForTheme(theme) : ThemeAction.inactiveActionsForTheme(theme)
         themeActions.forEach { themeAction in
-            alertController.addActionWithTitle(themeAction.title,
-                                               style: .default,
-                                               handler: { (_: UIAlertAction) in
-                                                themeAction.present(theme, presenter)
-            })
+            alertController.addActionWithTitle(
+                themeAction.title,
+                style: .default,
+                handler: { (_: UIAlertAction) in
+                    themeAction.present(theme, presenter)
+                }
+            )
         }
 
         let cancelTitle = NSLocalizedString("Cancel", comment: "Cancel action title")
@@ -290,7 +302,10 @@ extension ThemeBrowserCell: Accessible {
 
     private func prepareActionButtonForVoiceOver() {
         actionButton.isAccessibilityElement = true
-        actionButton.accessibilityLabel = NSLocalizedString("More", comment: "Action button to display more available options")
+        actionButton.accessibilityLabel = NSLocalizedString(
+            "More",
+            comment: "Action button to display more available options"
+        )
         actionButton.accessibilityTraits = .button
     }
 

--- a/WordPress/Classes/ViewRelated/Themes/ThemeBrowserViewController.swift
+++ b/WordPress/Classes/ViewRelated/Themes/ThemeBrowserViewController.swift
@@ -205,8 +205,6 @@ open class ThemeBrowserViewController: UIViewController, UICollectionViewDataSou
     fileprivate var activityIndicator: UIActivityIndicatorView = {
         let indicatorView = UIActivityIndicatorView(style: .medium)
         indicatorView.frame = themesLoaderFrame
-        //TODO update color with white headers
-        indicatorView.color = .white
         indicatorView.startAnimating()
         return indicatorView
     }()

--- a/WordPress/Classes/ViewRelated/Themes/ThemeBrowserViewController.swift
+++ b/WordPress/Classes/ViewRelated/Themes/ThemeBrowserViewController.swift
@@ -252,6 +252,9 @@ open class ThemeBrowserViewController: UIViewController, UICollectionViewDataSou
 
     fileprivate var presentingTheme: Theme?
 
+    /// The theme whose activation request is in flight. Drives the grid cell spinner across cell reuse and reloads.
+    private var activatingThemeId: String?
+
     private var noResultsViewController: NoResultsViewController?
 
     private struct NoResultsTitles {
@@ -620,6 +623,7 @@ open class ThemeBrowserViewController: UIViewController, UICollectionViewDataSou
 
         cell.presenter = self
         cell.theme = themeAtIndexPath(indexPath)
+        cell.isActivating = activatingThemeId != nil && cell.theme?.themeId == activatingThemeId
 
         if sections[indexPath.section] == .themes {
             syncMoreThemesIfNeeded(indexPath)
@@ -939,10 +943,12 @@ open class ThemeBrowserViewController: UIViewController, UICollectionViewDataSou
     @objc var onWebkitViewControllerClose: (() -> Void)?
 
     @objc open func activateTheme(_ theme: Theme?) {
-        guard let theme, !theme.isCurrentTheme() else {
+        guard let theme, !theme.isCurrentTheme(), activatingThemeId == nil else {
             return
         }
 
+        activatingThemeId = theme.themeId
+        collectionView?.reloadData()
         updateActivateButton(isLoading: true)
 
         _ = themeService.activate(
@@ -955,6 +961,7 @@ open class ThemeBrowserViewController: UIViewController, UICollectionViewDataSou
                     blog: self?.blog
                 )
 
+                self?.activatingThemeId = nil
                 self?.collectionView?.reloadData()
 
                 let successTitle = NSLocalizedString(
@@ -998,6 +1005,8 @@ open class ThemeBrowserViewController: UIViewController, UICollectionViewDataSou
                     comment: "Title of alert when theme activation fails"
                 )
 
+                self?.activatingThemeId = nil
+                self?.collectionView?.reloadData()
                 self?.activityIndicator.stopAnimating()
                 self?.activateButton?.customView = nil
 

--- a/WordPress/Classes/ViewRelated/Themes/ThemeBrowserViewController.swift
+++ b/WordPress/Classes/ViewRelated/Themes/ThemeBrowserViewController.swift
@@ -971,10 +971,6 @@ open class ThemeBrowserViewController: UIViewController, UICollectionViewDataSou
                     comment: "Message of alert when theme activation succeeds"
                 )
                 let successMessage = String(format: successFormat, theme?.name ?? "", theme?.author ?? "")
-                let manageTitle = NSLocalizedString(
-                    "Manage site",
-                    comment: "Return to blog screen action when theme activation succeeds"
-                )
 
                 self?.updateActivateButton(isLoading: false)
 
@@ -982,13 +978,6 @@ open class ThemeBrowserViewController: UIViewController, UICollectionViewDataSou
                     title: successTitle,
                     message: successMessage,
                     preferredStyle: .alert
-                )
-                alertController.addActionWithTitle(
-                    manageTitle,
-                    style: .default,
-                    handler: { [weak self] (_: UIAlertAction) in
-                        _ = self?.navigationController?.popViewController(animated: true)
-                    }
                 )
                 alertController.addDefaultActionWithTitle(SharedStrings.Button.ok, handler: nil)
                 alertController.presentFromRootViewController()


### PR DESCRIPTION
## Description

Fixes (kinda) https://linear.app/a8c/issue/CMM-2366. The "Manage site" action only dismisses the theme view controller, which I think is unnecessary. So, I removed it in this PR.

The PR fixes another issue: On the theme browser, tap the "..." button on a theme, tap "Activate", and wait. Nothing changes on screen until the "Theme Activated" alert shows up. Activating from the theme preview screen has the same problem, because the spinner replacing the "Activate" bar button is white on a white navigation bar.

The grid cell now replaces its "..." button with a spinner while the theme is being activated, and the preview bar button spinner uses the default color.


https://github.com/user-attachments/assets/c242466b-e536-4ced-888e-68849b889370


