### PR TITLE
[DO NOT MERGE] Validate Enterprise code signing for #25994

### DIFF
--- a/.buildkite/commands/validate-enterprise-codesign.sh
+++ b/.buildkite/commands/validate-enterprise-codesign.sh
@@ -1,0 +1,34 @@
+#!/bin/bash -eu
+
+echo "--- :rubygems: Setting up Gems"
+install_gems
+
+# The claim under test is that readonly runs need no Enterprise key, so drop the variables
+# whether or not the agent's environment carries them.
+unset APP_STORE_CONNECT_API_KEY_KEY_ID_ENTERPRISE
+unset APP_STORE_CONNECT_API_KEY_ISSUER_ID_ENTERPRISE
+unset APP_STORE_CONNECT_API_KEY_KEY_ENTERPRISE
+
+echo "--- :closed_lock_with_key: Readonly must succeed with no Enterprise key"
+bundle exec fastlane update_certs_and_profiles_enterprise
+
+echo "--- :closed_lock_with_key: Non-readonly must fail through the missing-variable guard"
+set +e
+output=$(bundle exec fastlane update_certs_and_profiles_wordpress_enterprise readonly:false 2>&1)
+status=$?
+set -e
+echo "$output"
+
+if [ $status -eq 0 ]; then
+  echo "^^^ +++"
+  echo "Expected a failure without APP_STORE_CONNECT_API_KEY_KEY_ID_ENTERPRISE, but the lane succeeded."
+  exit 1
+fi
+
+if ! grep -q "APP_STORE_CONNECT_API_KEY_KEY_ID_ENTERPRISE' is not set" <<< "$output"; then
+  echo "^^^ +++"
+  echo "The lane failed, but not through the missing-variable guard, so this run proves nothing."
+  exit 1
+fi
+
+echo "Guard fired as expected."

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -10,6 +10,13 @@ env:
 # This is the default pipeline – it will build and test the app
 steps:
   #################
+  # [DO NOT MERGE] Validation for #25994 - remove with this branch
+  #################
+  - label: "🔐 Validate Enterprise Code Signing"
+    command: ".buildkite/commands/validate-enterprise-codesign.sh"
+    plugins: [$CI_TOOLKIT_PLUGIN]
+
+  #################
   # Create Prototype Builds for WP and JP
   #################
   - group: "🛠 Prototype Builds"


### PR DESCRIPTION
## Description

**Validation only — do not merge.** Stacked on `ainfra-3083-add-in_house-true-asc-api-key-to-wordpress-and-jetpack-ios`, the head of #25994. It will be closed once it has answered.

#25994 went green on 28/28 checks without running a single build job. It touches only `fastlane/`, and `.buildkite/commands/should-skip-job.sh` lists `fastlane/**` in `COMMON_PATTERNS`; the `build` case skips whenever `pr_changed_files --all-match` succeeds. Both Prototype Builds reported `Skipped 🛠 … - no relevant files changed` in 48s, so `update_code_signing_enterprise` was never called. Touching `.buildkite/` defeats the all-match guard, which is what lets those jobs run here.

## Testing instructions

Read **🔐 Validate Enterprise Code Signing**. Every step is expected to pass; there is no intentional failure to leave alone.

It unsets the three `_ENTERPRISE` variables first, so the result holds whether or not the agent's environment carries them, and asserts in both directions:

- `update_certs_and_profiles_enterprise` (readonly) must succeed — proves CI needs no Enterprise key.
- `update_certs_and_profiles_wordpress_enterprise readonly:false` must fail, *and* the output must name `APP_STORE_CONNECT_API_KEY_KEY_ID_ENTERPRISE` — proves the first assertion could have gone red, and that the guard is what fires. `get_required_env` raises while the arguments to `update_code_signing` are being evaluated, so this reaches neither S3 nor Apple.

The two Prototype Builds are the second half of the evidence: they call the same lanes in readonly mode through the real build path.

CI cannot answer whether the key works against the Enterprise account — that needs `readonly:false` against Apple, which was verified by hand while regenerating the Enterprise provisioning profiles.
