### PR TITLE
fix: decode support attachment file paths before uploading

### DIFF
--- a/Tests/KeystoneTests/Tests/ViewRelated/NewSupport/SupportAttachmentFilePathTests.swift
+++ b/Tests/KeystoneTests/Tests/ViewRelated/NewSupport/SupportAttachmentFilePathTests.swift
@@ -1,0 +1,78 @@
+import Foundation
+import Testing
+import WordPressAPI
+
+@testable import WordPress
+
+/// Support attachments are handed to `wordpress-rs` as filesystem paths, which it opens directly.
+/// `URL.path()` percent-encodes by default, so a filename needing encoding produced a path that
+/// doesn't exist on disk and failed the whole ticket. Same shape as the media upload bug in #26005.
+struct SupportAttachmentFilePathTests {
+
+    /// A screenshot picked from the library keeps its original filename, and macOS names those
+    /// with spaces.
+    @Test func newTicketDecodesPercentEncodingInAttachmentPaths() {
+        let params = CreateSupportTicketParams(
+            subject: "Subject",
+            message: "Message",
+            application: "jetpack",
+            attachmentURLs: [URL(fileURLWithPath: "/tmp/attachments/Screen Shot 1.png")]
+        )
+
+        #expect(params.attachments == ["/tmp/attachments/Screen Shot 1.png"])
+    }
+
+    /// Characters beyond the space get encoded too — including non-ASCII, which `path()` renders
+    /// as UTF-8 escapes.
+    @Test func newTicketDecodesPercentEncodingBeyondSpaces() {
+        let params = CreateSupportTicketParams(
+            subject: "Subject",
+            message: "Message",
+            application: "jetpack",
+            attachmentURLs: [
+                URL(fileURLWithPath: "/tmp/attachments/100% done.png"),
+                URL(fileURLWithPath: "/tmp/attachments/café.png")
+            ]
+        )
+
+        #expect(params.attachments == ["/tmp/attachments/100% done.png", "/tmp/attachments/café.png"])
+    }
+
+    /// A name needing no encoding has to survive untouched.
+    @Test func newTicketLeavesAnOrdinaryPathAlone() {
+        let params = CreateSupportTicketParams(
+            subject: "Subject",
+            message: "Message",
+            application: "jetpack",
+            attachmentURLs: [URL(fileURLWithPath: "/tmp/attachments/IMG_0001.png")]
+        )
+
+        #expect(params.attachments == ["/tmp/attachments/IMG_0001.png"])
+    }
+
+    /// The reply path builds a different params type, so it needs its own coverage.
+    @Test func replyDecodesPercentEncodingInAttachmentPaths() {
+        let params = AddMessageToSupportConversationParams(
+            message: "Message",
+            attachmentURLs: [URL(fileURLWithPath: "/tmp/attachments/Screen Shot 1.png")]
+        )
+
+        #expect(params.attachments == ["/tmp/attachments/Screen Shot 1.png"])
+    }
+
+    @Test func replyLeavesAnOrdinaryPathAlone() {
+        let params = AddMessageToSupportConversationParams(
+            message: "Message",
+            attachmentURLs: [URL(fileURLWithPath: "/tmp/attachments/IMG_0001.png")]
+        )
+
+        #expect(params.attachments == ["/tmp/attachments/IMG_0001.png"])
+    }
+
+    /// No attachments is the common case and must not trip the mapping.
+    @Test func emptyAttachmentsProduceNoPaths() {
+        let params = AddMessageToSupportConversationParams(message: "Message", attachmentURLs: [])
+
+        #expect(params.attachments.isEmpty)
+    }
+}

--- a/WordPress/Classes/ViewRelated/NewSupport/SupportDataProvider.swift
+++ b/WordPress/Classes/ViewRelated/NewSupport/SupportDataProvider.swift
@@ -305,7 +305,7 @@ actor WpSupportConversationDataProvider: SupportConversationDataProvider {
             subject: subject,
             message: message,
             application: "jetpack",
-            attachments: attachments.map { $0.path() }
+            attachmentURLs: attachments
         )
 
         return try await self.wpcomClient.api
@@ -323,7 +323,7 @@ actor WpSupportConversationDataProvider: SupportConversationDataProvider {
     ) async throws -> Conversation {
         let params = AddMessageToSupportConversationParams(
             message: message,
-            attachments: attachments.map { $0.path() }
+            attachmentURLs: attachments
         )
 
         let conversation = try await self.wpcomClient.api
@@ -333,6 +333,33 @@ actor WpSupportConversationDataProvider: SupportConversationDataProvider {
             .asConversation()
 
         return conversation
+    }
+}
+
+// Not `private`: the file-path handling below is covered by `SupportAttachmentFilePathTests`.
+//
+// Both params types carry `attachments` as filesystem paths, which `wordpress-rs` turns into
+// `MultipartFormFile.file_path` and opens directly. `URL.path()` percent-encodes by default, so a
+// filename with a space — a macOS screenshot, say — becomes a path that doesn't exist on disk and
+// the whole request fails with `MediaFileNotFound`. These initializers own that conversion so the
+// call sites can pass URLs.
+extension CreateSupportTicketParams {
+    init(subject: String, message: String, application: String, attachmentURLs: [URL]) {
+        self.init(
+            subject: subject,
+            message: message,
+            application: application,
+            attachments: attachmentURLs.map { $0.path(percentEncoded: false) }
+        )
+    }
+}
+
+extension AddMessageToSupportConversationParams {
+    init(message: String, attachmentURLs: [URL]) {
+        self.init(
+            message: message,
+            attachments: attachmentURLs.map { $0.path(percentEncoded: false) }
+        )
     }
 }
 


### PR DESCRIPTION
Fixes a bug where a support ticket or reply fails to send if an attached screenshot's filename needs percent-encoding — a space is enough.

Same defect as #26005, in the other two `wordpress-rs` params types that carry filesystem paths. Found by sweeping the codebase for the shape after that PR.

## Summary

- `URL.path()` percent-encodes by default, unlike the legacy `url.path` property, which returns a decoded path.
- `CreateSupportTicketParams` and `AddMessageToSupportConversationParams` both passed the encoded form as `attachments`, so `wordpress-rs` looked for files that don't exist on disk.
- Reachable with ordinary content: the attachment keeps the picked photo's original filename, and macOS names screenshots `Screen Shot 2026-09-08 at 10.31.15.png`.

## Root Cause

**WordPress/Classes/ViewRelated/NewSupport/SupportDataProvider.swift**: both call sites built the attachment list with `attachments.map { $0.path() }`.

Those strings are filesystem paths, not URL components. In `wordpress-rs` they become `MultipartFormFile.file_path` — the same struct field `MediaCreateParams.filePath` feeds — and `SafeRequestExecutor` opens each one directly:

```swift
do {
    try form.append(.init(fileAtPath: file.filePath, ...))
} catch {
    throw RequestExecutionError.MediaFileNotFound(filePath: file.filePath)
}
```

The filename is **not** app-generated. `ScreenshotPicker.swift` builds the attachment URL as `directory.appendingPathComponent(received.file.lastPathComponent)`. The directory is app-generated — `URL.cachesDirectory` plus a UUID — but the last component is copied verbatim from the file PhotosUI exports, which preserves the asset's original filename.

The failure takes the whole request with it. `SupportForm` catches and shows an error alert, so a user attaching a screenshot to report a bug can't file the report.

### The encoding is wider than spaces

`path()` escapes non-ASCII too, which puts non-English filenames in scope:

```swift
URL(fileURLWithPath: "/tmp/Screen Shot 1.png").path()   // "/tmp/Screen%20Shot%201.png"  ❌
URL(fileURLWithPath: "/tmp/100% done.png").path()       // "/tmp/100%25%20done.png"      ❌
URL(fileURLWithPath: "/tmp/café.png").path()            // "/tmp/cafe%CC%81.png"         ❌
```

## Fix

**WordPress/Classes/ViewRelated/NewSupport/SupportDataProvider.swift**: added an initializer to each params type that takes `attachmentURLs: [URL]` and owns the conversion, so the call sites pass URLs and can't reintroduce the encoded form. Mirrors `MediaCreateParams.init?(media:)` from #26005.

## Test plan

- [x] Added `SupportAttachmentFilePathTests` — six cases across both params types: a filename with a space, one with a `%`, one non-ASCII, controls needing no encoding, and an empty attachment list.
- [x] Verified the three encoding tests **fail without the fix**, reproducing the exact encoded strings (`Screen%20Shot%201.png`, `cafe%CC%81.png`), and that the three controls pass either way.
- [x] `WordPressTest/SupportAttachmentFilePathTests` — 6/6 pass on an iOS 26.4 simulator.

Not device-verified. The one link not confirmed by reading code is whether PhotosUI's exported `lastPathComponent` retains the space in practice — everything upstream and downstream of that is.

## Notes

`Modules/Sources/WordPressMediaLibrary/Upload/UploadSourceMaterializer.swift` already builds `MediaCreateParams(filePath: destURL.path)` with the decoded property at five sites, so the newer media library was never affected.

## Related issues

- #26005 — the same defect in `MediaCreateParams`


## Follow-up

The conversion belongs in the library, not here — [Automattic/wordpress-rs#1623](https://github.com/Automattic/wordpress-rs/pull/1623) adds `attachmentURLs: [URL]` initializers to both params types.

The app pins `wordpress-rs` at `exact: "0.8.0"` and can't consume that until it ships and the app bumps, so the extensions in this PR stand in until then. When the app next bumps the dependency, delete them and pass `attachmentURLs:` straight through.
