### PR TITLE
Keep the tab bar's minimize behaviour in sync with programmatic tab selection

### DIFF
--- a/WordPress/Classes/ViewRelated/System/WPTabBarController+Swift.swift
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController+Swift.swift
@@ -26,10 +26,15 @@ import WordPressUI
 }
 
 extension WPTabBarController {
-    @objc public func didSelectViewController(_ viewController: UIViewController) {
-        if #available(iOS 26.0, *) {
-            tabBarMinimizeBehavior = viewController == self.readerNavigationController ? .onScrollDown : .never
-        }
+    /// Keeps ``tabBarMinimizeBehavior`` in sync with the selected tab.
+    ///
+    /// This is driven from the selection itself rather than from `UITabBarControllerDelegate`.
+    /// UIKit only sends the delegate messages when the user taps the tab bar, so every
+    /// programmatic selection – deep links, push notifications, `reloadTabs`, the key
+    /// commands – would otherwise leave the behavior set for whichever tab was tapped last.
+    @objc public func updateTabBarMinimizeBehavior() {
+        guard #available(iOS 26.0, *) else { return }
+        tabBarMinimizeBehavior = selectedIndex == WPTab.reader.rawValue ? .onScrollDown : .never
     }
 
     @objc public class func readerLocalizedTitle() -> String {

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -242,6 +242,20 @@ static NSInteger const WPTabBarIconOffsetiPhone = 5;
     ];
 }
 
+#pragma mark - Tab Selection
+
+- (void)setSelectedIndex:(NSUInteger)selectedIndex
+{
+    [super setSelectedIndex:selectedIndex];
+    [self updateTabBarMinimizeBehavior];
+}
+
+- (void)setSelectedViewController:(__kindof UIViewController *)selectedViewController
+{
+    [super setSelectedViewController:selectedViewController];
+    [self updateTabBarMinimizeBehavior];
+}
+
 - (void)showMySitesTab
 {
     [self setSelectedIndex:WPTabMySites];
@@ -304,9 +318,12 @@ static NSInteger const WPTabBarIconOffsetiPhone = 5;
         }
     }
 
-    [self didSelectViewController:viewController];
-
     return YES;
+}
+
+- (void)tabBarController:(UITabBarController *)tabBarController didSelectViewController:(UIViewController *)viewController
+{
+    [self updateTabBarMinimizeBehavior];
 }
 
 #pragma mark - UITabBarDelegate


### PR DESCRIPTION
## Description

On iOS 26 the Reader tab is the only tab whose tab bar minimizes on scroll. That behaviour is applied per-selection — and it was only ever updated when the user **tapped** the tab bar. Any selection made in code left it set for whichever tab was tapped last.

Two ways that goes wrong:

- Tap **My Site**, then follow a deep link or push notification into Reader — Reader keeps `.never` and no longer minimizes on scroll.
- Visit **Reader**, then get moved to another tab in code — that tab keeps `.onScrollDown` and minimizes on a screen that should never minimize.

| Before — `trunk` | After — this PR |
| :--: | :--: |
| <img width="400" alt="Reader feed on trunk, tab bar still fully expanded over the content" src="https://github.com/user-attachments/assets/3e040b1f-d05b-447f-b56b-a2a04e3210e5" /> | <img width="400" alt="Reader feed with the fix, tab bar collapsed to the Reader pill" src="https://github.com/user-attachments/assets/3bc5cce4-18af-4201-bd40-64d842f00522" /> |

Reader's Discover feed, reached by tapping **My Site** and then following `jpdebug:///discover` — a selection made in code rather than a tap. Same post, same scroll position. On `trunk` the tab bar stays expanded; with the fix it collapses to the pill, matching what already happens when Reader is reached by tapping.

### Root cause

`WPTabBarController.m` updated `tabBarMinimizeBehavior` from `tabBarController:shouldSelectViewController:`. UIKit sends that message only for taps on the tab bar itself, so every programmatic path bypassed it:

- `showMySitesTab` / `showReaderTab` / `showNotificationsTab` / `showMeTab`
- `reloadTabs`, which resets the selection to My Site
- deep links, push notification taps, widget and 3D Touch routing through `RootViewPresenter`
- the ⌘1/⌘2/⌘4 key commands

`shouldSelectViewController:` also runs *before* the selection commits, so it read the incoming view controller while `selectedIndex` still pointed at the outgoing tab.

### Changes

**`WPTabBarController.m`**: override `setSelectedIndex:` and `setSelectedViewController:` to update the behaviour after the selection lands, and move the tap path onto `tabBarController:didSelectViewController:`, which reads a committed selection.

**`WPTabBarController+Swift.swift`**: replace `didSelectViewController(_:)` with `updateTabBarMinimizeBehavior()`, which reads the current selection rather than taking a view controller.

The new method compares `selectedIndex` against `WPTab.reader` instead of comparing against `readerNavigationController`. That getter lazily builds the Reader presenter, and calling it from `setSelectedIndex:` would force the Reader stack into existence earlier than it is today. The two are equivalent — `tabViewControllers` builds in `WPTab` order.

Both the setter overrides and the delegate call the same update. It's idempotent, and keeping both means taps stay covered whether or not UIKit's internal tap handling routes through the public setter.

## Testing instructions

Needs iOS 26 or later — `tabBarMinimizeBehavior` does not exist before that.

Verified on an iPhone 17 simulator running iOS 26.4, comparing a build of `trunk` against this branch.

The observable is the tab bar collapsing to its minimized pill. In the accessibility tree the four `tabbar_*` buttons disappear when it collapses, which is what the counts below refer to.

- [x] **Reader reached programmatically now minimizes on scroll.** Tap My Site, then `xcrun simctl openurl booted "jpdebug:///discover"`, then scroll the feed. On `trunk` the bar stayed expanded (4 buttons before and after). On this branch it collapses (4 → 0). The feed scrolled in both runs — a tracked row moved from `y=231.0` to `y=-106.0` and `y=-76.0` respectively — so the stationary bar on `trunk` is not a missed gesture.
- [x] **Reaching Reader by tapping still minimizes on scroll** (4 → 0).
- [x] **My Site still does not minimize on scroll** (4 → 4).

For a reviewer:

- [ ] Tap **My Site**, run `xcrun simctl openurl booted "jpdebug:///discover"` and accept the "Open in Jetpack?" prompt, then scroll the Discover feed — the tab bar shrinks to a pill showing only the Reader icon.
- [ ] Tap **Reader** directly and scroll — the bar shrinks the same way.
- [ ] Tap **My Site** and scroll the dashboard to the bottom — the bar stays full width with all four tabs visible.

## Related issues

Investigated from #26004, where the tab bar renders with staggered label baselines and a truncated "Rea…" on My Site after the app has been backgrounded. A tab bar carrying the wrong minimize behaviour for its tab is a plausible cause of that state, and #26004's screenshot shows My Site selected with the dashboard scrolled — which is the configuration this PR fixes.

That link is unproven. This PR is not marked as closing #26004; the stale behaviour is a defect on its own terms, and the visual symptom in that report was not reproduced.

