### PR TITLE
Use a dedicated API key for Enterprise code signing

### DIFF
--- a/fastlane/env/user.env-example
+++ b/fastlane/env/user.env-example
@@ -5,6 +5,10 @@ APP_STORE_CONNECT_API_KEY_KEY_ID=<App Store Connect API key ID>
 APP_STORE_CONNECT_API_KEY_ISSUER_ID=<App Store Connect API issuer ID>
 APP_STORE_CONNECT_API_KEY_KEY=<App Store Connect API private key>
 
+APP_STORE_CONNECT_API_KEY_KEY_ID_ENTERPRISE=<Apple Developer Enterprise API key ID>
+APP_STORE_CONNECT_API_KEY_ISSUER_ID_ENTERPRISE=<Apple Developer Enterprise API issuer ID>
+APP_STORE_CONNECT_API_KEY_KEY_ENTERPRISE=<Apple Developer Enterprise API private key>
+
 GHHELPER_ACCESS=<GitHub access token>
 SENTRY_AUTH_TOKEN=<Sentry Auth Token>
 

--- a/fastlane/lanes/codesign.rb
+++ b/fastlane/lanes/codesign.rb
@@ -122,19 +122,23 @@ platform :ios do
 end
 
 def update_code_signing_enterprise(readonly:, app_identifiers:)
-  unless readonly
-    # The Enterprise account APIs do not support authentication via API key.
-    # If we want to modify data (readonly = false) we need to authenticate manually.
-    prompt_user_for_app_store_connect_credentials
-  end
-
   update_code_signing(
     type: 'enterprise',
     # Enterprise builds belong to the "internal" team
     team_id: INTERNAL_TEAM_ID,
     readonly: readonly,
     app_identifiers: app_identifiers,
-    api_key: nil
+    # `match` only authenticates when it has to generate something, so readonly runs need no key.
+    api_key: readonly ? nil : enterprise_app_store_connect_api_key
+  )
+end
+
+def enterprise_app_store_connect_api_key
+  app_store_connect_api_key(
+    key_id: get_required_env('APP_STORE_CONNECT_API_KEY_KEY_ID_ENTERPRISE'),
+    issuer_id: get_required_env('APP_STORE_CONNECT_API_KEY_ISSUER_ID_ENTERPRISE'),
+    key_content: get_required_env('APP_STORE_CONNECT_API_KEY_KEY_ENTERPRISE'),
+    in_house: true
   )
 end
 
@@ -160,13 +164,4 @@ def update_code_signing(type:, team_id:, readonly:, app_identifiers:, api_key:)
     api_key: api_key,
     **CODE_SIGNING_STORAGE_OPTIONS
   )
-end
-
-def prompt_user_for_app_store_connect_credentials
-  require 'credentials_manager'
-
-  # If Fastlane cannot instantiate a user, it will ask the caller for the email.
-  # Once we have it, we can set it as `FASTLANE_USER` in the environment (which has lifecycle limited to this call) so that the next commands will already have access to it.
-  # Note that if the user is already available to `AccountManager`, setting it in the environment is redundant, but Fastlane doesn't provide a way to check it so we have to do it anyway.
-  ENV['FASTLANE_USER'] = CredentialsManager::AccountManager.new.user
 end


### PR DESCRIPTION
## Description

Enterprise `match` with `readonly: false` still prompted for an Apple ID.
The Enterprise APIs now accept API keys, but that key is not the App Store Connect one, so this adds a dedicated `_ENTERPRISE` trio.

Readonly still passes no key, so CI is unchanged and does not exercise the write path.

Closes [AINFRA-3083](https://linear.app/a8c/issue/AINFRA-3083), part of [AINFRA-2023](https://linear.app/a8c/issue/AINFRA-2023).

## Testing instructions

Verified by generating the new Enterprise profiles after adding the age range capability.

- `bundle exec fastlane update_certs_and_profiles_wordpress_enterprise` — no new variables
- `bundle exec fastlane update_certs_and_profiles_wordpress_enterprise readonly:false` — needs the three `_ENTERPRISE` variables in `~/.wpios-env.default`


### CI evidence

This PR's own build is vacuous: it touches only `fastlane/`, and `should-skip-job.sh` lists `fastlane/**` in `COMMON_PATTERNS`, so every build job skipped in ~48s and none of this code ran.

Build [#34379](https://buildkite.com/automattic/wordpress-ios/builds/34379), on a throwaway branch that added a `.buildkite/` file to defeat that guard, ran it for real with the three `_ENTERPRISE` variables unset:

- Readonly `update_certs_and_profiles_enterprise` **passed** — 55 files from S3, `🔓 Successfully decrypted certificates repo`, 5 InHouse profiles installed, no Apple authentication attempted.
- `readonly:false` **failed through the guard**, with `Environment variable 'APP_STORE_CONNECT_API_KEY_KEY_ID_ENTERPRISE' is not set` and nothing else — it dies in `get_required_env` before `match` runs, so the readonly pass could have gone red.
- Both Prototype Builds ran the lanes through the real path and produced enterprise-signed IPAs (`org.wordpress.alpha@27.2+34379`, `com.jetpack.alpha@27.2+34379`).

CI cannot test the write path: `setup_ci` sets `MATCH_READONLY=true`, so `readonly:false` against Apple is only ever reachable by hand — which is the manual verification above.
