### PR TITLE
fix: DiskCache served a cache miss for entries that were still fresh

### DIFF
--- a/Modules/Sources/WordPressCore/DiskCache.swift
+++ b/Modules/Sources/WordPressCore/DiskCache.swift
@@ -7,9 +7,11 @@ public actor DiskCache: DiskCacheProtocol {
 
     public static let shared = DiskCache()
 
-    private let cacheRoot = URL.cachesDirectory
+    private let cacheRoot: URL
 
-    public init() {}
+    public init(cacheRoot: URL = .cachesDirectory) {
+        self.cacheRoot = cacheRoot
+    }
 
     public func read<T>(
         _ type: T.Type,
@@ -23,15 +25,19 @@ public actor DiskCache: DiskCacheProtocol {
         }
 
         if let interval {
-            let attributes = try FileManager.default.attributesOfItem(atPath: path.path())
+            // Read the date off the URL rather than a path string: `path()` percent-encodes, so a
+            // key needing encoding would name a file that doesn't exist.
+            let creationDate = try path.resourceValues(forKeys: [.creationDateKey]).creationDate
 
             // If we can't find the creation date, assume the cache object is invalid because we can't guarantee
             // the developer's intent will be respected.
-            guard let creationDate = attributes[.creationDate] as? Date else {
+            guard let creationDate else {
                 return nil
             }
 
-            if creationDate.addingTimeInterval(interval) > Date.now {
+            // The entry expires once `interval` has elapsed since it was written, so treat it as a
+            // miss only once that moment has passed.
+            if creationDate.addingTimeInterval(interval) < Date.now {
                 return nil
             }
         }

--- a/Modules/Tests/WordPressCoreTests/DiskCacheTests.swift
+++ b/Modules/Tests/WordPressCoreTests/DiskCacheTests.swift
@@ -1,0 +1,101 @@
+import Foundation
+import Testing
+
+@testable import WordPressCore
+
+struct DiskCacheTests {
+
+    /// Each test gets its own root so a run never reads, writes, or deletes anything in the real
+    /// caches directory.
+    private func makeCache() throws -> (DiskCache, URL) {
+        let root = URL.temporaryDirectory.appending(path: "DiskCacheTests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        return (DiskCache(cacheRoot: root), root)
+    }
+
+    @Test func storesAndReadsBackAValue() async throws {
+        let (cache, root) = try makeCache()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        try await cache.store(["a", "b"], forKey: "key")
+
+        #expect(try await cache.read([String].self, forKey: "key") == ["a", "b"])
+    }
+
+    /// A freshly-written entry is inside any sane window, so it has to come back. Before the fix
+    /// the comparison was inverted and this returned `nil`.
+    @Test func readsBackAnEntryThatIsStillFresh() async throws {
+        let (cache, root) = try makeCache()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        try await cache.store("value", forKey: "key")
+
+        #expect(try await cache.read(String.self, forKey: "key", notOlderThan: 3600) == "value")
+    }
+
+    /// The counterpart: a zero-length window expires the entry immediately.
+    @Test func treatsAnExpiredEntryAsAMiss() async throws {
+        let (cache, root) = try makeCache()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        try await cache.store("value", forKey: "key")
+        // The entry was written in the past, however narrowly, so any elapsed window excludes it.
+        try await Task.sleep(for: .milliseconds(50))
+
+        #expect(try await cache.read(String.self, forKey: "key", notOlderThan: 0) == nil)
+    }
+
+    /// Passing no interval skips the age check entirely.
+    @Test func readsBackAnEntryWhenNoIntervalIsGiven() async throws {
+        let (cache, root) = try makeCache()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        try await cache.store("value", forKey: "key")
+
+        #expect(try await cache.read(String.self, forKey: "key") == "value")
+    }
+
+    @Test func returnsNilForAKeyThatWasNeverStored() async throws {
+        let (cache, root) = try makeCache()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        #expect(try await cache.read(String.self, forKey: "missing") == nil)
+        #expect(try await cache.read(String.self, forKey: "missing", notOlderThan: 3600) == nil)
+    }
+
+    /// The age check used to resolve the file through a percent-encoded path string, which named a
+    /// file that doesn't exist whenever the key needed encoding.
+    @Test func handlesAKeyThatNeedsPercentEncoding() async throws {
+        let (cache, root) = try makeCache()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        try await cache.store("value", forKey: "conversation 1 of 100%")
+
+        #expect(try await cache.read(String.self, forKey: "conversation 1 of 100%", notOlderThan: 3600) == "value")
+    }
+
+    @Test func removesAStoredEntry() async throws {
+        let (cache, root) = try makeCache()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        try await cache.store("value", forKey: "key")
+        try await cache.remove(key: "key")
+
+        #expect(try await cache.read(String.self, forKey: "key") == nil)
+    }
+
+    /// `removeAll` only touches the injected root, which is what keeps these tests from clearing a
+    /// developer's real cache.
+    @Test func removeAllClearsOnlyTheInjectedRoot() async throws {
+        let (cache, root) = try makeCache()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        try await cache.store("a", forKey: "one")
+        try await cache.store("b", forKey: "two")
+        #expect(try await cache.count() == 2)
+
+        try await cache.removeAll()
+
+        #expect(try await cache.count() == 0)
+    }
+}


### PR DESCRIPTION
Fixes a bug where `DiskCache.read(_:forKey:notOlderThan:)` returned a cache miss for every entry inside the requested window, and a hit only for entries that had already aged past it.

Found while sweeping for the `URL.path()` shape from #26005. Unrelated to that bug, so it's on its own.

## Summary

- The freshness comparison was inverted: it discarded entries that were still fresh and served entries that were stale.
- The same block resolved the file through a percent-encoded path string while the existing-file check two lines above used the URL, so the two disagreed for any key needing encoding.
- Both are latent. No caller passes `notOlderThan:` today, and every cache key in the app is an ASCII slug.

## Root Cause

**Modules/Sources/WordPressCore/DiskCache.swift**

```swift
if creationDate.addingTimeInterval(interval) > Date.now {
    return nil
}
```

`creationDate + interval` is when the entry expires. The condition holds while that moment is still in the future — that is, while the entry is **valid** — and the branch returns `nil`. The comparison needs to be `<`.

The second issue is in the line above it:

```swift
guard FileManager.default.fileExists(at: path) else { ... }   // URL, decoded  ✅
let attributes = try FileManager.default.attributesOfItem(atPath: path.path())  // encoded  ❌
```

`path(forKey:)` is `cacheRoot.appendingPathComponent("\(key).cache.json")` with the key unhashed, so a key containing a space or a `%` would pass the first check and throw on the second.

## Fix

### 1. Compare against the expiry correctly

`<` instead of `>`, with a comment naming what the branch means.

### 2. Read the creation date off the URL

`path.resourceValues(forKeys: [.creationDateKey])` instead of `attributesOfItem(atPath: path.path())`. This matches the `fileExists(at:)` call above it and removes the encoding question rather than restating it.

### 3. Take the cache root as an init parameter

`public init(cacheRoot: URL = .cachesDirectory)`. Defaulted, so `DiskCache.shared`, `DiskCache()` in `AccountHelper`, and `CachedAndFetchedResult` are unchanged. Without it the tests would read, write, and `removeAll()` in the developer's real caches directory.

## Test plan

- [x] Added `DiskCacheTests` — 8 cases covering store/read round-trip, a fresh entry inside the window, an expired entry, no interval, a missing key, a key needing percent-encoding, `remove(key:)`, and `removeAll()`.
- [x] Verified the three bug-targeting cases **fail without the fix** and the five controls pass either way.
- [x] `swift test --filter DiskCacheTests` — 8/8 pass on macOS.

Each test writes to its own `UUID`-named directory under `temporaryDirectory` and removes it afterwards.
