### PR TITLE
fix: decode the local file path before handing it to the media upload API

### DIFF
--- a/Tests/KeystoneTests/Tests/Services/MediaCreateParamsFilePathTests.swift
+++ b/Tests/KeystoneTests/Tests/Services/MediaCreateParamsFilePathTests.swift
@@ -1,0 +1,41 @@
+import Foundation
+import Testing
+import WordPressAPI
+import WordPressKit
+
+@testable import WordPress
+
+/// `URL.path()` percent-encodes by default, unlike the legacy `url.path` property, so the
+/// upload API was handed a path that doesn't exist on disk whenever the filename needed
+/// encoding. A space is enough, which makes it reachable with ordinary content.
+struct MediaCreateParamsFilePathTests {
+
+    @Test func decodesPercentEncodingInTheFilePath() throws {
+        let media = RemoteMedia()
+        media.localURL = URL(fileURLWithPath: "/tmp/media/screen recording 1.mp4")
+
+        let params = try #require(MediaCreateParams(media: media))
+
+        #expect(params.filePath == "/tmp/media/screen recording 1.mp4")
+    }
+
+    /// Characters beyond the space get encoded too, so check one of those as well.
+    @Test func decodesPercentEncodingBeyondSpaces() throws {
+        let media = RemoteMedia()
+        media.localURL = URL(fileURLWithPath: "/tmp/media/100% done.jpg")
+
+        let params = try #require(MediaCreateParams(media: media))
+
+        #expect(params.filePath == "/tmp/media/100% done.jpg")
+    }
+
+    /// A name needing no encoding has to survive untouched.
+    @Test func leavesAnOrdinaryPathAlone() throws {
+        let media = RemoteMedia()
+        media.localURL = URL(fileURLWithPath: "/tmp/media/IMG_0001.jpg")
+
+        let params = try #require(MediaCreateParams(media: media))
+
+        #expect(params.filePath == "/tmp/media/IMG_0001.jpg")
+    }
+}

--- a/WordPress/Classes/Services/MediaServiceRemoteCoreREST.swift
+++ b/WordPress/Classes/Services/MediaServiceRemoteCoreREST.swift
@@ -176,7 +176,9 @@ private extension RemoteMedia {
     }
 }
 
-private extension MediaCreateParams {
+// Not `private`: the file-path handling below is covered by
+// `MediaCreateParamsFilePathTests`.
+extension MediaCreateParams {
     init?(media: RemoteMedia) {
 
         guard let localURL = media.localURL else {
@@ -198,7 +200,9 @@ private extension MediaCreateParams {
             caption: media.caption,
             description: media.descriptionText,
             postId: media.postID?.int64Value,
-            filePath: localURL.path()
+            // `path()` percent-encodes by default, so a filename with a space (a screen
+            // recording, say) becomes a path that doesn't exist on disk.
+            filePath: localURL.path(percentEncoded: false)
         )
     }
 }


### PR DESCRIPTION
Fixes a bug where any media file whose name needs percent-encoding — a space is enough — fails to upload through the WordPress core REST API.

## Summary

- `URL.path()` percent-encodes by default, unlike the legacy `url.path` property, which returns a decoded path.
- `MediaCreateParams` passed the encoded form as `filePath`, so `wordpress-rs` looked for a file that doesn't exist on disk.
- Reachable with ordinary content: screen recordings and files imported from macOS routinely have spaces in their names.

## Root Cause

**WordPress/Classes/Services/MediaServiceRemoteCoreREST.swift**: `MediaCreateParams.init?(media:)` built `filePath` with `localURL.path()`.

The two APIs differ in a way the names don't advertise:

```swift
let url = URL(fileURLWithPath: "/tmp/media/screen recording 1.mp4")
url.path                          // "/tmp/media/screen recording 1.mp4"  ✅
url.path()                        // "/tmp/media/screen%20recording%201.mp4"  ❌
url.path(percentEncoded: false)   // "/tmp/media/screen recording 1.mp4"  ✅
```

Observed on device, uploading a screen recording:

```
WpApiError.MediaFileNotFound(filePath:
  ".../Documents/Media/screenrecording_08-27-2024%2012-12-08_1.mp4")
```

The file on disk was `screenrecording_08-27-2024 12-12-08_1.mp4`. Confirmed by listing the app's `Documents/Media` directory on the device — the name there has a literal space.

The export itself succeeds, so the failure lands late: the media object is created, `media_service_upload_started` fires, and the upload then fails with `MediaFileNotFound`.

## Fix

**WordPress/Classes/Services/MediaServiceRemoteCoreREST.swift**: pass `localURL.path(percentEncoded: false)`.

## Test plan

- [x] Added `MediaCreateParamsFilePathTests` — a filename with a space, one with a `%`, and a control that needs no encoding.
- [x] Verified the test **fails without the fix**, reproducing the exact production string (`screen%20recording%201.mp4`), and that the control passes either way.
- [x] Device A/B on a self-hosted site (iPhone 15 Pro, iOS 27): the same 39-second screen recording failed with `MediaFileNotFound` before the change and uploaded successfully after it.

## Notes

`MediaCreateParams`'s extension is no longer `private`, so the test can reach it. The comment on it says why.

Four other `.path()` call sites share this shape and are **not** changed here — `SupportDataProvider` (x2), `AsyncImageKit/ImageDownloader`, and `WordPressCore/DiskCache`. They looked safe because the paths are app-generated, but that was not verified and is worth a separate sweep.
