### PR TITLE
fix: surface an error when a picked media item can't be loaded

### DIFF
--- a/Tests/KeystoneTests/Tests/Features/Media/ItemProviderMediaExporterErrorTests.swift
+++ b/Tests/KeystoneTests/Tests/Features/Media/ItemProviderMediaExporterErrorTests.swift
@@ -1,0 +1,49 @@
+import Foundation
+import Testing
+
+@testable import WordPress
+
+struct ItemProviderMediaExporterErrorTests {
+
+    /// The exact error shape observed on device when the Photos provider is killed
+    /// while materializing an image too large for its memory limit:
+    /// `NSItemProviderErrorDomain -1000` wrapping `NSCocoaErrorDomain 4099`.
+    @Test func detectsProviderProcessDeathFromNestedXPCError() {
+        let xpcError = NSError(domain: NSCocoaErrorDomain, code: CocoaError.Code.xpcConnectionInvalid.rawValue)
+        let itemProviderError = NSError(
+            domain: "NSItemProviderErrorDomain",
+            code: -1000,
+            userInfo: [NSUnderlyingErrorKey: xpcError]
+        )
+
+        let match = ItemProviderMediaExporter.providerConnectionError(in: itemProviderError)
+
+        #expect(match?.domain == NSCocoaErrorDomain)
+        #expect(match?.code == CocoaError.Code.xpcConnectionInvalid.rawValue)
+    }
+
+    @Test func detectsXPCConnectionInterruptedAtTopLevel() {
+        let error = NSError(domain: NSCocoaErrorDomain, code: CocoaError.Code.xpcConnectionInterrupted.rawValue)
+        #expect(ItemProviderMediaExporter.providerConnectionError(in: error) != nil)
+    }
+
+    @Test func findsXPCErrorNestedSeveralLevelsDeep() {
+        let xpcError = NSError(domain: NSCocoaErrorDomain, code: CocoaError.Code.xpcConnectionReplyInvalid.rawValue)
+        let middle = NSError(domain: "Middle", code: 1, userInfo: [NSUnderlyingErrorKey: xpcError])
+        let outer = NSError(domain: "Outer", code: 2, userInfo: [NSUnderlyingErrorKey: middle])
+        #expect(ItemProviderMediaExporter.providerConnectionError(in: outer) != nil)
+    }
+
+    /// A generic Cocoa error that is *not* an XPC connection failure must not match —
+    /// otherwise every load failure would be misreported as a provider process death.
+    @Test func ignoresUnrelatedCocoaError() {
+        let error = NSError(domain: NSCocoaErrorDomain, code: CocoaError.Code.fileNoSuchFile.rawValue)
+        #expect(ItemProviderMediaExporter.providerConnectionError(in: error) == nil)
+    }
+
+    /// The same numeric code in a different domain is not an XPC error.
+    @Test func ignoresXPCCodeInADifferentDomain() {
+        let error = NSError(domain: "SomeOtherDomain", code: CocoaError.Code.xpcConnectionInvalid.rawValue)
+        #expect(ItemProviderMediaExporter.providerConnectionError(in: error) == nil)
+    }
+}

--- a/Tests/KeystoneTests/Tests/Features/Media/ItemProviderMediaExporterErrorTests.swift
+++ b/Tests/KeystoneTests/Tests/Features/Media/ItemProviderMediaExporterErrorTests.swift
@@ -34,6 +34,21 @@ struct ItemProviderMediaExporterErrorTests {
         #expect(ItemProviderMediaExporter.providerConnectionError(in: outer) != nil)
     }
 
+    /// A provider-death XPC error can be buried several layers down a wrapped chain.
+    /// The classifier must still find it: the chain-walk previously enqueued every
+    /// wrapped error twice (`underlyingErrors` *and* `NSUnderlyingErrorKey`), exhausting
+    /// its traversal budget long before reaching errors this deep.
+    @Test func findsXPCErrorFiveLevelsDeep() {
+        let xpcError = NSError(domain: NSCocoaErrorDomain, code: CocoaError.Code.xpcConnectionInvalid.rawValue)
+        // Bury the XPC error five `NSUnderlyingErrorKey` levels down.
+        var nested: Error = xpcError
+        for level in 1...5 {
+            nested = NSError(domain: "Wrapper\(level)", code: level, userInfo: [NSUnderlyingErrorKey: nested])
+        }
+        let match = ItemProviderMediaExporter.providerConnectionError(in: nested)
+        #expect(match?.code == CocoaError.Code.xpcConnectionInvalid.rawValue)
+    }
+
     /// A generic Cocoa error that is *not* an XPC connection failure must not match —
     /// otherwise every load failure would be misreported as a provider process death.
     @Test func ignoresUnrelatedCocoaError() {
@@ -45,5 +60,40 @@ struct ItemProviderMediaExporterErrorTests {
     @Test func ignoresXPCCodeInADifferentDomain() {
         let error = NSError(domain: "SomeOtherDomain", code: CocoaError.Code.xpcConnectionInvalid.rawValue)
         #expect(ItemProviderMediaExporter.providerConnectionError(in: error) == nil)
+    }
+
+    // MARK: - Cancellation
+
+    /// A user-cancelled load must not be surfaced as an error (it would show a
+    /// spurious "failed" message for an upload the user deliberately cancelled).
+    @Test func detectsUserCancellation() {
+        let error = NSError(domain: NSCocoaErrorDomain, code: NSUserCancelledError)
+        #expect(ItemProviderMediaExporter.isCancellation(error))
+    }
+
+    @Test func detectsURLCancellation() {
+        let error = NSError(domain: NSURLErrorDomain, code: NSURLErrorCancelled)
+        #expect(ItemProviderMediaExporter.isCancellation(error))
+    }
+
+    @Test func detectsSwiftConcurrencyCancellation() {
+        #expect(ItemProviderMediaExporter.isCancellation(CancellationError()))
+    }
+
+    @Test func detectsCancellationNestedInChain() {
+        let cancel = NSError(domain: NSURLErrorDomain, code: NSURLErrorCancelled)
+        let outer = NSError(domain: "Outer", code: 1, userInfo: [NSUnderlyingErrorKey: cancel])
+        #expect(ItemProviderMediaExporter.isCancellation(outer))
+    }
+
+    /// A provider-death (XPC) error is a genuine failure, not a cancellation.
+    @Test func doesNotTreatXPCFailureAsCancellation() {
+        let error = NSError(domain: NSCocoaErrorDomain, code: CocoaError.Code.xpcConnectionInvalid.rawValue)
+        #expect(!ItemProviderMediaExporter.isCancellation(error))
+    }
+
+    @Test func doesNotTreatUnrelatedErrorAsCancellation() {
+        let error = NSError(domain: NSCocoaErrorDomain, code: CocoaError.Code.fileNoSuchFile.rawValue)
+        #expect(!ItemProviderMediaExporter.isCancellation(error))
     }
 }

--- a/Tests/KeystoneTests/Tests/Features/Media/ItemProviderMediaExporterErrorTests.swift
+++ b/Tests/KeystoneTests/Tests/Features/Media/ItemProviderMediaExporterErrorTests.swift
@@ -5,8 +5,8 @@ import Testing
 
 struct ItemProviderMediaExporterErrorTests {
 
-    /// The exact error shape observed on device when the Photos provider is killed
-    /// while materializing an image too large for its memory limit:
+    /// The exact error shape observed on device (under iOS Lockdown Mode) when the
+    /// Photos provider is killed while materializing a large image:
     /// `NSItemProviderErrorDomain -1000` wrapping `NSCocoaErrorDomain 4099`.
     @Test func detectsProviderProcessDeathFromNestedXPCError() {
         let xpcError = NSError(domain: NSCocoaErrorDomain, code: CocoaError.Code.xpcConnectionInvalid.rawValue)

--- a/Tests/KeystoneTests/Tests/Features/Media/ItemProviderMediaExporterErrorTests.swift
+++ b/Tests/KeystoneTests/Tests/Features/Media/ItemProviderMediaExporterErrorTests.swift
@@ -34,10 +34,8 @@ struct ItemProviderMediaExporterErrorTests {
         #expect(ItemProviderMediaExporter.providerConnectionError(in: outer) != nil)
     }
 
-    /// A provider-death XPC error can be buried several layers down a wrapped chain.
-    /// The classifier must still find it: the chain-walk previously enqueued every
-    /// wrapped error twice (`underlyingErrors` *and* `NSUnderlyingErrorKey`), exhausting
-    /// its traversal budget long before reaching errors this deep.
+    /// A provider-death XPC error can be buried deeper than the shallow nesting
+    /// above. The classifier must still walk the whole chain to find it.
     @Test func findsXPCErrorFiveLevelsDeep() {
         let xpcError = NSError(domain: NSCocoaErrorDomain, code: CocoaError.Code.xpcConnectionInvalid.rawValue)
         // Bury the XPC error five `NSUnderlyingErrorKey` levels down.

--- a/WordPress/Classes/System/WordPressAppDelegate.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate.swift
@@ -218,6 +218,8 @@ public class WordPressAppDelegate: UIResponder, UIApplicationDelegate {
     ) -> Bool {
         Loggers.app.info("didFinishLaunchingWithOptions state: \(application.applicationState)")
 
+        LockdownHelper.primeAppLockdownState()
+
         ABTest.start()
 
         Media.removeTemporaryData()

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -18,6 +18,7 @@ import WordPressShared
     case mediaStorageDetailsViewed
     case mediaStorageDetailsActionTapped
     case mediaStorageDetailsPurchaseCompleted
+    case mediaImportItemUnavailable
 
     // Settings and Prepublishing Nudges
     case editorPostPublishTap
@@ -732,6 +733,8 @@ import WordPressShared
             return "media_storage_details_action_tapped"
         case .mediaStorageDetailsPurchaseCompleted:
             return "media_storage_details_purchase_completed"
+        case .mediaImportItemUnavailable:
+            return "media_import_item_unavailable"
         // Editor
         case .editorPostPublishTap:
             return "editor_post_publish_tapped"

--- a/WordPress/Classes/Utility/LockdownHelper.swift
+++ b/WordPress/Classes/Utility/LockdownHelper.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+/// Reports whether iOS Lockdown Mode is enabled.
+///
+/// Lockdown Mode can only be toggled with a device restart, so its state is constant
+/// for the lifetime of the process. The flag is therefore read once — lazily, on first
+/// access — from the system-maintained `LDMGlobalEnabled` user default; `static let`
+/// makes that read thread-safe and the result immutable.
+enum LockdownHelper {
+    /// The system-maintained global user default, set while Lockdown Mode is enabled.
+    private static let lockdownModeDefaultsKey = "LDMGlobalEnabled"
+
+    static let isLockdownModeEnabled = UserDefaults.standard.bool(forKey: lockdownModeDefaultsKey)
+}

--- a/WordPress/Classes/Utility/LockdownHelper.swift
+++ b/WordPress/Classes/Utility/LockdownHelper.swift
@@ -1,14 +1,45 @@
 import Foundation
+import WebKit
+import os
 
-/// Reports whether iOS Lockdown Mode is enabled.
+/// Reports iOS Lockdown Mode state at two scopes.
 ///
-/// Lockdown Mode can only be toggled with a device restart, so its state is constant
-/// for the lifetime of the process. The flag is therefore read once — lazily, on first
-/// access — from the system-maintained `LDMGlobalEnabled` user default; `static let`
-/// makes that read thread-safe and the result immutable.
+/// The media-import failure this guards originates in the shared `PhotosFileProvider`
+/// system extension, which stays memory-restricted whenever Lockdown Mode is enabled
+/// *device-wide* — even for an app the user has excluded from Lockdown Mode (verified on
+/// device: an excluded app's import still fails). So the device-wide flag is what
+/// correlates with the failure and drives the error copy; the per-app value is recorded
+/// only as secondary telemetry.
 enum LockdownHelper {
     /// The system-maintained global user default, set while Lockdown Mode is enabled.
     private static let lockdownModeDefaultsKey = "LDMGlobalEnabled"
 
-    static let isLockdownModeEnabled = UserDefaults.standard.bool(forKey: lockdownModeDefaultsKey)
+    /// Whether Lockdown Mode is enabled device-wide. Governs shared system services like
+    /// `PhotosFileProvider`, so it's the signal that correlates with the media-import
+    /// failure. Device-wide Lockdown Mode only toggles on a device restart, so it's read
+    /// once — lazily, on first access — and constant for the process; `static let` makes
+    /// that read thread-safe and the result immutable.
+    static let isDeviceLockdownModeEnabled = UserDefaults.standard.bool(forKey: lockdownModeDefaultsKey)
+
+    /// Cached per-app Lockdown Mode state, populated by `primeAppLockdownState()`.
+    private static let appLockdownState = OSAllocatedUnfairLock(initialState: false)
+
+    /// Reads and caches whether *this app* is running under Lockdown Mode.
+    ///
+    /// The value comes from WebKit's per-app-effective `isLockdownModeEnabled`, which is
+    /// `@MainActor`; the sole reader (`ItemProviderMediaExporter`) runs on a background
+    /// callback queue, and the per-app value is applied at process launch and constant
+    /// thereafter — so it's read once here on the main actor and cached for later reads.
+    ///
+    /// Call once, early, on the main actor (from `didFinishLaunchingWithOptions`).
+    @MainActor static func primeAppLockdownState() {
+        let isEnabled = WKWebViewConfiguration().defaultWebpagePreferences.isLockdownModeEnabled
+        appLockdownState.withLock { $0 = isEnabled }
+    }
+
+    /// Whether *this app* is itself running under Lockdown Mode (`false` if the user has
+    /// excluded it). Valid only after `primeAppLockdownState()`; defaults to `false`.
+    static var isAppLockdownModeEnabled: Bool {
+        appLockdownState.withLock { $0 }
+    }
 }

--- a/WordPress/Classes/Utility/Media/ItemProviderMediaExporter.swift
+++ b/WordPress/Classes/Utility/Media/ItemProviderMediaExporter.swift
@@ -139,8 +139,9 @@ final class ItemProviderMediaExporter: MediaExporter {
     /// Surfaces a failure to load the picked file from the `NSItemProvider`.
     ///
     /// When the provider's connection died (an XPC failure), the app shows a friendly
-    /// message and tracks the event so this case can be told apart from ordinary load
-    /// failures. Any other error is surfaced as-is.
+    /// message — specific to Lockdown Mode when it's enabled — and tracks the event so
+    /// this case can be told apart from ordinary load failures. Any other error is
+    /// surfaced as-is.
     ///
     /// Observed only with iOS Lockdown Mode enabled: materializing a large photo
     /// (e.g. 36 MP) fails and the `PhotosFileProvider` process is killed, giving
@@ -151,14 +152,15 @@ final class ItemProviderMediaExporter: MediaExporter {
             return
         }
         if let connectionError = ItemProviderMediaExporter.providerConnectionError(in: error) {
-            WPAnalytics.track(.mediaImportItemUnavailable, properties: providerErrorProperties(for: error, connectionError: connectionError))
-            onError(ExportError.cannotLoadItem)
+            let isLockdownModeEnabled = ItemProviderMediaExporter.isLockdownModeEnabled
+            WPAnalytics.track(.mediaImportItemUnavailable, properties: providerErrorProperties(for: error, connectionError: connectionError, isLockdownModeEnabled: isLockdownModeEnabled))
+            onError(isLockdownModeEnabled ? ExportError.lockdownModeRestricted : ExportError.cannotLoadItem)
         } else {
             onError(ExportError.underlyingError(error))
         }
     }
 
-    private func providerErrorProperties(for error: Error, connectionError: NSError) -> [AnyHashable: Any] {
+    private func providerErrorProperties(for error: Error, connectionError: NSError, isLockdownModeEnabled: Bool) -> [AnyHashable: Any] {
         let error = error as NSError
         return [
             "error_domain": error.domain,
@@ -166,7 +168,7 @@ final class ItemProviderMediaExporter: MediaExporter {
             "underlying_error_domain": connectionError.domain,
             "underlying_error_code": connectionError.code,
             "type_identifiers": provider.registeredTypeIdentifiers.joined(separator: ", "),
-            "lockdown_mode": ItemProviderMediaExporter.isLockdownModeEnabled
+            "lockdown_mode": isLockdownModeEnabled
         ]
     }
 
@@ -214,6 +216,7 @@ final class ItemProviderMediaExporter: MediaExporter {
     enum ExportError: MediaExportError {
         case unsupportedContentType
         case cannotLoadItem
+        case lockdownModeRestricted
         case underlyingError(Error)
         case unknown
 
@@ -225,6 +228,8 @@ final class ItemProviderMediaExporter: MediaExporter {
                 return NSLocalizedString("mediaExporter.error.unsupportedContentType", value: "Unsupported content type", comment: "An error message the app shows if media import fails")
             case .cannotLoadItem:
                 return NSLocalizedString("mediaExporter.error.cannotLoadItem", value: "This item could not be added to the Media library. It may be too large to import.", comment: "Error shown when a selected photo or video can't be loaded from the device for upload.")
+            case .lockdownModeRestricted:
+                return NSLocalizedString("mediaExporter.error.lockdownMode", value: "This item can’t be added to the Media library while Lockdown Mode is on.", comment: "Error shown when a selected photo or video can't be imported because iOS Lockdown Mode is enabled.")
             case .underlyingError(let error):
                 return error.localizedDescription
             case .unknown:

--- a/WordPress/Classes/Utility/Media/ItemProviderMediaExporter.swift
+++ b/WordPress/Classes/Utility/Media/ItemProviderMediaExporter.swift
@@ -152,7 +152,7 @@ final class ItemProviderMediaExporter: MediaExporter {
             return
         }
         if let connectionError = ItemProviderMediaExporter.providerConnectionError(in: error) {
-            let isLockdownModeEnabled = ItemProviderMediaExporter.isLockdownModeEnabled
+            let isLockdownModeEnabled = LockdownHelper.isLockdownModeEnabled
             WPAnalytics.track(.mediaImportItemUnavailable, properties: providerErrorProperties(for: error, connectionError: connectionError, isLockdownModeEnabled: isLockdownModeEnabled))
             onError(isLockdownModeEnabled ? ExportError.lockdownModeRestricted : ExportError.cannotLoadItem)
         } else {
@@ -170,13 +170,6 @@ final class ItemProviderMediaExporter: MediaExporter {
             "type_identifiers": provider.registeredTypeIdentifiers.joined(separator: ", "),
             "lockdown_mode": isLockdownModeEnabled
         ]
-    }
-
-    /// Whether iOS Lockdown Mode is enabled, read from the system's global
-    /// `LDMGlobalEnabled` user-defaults flag. Recorded on the failure event to
-    /// confirm the correlation — this failure is only expected under Lockdown Mode.
-    private static var isLockdownModeEnabled: Bool {
-        UserDefaults.standard.bool(forKey: "LDMGlobalEnabled")
     }
 
     /// The XPC connection error codes (in `NSCocoaErrorDomain`) that signal the item

--- a/WordPress/Classes/Utility/Media/ItemProviderMediaExporter.swift
+++ b/WordPress/Classes/Utility/Media/ItemProviderMediaExporter.swift
@@ -85,7 +85,7 @@ final class ItemProviderMediaExporter: MediaExporter {
         let loadProgress = provider.loadFileRepresentation(forTypeIdentifier: UTType.data.identifier) { url, error in
             guard let url else {
                 DDLogError("Failed to load file representation for provider: \(ObjectIdentifier(self.provider)), error: \(String(describing: error))")
-                onError(ExportError.cannotLoadItem)
+                self.handleLoadFailure(error, onError: onError)
                 return
             }
             let diff = CFAbsoluteTimeGetCurrent() - start
@@ -136,10 +136,75 @@ final class ItemProviderMediaExporter: MediaExporter {
         provider.hasItemConformingToTypeIdentifier(type.identifier)
     }
 
+    /// Surfaces a failure to load the picked file from the `NSItemProvider`.
+    ///
+    /// When the provider's connection died (an XPC failure — typically the provider
+    /// process being killed while materializing an image too large for its memory
+    /// limit), the app shows a friendly message and tracks the event so this case can
+    /// be told apart from ordinary load failures. Any other error is surfaced as-is.
+    private func handleLoadFailure(_ error: Error?, onError: (MediaExportError) -> Void) {
+        guard let error else {
+            onError(ExportError.unknown)
+            return
+        }
+        if let connectionError = ItemProviderMediaExporter.providerConnectionError(in: error) {
+            WPAnalytics.track(.mediaImportItemUnavailable, properties: providerErrorProperties(for: error, connectionError: connectionError))
+            onError(ExportError.cannotLoadItem)
+        } else {
+            onError(ExportError.underlyingError(error))
+        }
+    }
+
+    private func providerErrorProperties(for error: Error, connectionError: NSError) -> [AnyHashable: Any] {
+        let error = error as NSError
+        return [
+            "error_domain": error.domain,
+            "error_code": error.code,
+            "underlying_error_domain": connectionError.domain,
+            "underlying_error_code": connectionError.code,
+            "type_identifiers": provider.registeredTypeIdentifiers.joined(separator: ", ")
+        ]
+    }
+
+    /// The XPC connection error codes (in `NSCocoaErrorDomain`) that signal the item
+    /// provider's process died while producing the file.
+    private static let xpcConnectionErrorCodes: Set<Int> = [
+        CocoaError.Code.xpcConnectionInterrupted.rawValue,
+        CocoaError.Code.xpcConnectionInvalid.rawValue,
+        CocoaError.Code.xpcConnectionReplyInvalid.rawValue
+    ]
+
+    /// Returns the first XPC connection error found in `error` or any of its
+    /// underlying errors, or `nil` if there is none.
+    static func providerConnectionError(in error: Error) -> NSError? {
+        errorChain(from: error)
+            .map { $0 as NSError }
+            .first { $0.domain == NSCocoaErrorDomain && xpcConnectionErrorCodes.contains($0.code) }
+    }
+
+    /// Flattens `error` and its underlying errors (both the `underlyingErrors` array
+    /// and the legacy `NSUnderlyingErrorKey`) into a single list, bounded to guard
+    /// against pathological cycles.
+    private static func errorChain(from error: Error) -> [Error] {
+        var result: [Error] = []
+        var queue: [Error] = [error]
+        while let next = queue.first, result.count < 16 {
+            queue.removeFirst()
+            result.append(next)
+            let nsError = next as NSError
+            queue.append(contentsOf: nsError.underlyingErrors)
+            if let underlying = nsError.userInfo[NSUnderlyingErrorKey] as? Error {
+                queue.append(underlying)
+            }
+        }
+        return result
+    }
+
     enum ExportError: MediaExportError {
         case unsupportedContentType
         case cannotLoadItem
-        case underlyingError(Error?)
+        case underlyingError(Error)
+        case unknown
 
         public var errorDescription: String? { description }
 
@@ -150,7 +215,9 @@ final class ItemProviderMediaExporter: MediaExporter {
             case .cannotLoadItem:
                 return NSLocalizedString("mediaExporter.error.cannotLoadItem", value: "This item could not be added to the Media library. It may be too large to import.", comment: "Error shown when a selected photo or video can't be loaded from the device for upload.")
             case .underlyingError(let error):
-                return error?.localizedDescription ?? NSLocalizedString("mediaExporter.error.unknown", value: "The item could not be added to the Media library", comment: "An error message the app shows if media import fails")
+                return error.localizedDescription
+            case .unknown:
+                return NSLocalizedString("mediaExporter.error.unknown", value: "The item could not be added to the Media library", comment: "An error message the app shows if media import fails")
             }
         }
     }

--- a/WordPress/Classes/Utility/Media/ItemProviderMediaExporter.swift
+++ b/WordPress/Classes/Utility/Media/ItemProviderMediaExporter.swift
@@ -138,10 +138,13 @@ final class ItemProviderMediaExporter: MediaExporter {
 
     /// Surfaces a failure to load the picked file from the `NSItemProvider`.
     ///
-    /// When the provider's connection died (an XPC failure — typically the provider
-    /// process being killed while materializing an image too large for its memory
-    /// limit), the app shows a friendly message and tracks the event so this case can
-    /// be told apart from ordinary load failures. Any other error is surfaced as-is.
+    /// When the provider's connection died (an XPC failure), the app shows a friendly
+    /// message and tracks the event so this case can be told apart from ordinary load
+    /// failures. Any other error is surfaced as-is.
+    ///
+    /// Observed only with iOS Lockdown Mode enabled: materializing a large photo
+    /// (e.g. 36 MP) fails and the `PhotosFileProvider` process is killed, giving
+    /// `NSItemProviderError -1000` over `NSCocoaErrorDomain 4099`.
     private func handleLoadFailure(_ error: Error?, onError: (MediaExportError) -> Void) {
         guard let error else {
             onError(ExportError.unknown)

--- a/WordPress/Classes/Utility/Media/ItemProviderMediaExporter.swift
+++ b/WordPress/Classes/Utility/Media/ItemProviderMediaExporter.swift
@@ -85,7 +85,6 @@ final class ItemProviderMediaExporter: MediaExporter {
 
         let loadProgress = provider.loadFileRepresentation(forTypeIdentifier: UTType.data.identifier) { url, error in
             guard let url else {
-                DDLogError("Failed to load file representation for provider: \(ObjectIdentifier(self.provider)), error: \(String(describing: error))")
                 self.handleLoadFailure(error, onError: onError)
                 return
             }
@@ -144,14 +143,29 @@ final class ItemProviderMediaExporter: MediaExporter {
     /// this case can be told apart from ordinary load failures. Any other error is
     /// surfaced as-is.
     ///
+    /// A cancelled load (the user cancelled the upload, or the system cancelled the
+    /// request) is *not* surfaced — cancellation is reported separately by the upload
+    /// coordinator, so calling `onError` here would show a spurious failure.
+    ///
     /// Observed only with iOS Lockdown Mode enabled: materializing a large photo
     /// (e.g. 36 MP) fails and the `PhotosFileProvider` process is killed, giving
     /// `NSItemProviderError -1000` over `NSCocoaErrorDomain 4099`.
     private func handleLoadFailure(_ error: Error?, onError: (MediaExportError) -> Void) {
+        let providerID = ObjectIdentifier(provider)
         guard let error else {
+            DDLogError("Failed to load file representation for provider: \(providerID), error: nil")
             onError(ExportError.unknown)
             return
         }
+        // A cancelled load isn't a failure to report: the upload coordinator cancels
+        // this request's `Progress` (which fires this completion with a cancellation
+        // error) and surfaces the cancellation itself. Bail out without calling
+        // `onError` so we don't show a spurious "failed" message.
+        if ItemProviderMediaExporter.isCancellation(error) {
+            DDLogInfo("Cancelled loading file representation for provider: \(providerID)")
+            return
+        }
+        DDLogError("Failed to load file representation for provider: \(providerID), error: \(error)")
         if let connectionError = ItemProviderMediaExporter.providerConnectionError(in: error) {
             let isLockdownModeEnabled = LockdownHelper.isLockdownModeEnabled
             WPAnalytics.track(.mediaImportItemUnavailable, properties: providerErrorProperties(for: error, connectionError: connectionError, isLockdownModeEnabled: isLockdownModeEnabled))
@@ -189,20 +203,39 @@ final class ItemProviderMediaExporter: MediaExporter {
             .first { $0.domain == NSCocoaErrorDomain && xpcConnectionErrorCodes.contains($0.code) }
     }
 
-    /// Flattens `error` and its underlying errors (both the `underlyingErrors` array
-    /// and the legacy `NSUnderlyingErrorKey`) into a single list, bounded to guard
+    /// Returns `true` when `error`, or any error it wraps, represents a cancellation
+    /// rather than a genuine failure — a `CancellationError`, `NSUserCancelledError`,
+    /// or `NSURLErrorCancelled`.
+    static func isCancellation(_ error: Error) -> Bool {
+        errorChain(from: error).contains { element in
+            if element is CancellationError {
+                return true
+            }
+            let nsError = element as NSError
+            switch (nsError.domain, nsError.code) {
+            case (NSCocoaErrorDomain, NSUserCancelledError),
+                 (NSURLErrorDomain, NSURLErrorCancelled):
+                return true
+            default:
+                return false
+            }
+        }
+    }
+
+    /// Flattens `error` and its underlying errors into a single list, bounded to guard
     /// against pathological cycles.
+    ///
+    /// `NSError.underlyingErrors` already surfaces the value stored under the legacy
+    /// `NSUnderlyingErrorKey` (along with `NSMultipleUnderlyingErrorsKey`), so it is the
+    /// only source we enqueue. Reading `NSUnderlyingErrorKey` separately as well would
+    /// visit every wrapped error twice and halve the depth reachable before the bound.
     private static func errorChain(from error: Error) -> [Error] {
         var result: [Error] = []
         var queue: [Error] = [error]
         while let next = queue.first, result.count < 16 {
             queue.removeFirst()
             result.append(next)
-            let nsError = next as NSError
-            queue.append(contentsOf: nsError.underlyingErrors)
-            if let underlying = nsError.userInfo[NSUnderlyingErrorKey] as? Error {
-                queue.append(underlying)
-            }
+            queue.append(contentsOf: (next as NSError).underlyingErrors)
         }
         return result
     }

--- a/WordPress/Classes/Utility/Media/ItemProviderMediaExporter.swift
+++ b/WordPress/Classes/Utility/Media/ItemProviderMediaExporter.swift
@@ -84,7 +84,8 @@ final class ItemProviderMediaExporter: MediaExporter {
 
         let loadProgress = provider.loadFileRepresentation(forTypeIdentifier: UTType.data.identifier) { url, error in
             guard let url else {
-                DDLogDebug("Loaded file representation for provider: \(ObjectIdentifier(self.provider)), error: \(String(describing: error)))")
+                DDLogError("Failed to load file representation for provider: \(ObjectIdentifier(self.provider)), error: \(String(describing: error))")
+                onError(ExportError.cannotLoadItem)
                 return
             }
             let diff = CFAbsoluteTimeGetCurrent() - start
@@ -137,6 +138,7 @@ final class ItemProviderMediaExporter: MediaExporter {
 
     enum ExportError: MediaExportError {
         case unsupportedContentType
+        case cannotLoadItem
         case underlyingError(Error?)
 
         public var errorDescription: String? { description }
@@ -145,6 +147,8 @@ final class ItemProviderMediaExporter: MediaExporter {
             switch self {
             case .unsupportedContentType:
                 return NSLocalizedString("mediaExporter.error.unsupportedContentType", value: "Unsupported content type", comment: "An error message the app shows if media import fails")
+            case .cannotLoadItem:
+                return NSLocalizedString("mediaExporter.error.cannotLoadItem", value: "This item could not be added to the Media library. It may be too large to import.", comment: "Error shown when a selected photo or video can't be loaded from the device for upload.")
             case .underlyingError(let error):
                 return error?.localizedDescription ?? NSLocalizedString("mediaExporter.error.unknown", value: "The item could not be added to the Media library", comment: "An error message the app shows if media import fails")
             }

--- a/WordPress/Classes/Utility/Media/ItemProviderMediaExporter.swift
+++ b/WordPress/Classes/Utility/Media/ItemProviderMediaExporter.swift
@@ -165,8 +165,16 @@ final class ItemProviderMediaExporter: MediaExporter {
             "error_code": error.code,
             "underlying_error_domain": connectionError.domain,
             "underlying_error_code": connectionError.code,
-            "type_identifiers": provider.registeredTypeIdentifiers.joined(separator: ", ")
+            "type_identifiers": provider.registeredTypeIdentifiers.joined(separator: ", "),
+            "lockdown_mode": ItemProviderMediaExporter.isLockdownModeEnabled
         ]
+    }
+
+    /// Whether iOS Lockdown Mode is enabled, read from the system's global
+    /// `LDMGlobalEnabled` user-defaults flag. Recorded on the failure event to
+    /// confirm the correlation — this failure is only expected under Lockdown Mode.
+    private static var isLockdownModeEnabled: Bool {
+        UserDefaults.standard.bool(forKey: "LDMGlobalEnabled")
     }
 
     /// The XPC connection error codes (in `NSCocoaErrorDomain`) that signal the item

--- a/WordPress/Classes/Utility/Media/ItemProviderMediaExporter.swift
+++ b/WordPress/Classes/Utility/Media/ItemProviderMediaExporter.swift
@@ -1,6 +1,7 @@
 import Foundation
 import PhotosUI
 import WordPressData
+import WordPressShared
 
 /// Manages export of media assets: images and video.
 final class ItemProviderMediaExporter: MediaExporter {

--- a/WordPress/Classes/Utility/Media/ItemProviderMediaExporter.swift
+++ b/WordPress/Classes/Utility/Media/ItemProviderMediaExporter.swift
@@ -167,15 +167,22 @@ final class ItemProviderMediaExporter: MediaExporter {
         }
         DDLogError("Failed to load file representation for provider: \(providerID), error: \(error)")
         if let connectionError = ItemProviderMediaExporter.providerConnectionError(in: error) {
-            let isLockdownModeEnabled = LockdownHelper.isLockdownModeEnabled
-            WPAnalytics.track(.mediaImportItemUnavailable, properties: providerErrorProperties(for: error, connectionError: connectionError, isLockdownModeEnabled: isLockdownModeEnabled))
-            onError(isLockdownModeEnabled ? ExportError.lockdownModeRestricted : ExportError.cannotLoadItem)
+            let device = LockdownHelper.isDeviceLockdownModeEnabled
+            let appExcluded = device && !LockdownHelper.isAppLockdownModeEnabled
+            let properties = providerErrorProperties(
+                for: error,
+                connectionError: connectionError,
+                deviceLockdown: device,
+                appExcluded: appExcluded
+            )
+            WPAnalytics.track(.mediaImportItemUnavailable, properties: properties)
+            onError(device ? ExportError.lockdownModeRestricted : ExportError.cannotLoadItem)
         } else {
             onError(ExportError.underlyingError(error))
         }
     }
 
-    private func providerErrorProperties(for error: Error, connectionError: NSError, isLockdownModeEnabled: Bool) -> [AnyHashable: Any] {
+    private func providerErrorProperties(for error: Error, connectionError: NSError, deviceLockdown: Bool, appExcluded: Bool) -> [AnyHashable: Any] {
         let error = error as NSError
         return [
             "error_domain": error.domain,
@@ -183,7 +190,8 @@ final class ItemProviderMediaExporter: MediaExporter {
             "underlying_error_domain": connectionError.domain,
             "underlying_error_code": connectionError.code,
             "type_identifiers": provider.registeredTypeIdentifiers.joined(separator: ", "),
-            "lockdown_mode": isLockdownModeEnabled
+            "lockdown_mode": deviceLockdown,
+            "lockdown_mode_app_excluded": appExcluded
         ]
     }
 

--- a/WordPress/Classes/Utility/Media/ItemProviderMediaExporter.swift
+++ b/WordPress/Classes/Utility/Media/ItemProviderMediaExporter.swift
@@ -254,7 +254,7 @@ final class ItemProviderMediaExporter: MediaExporter {
             case .unsupportedContentType:
                 return NSLocalizedString("mediaExporter.error.unsupportedContentType", value: "Unsupported content type", comment: "An error message the app shows if media import fails")
             case .cannotLoadItem:
-                return NSLocalizedString("mediaExporter.error.cannotLoadItem", value: "This item could not be added to the Media library. It may be too large to import.", comment: "Error shown when a selected photo or video can't be loaded from the device for upload.")
+                return NSLocalizedString("mediaExporter.error.cannotLoadItem", value: "This item could not be added to the Media library. It may be too large to import. Please try again or resize the media.", comment: "Error shown when a selected photo or video can't be loaded from the device for upload.")
             case .lockdownModeRestricted:
                 return NSLocalizedString("mediaExporter.error.lockdownMode", value: "This item can’t be added to the Media library while Lockdown Mode is on.", comment: "Error shown when a selected photo or video can't be imported because iOS Lockdown Mode is enabled.")
             case .underlyingError(let error):


### PR DESCRIPTION
Fixes a bug where a device photo that fails to load from the Photos picker leaves a Media Library upload spinning forever instead of reporting a failure — and distinguishes the specific failure that motivated this from ordinary load errors.

## Root Cause

`ItemProviderMediaExporter.export` loads the picked file via `NSItemProvider.loadFileRepresentation`. On failure its completion handler logged at debug level and `return`ed **without calling `onError`**, so the export never completed and the import stayed `pending` indefinitely — the spinner never resolved.

## Fix

The load-failure path now always calls `onError`, and splits by cause:

- **Provider process died (XPC).** When the error chain contains an XPC connection failure (`NSCocoaErrorDomain` `xpcConnectionInterrupted` / `Invalid` / `ReplyInvalid`, nested under the `NSItemProviderError`), surface a user-facing error — a Lockdown-Mode-specific message (*"…while Lockdown Mode is on."*) when Lockdown Mode is enabled, otherwise the `cannotLoadItem` size hint (*"…It may be too large to import."*) — and emit a `media_import_item_unavailable` Tracks event carrying the error domains/codes, the provider's registered type identifiers, and whether Lockdown Mode is enabled (`LDMGlobalEnabled`). This is the case that motivated the PR.
- **Everything else** surfaces `underlyingError`, showing the system's own message. No event.
- `underlyingError` now carries a **non-optional** `Error`; a new `unknown` case covers the (contract-violating) no-URL/no-error result.

## What triggers it

This only reproduces with **iOS Lockdown Mode** enabled. Lockdown Mode hardens how the system materializes media for apps; loading the photo fails and the `PhotosFileProvider` process is killed, so `loadFileRepresentation` returns `NSItemProviderError -1000` with an underlying `NSCocoaErrorDomain 4099` — the provider's XPC connection dying. The repro used a **36 MP** JPEG; outside Lockdown Mode the same photo imports normally.

This PR makes the failure graceful and observable; it does **not** change what Lockdown Mode allows. Actually importing these under Lockdown Mode would need an import path that streams the original (e.g. `PHAsset` / `PHAssetResourceManager`) — a separate follow-up.

## Test plan

- [x] Device-verified (iPhone 15 Pro, iOS 27, **Lockdown Mode on**): a 36 MP photo via My Site → Media → *Choose from Device* shows **"1 file not uploaded"** immediately instead of spinning. Log: `Failed to load file representation … NSItemProviderError -1000 / 4099`. (This is the XPC path, so it resolves to `cannotLoadItem`.)
- [x] Unit tests cover the XPC-error detection: nested chains, all three XPC codes, and negatives (an unrelated Cocoa error, a matching code in a different domain).
- [ ] Confirm `media_import_item_unavailable` fires in Tracks (with `lockdown_mode = true`) when reproducing the case.
- [ ] A normal photo still imports successfully (outside Lockdown Mode).
